### PR TITLE
feat: add custom menu to search in raw content

### DIFF
--- a/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/CustomTextToolbar.kt
+++ b/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/CustomTextToolbar.kt
@@ -1,0 +1,97 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.commonui
+
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.TextToolbarStatus
+
+private const val ACTION_ID_COPY = 0
+private const val ACTION_ID_SEARCH = 1
+
+class CustomTextToolbar(
+    private val view: View,
+    private val onSearch: () -> Unit,
+) : TextToolbar {
+    private var actionMode: ActionMode? = null
+
+    override var status: TextToolbarStatus = TextToolbarStatus.Hidden
+        private set
+
+    override fun hide() {
+        status = TextToolbarStatus.Hidden
+        actionMode?.finish()
+        actionMode = null
+    }
+
+    override fun showMenu(
+        rect: Rect,
+        onCopyRequested: (() -> Unit)?,
+        onPasteRequested: (() -> Unit)?,
+        onCutRequested: (() -> Unit)?,
+        onSelectAllRequested: (() -> Unit)?,
+    ) {
+        if (actionMode == null) {
+            status = TextToolbarStatus.Shown
+            view.startActionMode(
+                CustomTextActionModeCallback(
+                    rect = rect,
+                    onCopy = {
+                        onCopyRequested?.invoke()
+                    },
+                    onSearch = {
+                        onCopyRequested?.invoke()
+                        onSearch()
+                    },
+                ),
+                ActionMode.TYPE_FLOATING,
+            )
+        } else {
+            actionMode?.invalidate()
+        }
+    }
+}
+
+internal class CustomTextActionModeCallback(
+    private val rect: Rect,
+    private val onCopy: () -> Unit,
+    private val onSearch: () -> Unit,
+) : ActionMode.Callback2() {
+
+    override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        menu?.apply {
+            val groupId = 0
+            add(
+                groupId, ACTION_ID_COPY, 0, android.R.string.copy
+            ).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+            add(
+                groupId, ACTION_ID_SEARCH, 1, android.R.string.search_go
+            ).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+        }
+        return true
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean = false
+
+    override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+        when (item?.itemId) {
+            ACTION_ID_COPY -> onCopy()
+            ACTION_ID_SEARCH -> onSearch()
+            else -> return false
+        }
+        mode?.finish()
+        return true
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode?) {
+        // no-op
+    }
+
+    override fun onGetContentRect(mode: ActionMode?, view: View?, outRect: android.graphics.Rect?) {
+        rect.apply {
+            outRect?.set(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
+        }
+    }
+}

--- a/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
+++ b/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
@@ -1,5 +1,9 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.commonui.di
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.TextToolbar
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.CustomTextToolbar
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.chat.InboxChatMviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.communityInfo.CommunityInfoMviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.communitydetail.CommunityDetailMviModel
@@ -82,18 +86,14 @@ actual fun getCreateCommentViewModel(
     parentId: Int?,
     editedCommentId: Int?,
 ): CreateCommentMviModel {
-    val res: CreateCommentMviModel by inject(
-        clazz = CreateCommentMviModel::class.java,
-        parameters = { parametersOf(postId, parentId, editedCommentId) }
-    )
+    val res: CreateCommentMviModel by inject(clazz = CreateCommentMviModel::class.java,
+        parameters = { parametersOf(postId, parentId, editedCommentId) })
     return res
 }
 
 actual fun getCreatePostViewModel(communityId: Int?, editedPostId: Int?): CreatePostMviModel {
-    val res: CreatePostMviModel by inject(
-        clazz = CreatePostMviModel::class.java,
-        parameters = { parametersOf(communityId, editedPostId) }
-    )
+    val res: CreatePostMviModel by inject(clazz = CreatePostMviModel::class.java,
+        parameters = { parametersOf(communityId, editedPostId) })
     return res
 }
 
@@ -132,4 +132,15 @@ actual fun getCreateReportViewModel(
         parametersOf(postId, commentId)
     })
     return res
