### PR TITLE
refactor: better md management

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/PostCardTitle.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/PostCardTitle.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.image.ZoomableImageScreen
 import com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose.CustomMarkdown
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsRepository
 
@@ -30,6 +31,9 @@ fun PostCardTitle(
                 uriHandler = uriHandler,
                 navigator = navigator
             )
+        },
+        onOpenImage = { url ->
+            navigator?.push(ZoomableImageScreen(url))
         },
         onClick = onClick,
     )

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/di/MarkwonModule.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/di/MarkwonModule.kt
@@ -1,13 +1,13 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.markdown.di
 
-import com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose.DefaultMarkwonProvider
-import com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose.MarkwonProvider
+import com.github.diegoberaldin.raccoonforlemmy.core.markdown.provider.DefaultMarkwonProvider
+import com.github.diegoberaldin.raccoonforlemmy.core.markdown.provider.MarkwonProvider
 import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 import org.koin.java.KoinJavaComponent
 
 val markwonModule = module {
-    factory<MarkwonProvider> { params ->
+    single<MarkwonProvider> { params ->
         DefaultMarkwonProvider(
             context = get(),
             onOpenUrl = params[0],

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/DefaultMarkwonProvider.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/DefaultMarkwonProvider.kt
@@ -1,4 +1,4 @@
-package com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose
+package com.github.diegoberaldin.raccoonforlemmy.core.markdown.provider
 
 import android.content.Context
 import android.text.util.Linkify

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/MarkwonProvider.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/MarkwonProvider.kt
@@ -1,4 +1,4 @@
-package com.github.diegoberaldin.raccoonforlemmy.core.markdown.compose
+package com.github.diegoberaldin.raccoonforlemmy.core.markdown.provider
 
 import io.noties.markwon.Markwon
 


### PR DESCRIPTION
MarkwonProvider should exist as a `single` binding. This works provided that the callbacks for opening URLs and images are consistent.