### PR TITLE
fix: load more button visibility

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
@@ -646,10 +646,7 @@ class PostDetailScreen(
                                     thickness = 0.25.dp
                                 )
                             }
-                            val hasMoreComments = (comment.comments ?: 0) > 0
-                            val isNextCommentNotChild =
-                                idx < uiState.comments.lastIndex && uiState.comments[idx + 1].depth <= comment.depth
-                            if (hasMoreComments && isNextCommentNotChild) {
+                            if (comment.loadMoreButtonVisible) {
                                 Row {
                                     Spacer(modifier = Modifier.weight(1f))
                                     Button(onClick = {

--- a/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/CommentModel.kt
+++ b/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/CommentModel.kt
@@ -21,6 +21,8 @@ data class CommentModel(
     val visible: Boolean = true,
     @Transient
     val expanded: Boolean? = null,
+    @Transient
+    val loadMoreButtonVisible: Boolean = false,
 ) : JavaSerializable {
     val depth: Int get() = (path.split(".").size - 2).coerceAtLeast(0)
     val parentId: String?


### PR DESCRIPTION
There is a problem with comment loading if a comment has deleted children, because the button to fetch more comments remains always visible. This PR fixes that issue and moves the logic to display the button in the ViewModel.