### PR TITLE
fix: avoid comment duplication

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailViewModel.kt
@@ -320,7 +320,9 @@ class PostDetailViewModel(
                 sort = sort,
             )?.processCommentsToGetNestedOrder(
                 ancestorId = parentId.toString(),
-            )?.let {
+            )?.filter {
+                currentState.comments.none { c -> c.id == it.id }
+            }?.let {
                 if (autoExpandComments) {
                     expandedTopLevelComments =
                         it.filter { c -> c.depth == 0 }.map { c -> c.id }.toMutableList()


### PR DESCRIPTION
This PR avoid inserting the same comment over and over again when downloading children of a parent comment (which could never be found if the comment itself was deleted).