### PR TITLE
fix: reintroduce clickable images in markdown

### DIFF
--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/compose/CustomMarkdown.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/compose/CustomMarkdown.kt
@@ -57,10 +57,12 @@ actual fun CustomMarkdown(
         LocalMarkdownColors provides colors,
         LocalMarkdownTypography provides typography,
     ) {
-        val markwonProvider = getMarkwonProvider(
-            onOpenUrl = onOpenUrl,
-            onOpenImage = onOpenImage,
-        )
+        val markwonProvider = remember {
+            getMarkwonProvider(
+                onOpenUrl = onOpenUrl,
+                onOpenImage = onOpenImage,
+            )
+        }
         BoxWithConstraints(
             modifier = modifier.clickable(
                 interactionSource = remember { MutableInteractionSource() },

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/compose/DefaultMarkwonProvider.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/compose/DefaultMarkwonProvider.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose
 
 import android.content.Context
 import android.text.util.Linkify
+import com.github.diegoberaldin.raccoonforlemmy.core.markdown.plugins.ClickableImagesPlugin
 import com.github.diegoberaldin.raccoonforlemmy.core.markdown.plugins.MarkwonSpoilerPlugin
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
@@ -15,7 +16,6 @@ import io.noties.markwon.linkify.LinkifyPlugin
 class DefaultMarkwonProvider(
     context: Context,
     onOpenUrl: ((String) -> Unit)?,
-    // TODO: handle image clicks in the future
     onOpenImage: ((String) -> Unit)?,
 ) : MarkwonProvider {
     override val markwon: Markwon
@@ -28,6 +28,9 @@ class DefaultMarkwonProvider(
             .usePlugin(HtmlPlugin.create())
             .usePlugin(CoilImagesPlugin.create(context))
             .usePlugin(MarkwonSpoilerPlugin.create(true))
+            .usePlugin(ClickableImagesPlugin.create(context) { url ->
+                onOpenImage?.invoke(url)
+            })
             .usePlugin(
                 object : AbstractMarkwonPlugin() {
                     override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/di/MarkwonModule.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/di/MarkwonModule.kt
@@ -7,7 +7,7 @@ import org.koin.dsl.module
 import org.koin.java.KoinJavaComponent
 
 val markwonModule = module {
-    single<MarkwonProvider> { params ->
+    factory<MarkwonProvider> { params ->
         DefaultMarkwonProvider(
             context = get(),
             onOpenUrl = params[0],

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/plugins/ClickableImagesPlugin.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/plugins/ClickableImagesPlugin.kt
@@ -1,0 +1,40 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.markdown.plugins
+
+import android.content.Context
+import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.MarkwonSpansFactory
+import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.core.spans.LinkSpan
+import io.noties.markwon.image.ImageProps
+import org.commonmark.node.Image
+
+
+class ClickableImagesPlugin private constructor(
+    private val context: Context,
+    private val onOpenImage: (String) -> Unit,
+) : AbstractMarkwonPlugin() {
+
+    companion object {
+        fun create(context: Context, onOpenImage: (String) -> Unit) =
+            ClickableImagesPlugin(context, onOpenImage)
+    }
+
+    override fun configureSpansFactory(builder: MarkwonSpansFactory.Builder) {
+        val origin = builder.getFactory(Image::class.java)
+        if (origin != null) {
+            builder.setFactory(Image::class.java) { configuration, props ->
+                val url = ImageProps.DESTINATION.require(props)
+                val linkSpan = LinkSpan(
+                    MarkwonTheme.create(context), url,
+                ) { view, link ->
+                    view.cancelPendingInputEvents()
+                    onOpenImage(link)
+                }
+                arrayOf(
+                    origin.getSpans(configuration, props),
+                    linkSpan
+                )
+            }
+        }
+    }
+}

--- a/core-md/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/compose/CustomMarkdown.kt
+++ b/core-md/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/compose/CustomMarkdown.kt
@@ -1,11 +1,13 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose.elements.MarkdownBlockQuote
 import com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose.elements.MarkdownBulletList


### PR DESCRIPTION
#77 removed temporarily clickable images due to glitches while rendering. This PR aims at reintroducing the feature with a new plugin.