+}
+
+
+@Composable
+actual fun getCustomTextToolbar(
+    onSearch: () -> Unit,
+): TextToolbar {
+    return CustomTextToolbar(
+        view = LocalView.current,
+        onSearch = onSearch,
+    )
 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
@@ -1,5 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.commonui.di
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.TextToolbar
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.chat.InboxChatMviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.communityInfo.CommunityInfoMviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.communitydetail.CommunityDetailMviModel
@@ -69,3 +71,8 @@ expect fun getCreateReportViewModel(
     postId: Int? = null,
     commentId: Int? = null,
 ): CreateReportMviModel
+
+@Composable
+expect fun getCustomTextToolbar(
+    onSearch: () -> Unit,
+): TextToolbar

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/RawContentDialog.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/RawContentDialog.kt
@@ -16,13 +16,23 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalTextToolbar
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.handleUrl
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getCustomTextToolbar
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,6 +42,21 @@ fun RawContentDialog(
     text: String? = null,
     onDismiss: (() -> Unit)? = null,
 ) {
+    val uriHandler = LocalUriHandler.current
+    val navigator = remember { getNavigationCoordinator().getRootNavigator() }
+    val settingsRepository = remember { getSettingsRepository() }
+    val clipboardManager = LocalClipboardManager.current
+    val onSearchLambda = {
+        val query = clipboardManager.getText()?.text.orEmpty()
+        val url = "https://www.google.com/search?q=$query"
+        handleUrl(
+            url = url,
+            openExternal = settingsRepository.currentSettings.value.openUrlsInExternalBrowser,
+            uriHandler = uriHandler,
+            navigator = navigator
+        )
+    }
+
     AlertDialog(
         onDismissRequest = { onDismiss?.invoke() },
     ) {
@@ -62,15 +87,21 @@ fun RawContentDialog(
                                 style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.onBackground,
                             )
-                            SelectionContainer {
-                                Text(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    text = it,
-                                    style = MaterialTheme.typography.bodyLarge.copy(
-                                        fontFamily = FontFamily.Monospace,
-                                    ),
-                                    color = MaterialTheme.colorScheme.onBackground,
+                            CompositionLocalProvider(
+                                LocalTextToolbar provides getCustomTextToolbar(
+                                    onSearch = onSearchLambda,
                                 )
+                            ) {
+                                SelectionContainer {
+                                    Text(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        text = it,
+                                        style = MaterialTheme.typography.bodyLarge.copy(
+                                            fontFamily = FontFamily.Monospace,
+                                        ),
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                    )
+                                }
                             }
                         }
                     }
@@ -84,15 +115,21 @@ fun RawContentDialog(
                                 style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.onBackground,
                             )
-                            SelectionContainer {
-                                Text(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    text = it,
-                                    style = MaterialTheme.typography.bodyMedium.copy(
-                                        fontFamily = FontFamily.Monospace,
-                                    ),
-                                    color = MaterialTheme.colorScheme.onBackground,
+                            CompositionLocalProvider(
+                                LocalTextToolbar provides getCustomTextToolbar(
+                                    onSearch = onSearchLambda,
                                 )
+                            ) {
+                                SelectionContainer {
+                                    Text(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        text = it,
+                                        style = MaterialTheme.typography.bodyMedium.copy(
+                                            fontFamily = FontFamily.Monospace,
+                                        ),
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                    )
+                                }
                             }
                         }
                     }
@@ -106,15 +143,22 @@ fun RawContentDialog(
                                 style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.onBackground,
                             )
-                            SelectionContainer {
-                                Text(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    text = it,
-                                    style = MaterialTheme.typography.bodyMedium.copy(
-                                        fontFamily = FontFamily.Monospace,
-                                    ),
-                                    color = MaterialTheme.colorScheme.onBackground,
+
+                            CompositionLocalProvider(
+                                LocalTextToolbar provides getCustomTextToolbar(
+                                    onSearch = onSearchLambda,
                                 )
+                            ) {
+                                SelectionContainer {
+                                    Text(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        text = it,
+                                        style = MaterialTheme.typography.bodyMedium.copy(
+                                            fontFamily = FontFamily.Monospace,
+                                        ),
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                    )
+                                }
                             }
                         }
                     }

--- a/core-commonui/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
+++ b/core-commonui/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
@@ -1,5 +1,8 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.commonui.di
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalTextToolbar
+import androidx.compose.ui.platform.TextToolbar
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.chat.InboxChatMviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.communityInfo.CommunityInfoMviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.communitydetail.CommunityDetailMviModel
@@ -161,4 +164,11 @@ object CommonUiViewModelHelper : KoinComponent {
         )
         return model
     }
+}
+
+@Composable
+actual fun getCustomTextToolbar(
+    onSearch: () -> Unit,
+): TextToolbar {
+    return LocalTextToolbar.current
 }


### PR DESCRIPTION
This PR adds a custom "Search" action to the raw content dialog to open a browser and search for the selected text.

<div align="center">
<img width="189" alt="search" src="https://github.com/diegoberaldin/RaccoonForLemmy/assets/2738294/30f84733-aecb-4993-9dba-4326d4179f9a">
</div>