### PR TITLE
fix: create report request body

### DIFF
--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreateCommentReportForm.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreateCommentReportForm.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 data class CreateCommentReportForm(
     @SerialName("comment_id") val commentId: CommentId,
     @SerialName("reason") val reason: String,
-    @SerialName("auto") val auth: String,
+    @SerialName("auth") val auth: String,
 )

--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreatePostReportForm.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreatePostReportForm.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 data class CreatePostReportForm(
     @SerialName("post_id") val postId: PostId,
     @SerialName("reason") val reason: String,
-    @SerialName("auto") val auth: String,
+    @SerialName("auth") val auth: String,
 )


### PR DESCRIPTION
This PR fixes a typo in the authorization param of the create report request body for posts and comments.