### PR TITLE
fix: cross post destination

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
@@ -434,9 +434,13 @@ class PostDetailScreen(
                                             }
                                             Text(
                                                 modifier = Modifier.onClick {
+                                                    val post = PostModel(
+                                                        id = crossPost.id,
+                                                        community = community,
+                                                    )
                                                     navigator?.push(
-                                                        CommunityDetailScreen(
-                                                            community = community
+                                                        PostDetailScreen(
+                                                            post = post,
                                                         )
                                                     )
                                                 },


### PR DESCRIPTION
Cross posts should point to the detail of the post in the other community instead of the community detail.