### PR TITLE
fix: open detail from list

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
@@ -395,7 +395,7 @@ class CommunityDetailScreen(
                                 }
                             }
                         }
-                        items(uiState.posts) { post ->
+                        items(uiState.posts, { it.id }) { post ->
                             SwipeableCard(
                                 modifier = Modifier.fillMaxWidth(),
                                 enabled = uiState.swipeActionsEnabled && !isOnOtherInstance,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailViewModel.kt
@@ -84,29 +84,45 @@ class CommunityDetailViewModel(
             CommunityDetailMviModel.Intent.LoadNextPage -> loadNextPage()
             CommunityDetailMviModel.Intent.Refresh -> refresh()
 
-            is CommunityDetailMviModel.Intent.DownVotePost -> toggleDownVotePost(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is CommunityDetailMviModel.Intent.DownVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleDownVotePost(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is CommunityDetailMviModel.Intent.SavePost -> toggleSavePost(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is CommunityDetailMviModel.Intent.SavePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleSavePost(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is CommunityDetailMviModel.Intent.UpVotePost -> toggleUpVotePost(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is CommunityDetailMviModel.Intent.UpVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleUpVotePost(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
             CommunityDetailMviModel.Intent.HapticIndication -> hapticFeedback.vibrate()
             is CommunityDetailMviModel.Intent.ChangeSort -> applySortType(intent.value)
             CommunityDetailMviModel.Intent.Subscribe -> subscribe()
             CommunityDetailMviModel.Intent.Unsubscribe -> unsubscribe()
             is CommunityDetailMviModel.Intent.DeletePost -> handlePostDelete(intent.id)
-            is CommunityDetailMviModel.Intent.SharePost -> share(
-                post = uiState.value.posts.first { it.id == intent.id },
-            )
+            is CommunityDetailMviModel.Intent.SharePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    share(
+                        post = post,
+                    )
+                }
+            }
 
             CommunityDetailMviModel.Intent.Block -> blockCommunity()
             CommunityDetailMviModel.Intent.BlockInstance -> blockInstance()
@@ -115,7 +131,11 @@ class CommunityDetailViewModel(
             }
 
             CommunityDetailMviModel.Intent.ClearRead -> clearRead()
-            is CommunityDetailMviModel.Intent.Hide -> hide(post = uiState.value.posts.first { it.id == intent.id })
+            is CommunityDetailMviModel.Intent.Hide -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    hide(post = post)
+                }
+            }
         }
     }
 

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/ListingTypeBottomSheet.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/ListingTypeBottomSheet.kt
@@ -78,10 +78,11 @@ class ListingTypeBottomSheet(
                                 .fillMaxWidth()
                                 .onClick(
                                     rememberCallback {
-                                        notificationCenter.getObserver(
+                                        notificationCenter.getAllObservers(
                                             NotificationCenterContractKeys.ChangeFeedType
-                                        )
-                                            ?.invoke(value)
+                                        ).forEach {
+                                            it.invoke(value)
+                                        }
                                         navigationCoordinator.getBottomNavigator()?.hide()
                                     },
                                 ),

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
@@ -112,12 +112,11 @@ internal class SortBottomSheetMain(
                                             SortBottomSheetTop()
                                         )
                                     } else {
-                                        notificationCenter.getObserver(
+                                        notificationCenter.getAllObservers(
                                             NotificationCenterContractKeys.ChangeSortType
-                                        )
-                                            ?.also {
-                                                it.invoke(value)
-                                            }
+                                        ).forEach {
+                                            it.invoke(value)
+                                        }
                                         navigationCoordinator.getBottomNavigator()?.hide()
                                     }
                                 },
@@ -201,8 +200,10 @@ internal class SortBottomSheetTop(
                             .fillMaxWidth()
                             .onClick(
                                 rememberCallback {
-                                    notificationCenter.getObserver(NotificationCenterContractKeys.ChangeSortType)
-                                        ?.also {
+                                    notificationCenter.getAllObservers(
+                                        NotificationCenterContractKeys.ChangeSortType
+                                    )
+                                        .forEach {
                                             it.invoke(value)
                                         }
                                     navigationCoordinator.getBottomNavigator()?.hide()

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
@@ -364,7 +364,7 @@ class UserDetailScreen(
                                 }
                             }
                         }
-                        items(uiState.posts) { post ->
+                        items(uiState.posts, { it.id }) { post ->
                             SwipeableCard(
                                 modifier = Modifier.fillMaxWidth(),
                                 enabled = uiState.swipeActionsEnabled,
@@ -536,7 +536,7 @@ class UserDetailScreen(
                                 )
                             }
                         }
-                        items(uiState.comments) { comment ->
+                        items(uiState.comments, { it.id }) { comment ->
                             SwipeableCard(
                                 modifier = Modifier.fillMaxWidth(),
                                 enabled = uiState.swipeActionsEnabled,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailViewModel.kt
@@ -93,44 +93,68 @@ class UserDetailViewModel(
         when (intent) {
             is UserDetailMviModel.Intent.ChangeSort -> applySortType(intent.value)
             is UserDetailMviModel.Intent.ChangeSection -> changeSection(intent.section)
-            is UserDetailMviModel.Intent.DownVoteComment -> toggleDownVoteComment(
-                comment = uiState.value.comments.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is UserDetailMviModel.Intent.DownVoteComment -> {
+                uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
+                    toggleDownVoteComment(
+                        comment = comment,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
             is UserDetailMviModel.Intent.DownVotePost -> {
-                toggleDownVote(
-                    post = uiState.value.posts.first { it.id == intent.id },
-                    feedback = intent.feedback,
-                )
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleDownVote(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
             }
 
             UserDetailMviModel.Intent.HapticIndication -> hapticFeedback.vibrate()
             UserDetailMviModel.Intent.LoadNextPage -> loadNextPage()
             UserDetailMviModel.Intent.Refresh -> refresh()
-            is UserDetailMviModel.Intent.SaveComment -> toggleSaveComment(
-                comment = uiState.value.comments.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is UserDetailMviModel.Intent.SaveComment -> {
+                uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
+                    toggleSaveComment(
+                        comment = comment,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is UserDetailMviModel.Intent.SavePost -> toggleSave(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is UserDetailMviModel.Intent.SavePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleSave(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is UserDetailMviModel.Intent.UpVoteComment -> toggleUpVoteComment(
-                comment = uiState.value.comments.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is UserDetailMviModel.Intent.UpVoteComment -> {
+                uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
+                    toggleUpVoteComment(
+                        comment = comment,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is UserDetailMviModel.Intent.UpVotePost -> toggleUpVote(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is UserDetailMviModel.Intent.UpVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleUpVote(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is UserDetailMviModel.Intent.SharePost -> share(
-                post = uiState.value.posts.first { it.id == intent.id },
-            )
+            is UserDetailMviModel.Intent.SharePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    share(post = post)
+                }
+            }
 
             UserDetailMviModel.Intent.Block -> blockUser()
             UserDetailMviModel.Intent.BlockInstance -> blockInstance()

--- a/core-utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/RememberCallback.kt
+++ b/core-utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/RememberCallback.kt
@@ -11,8 +11,22 @@ fun rememberCallback(key: Any = Unit, block: () -> Unit): () -> Unit {
 }
 
 @Composable
+fun rememberCallback(key1: Any = Unit, key2: Any, block: () -> Unit): () -> Unit {
+    return remember(key1, key2) {
+        block
+    }
+}
+
+@Composable
 fun <T, U> rememberCallbackArgs(key: Any = Unit, block: (T) -> U): (T) -> U {
     return remember(key) {
+        block
+    }
+}
+
+@Composable
+fun <T, U> rememberCallbackArgs(key1: Any = Unit, key2: Any, block: (T) -> U): (T) -> U {
+    return remember(key1, key2) {
         block
     }
 }

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
@@ -60,6 +60,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.Floatin
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.PostCard
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.PostCardPlaceholder
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.SwipeableCard
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.createcomment.CreateCommentScreen
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.createpost.CreatePostScreen
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getDrawerCoordinator
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getFabNestedScrollConnection
@@ -279,7 +280,7 @@ class PostListScreen : Screen {
                                 }
                             }
                         }
-                        items(uiState.posts) { post ->
+                        items(uiState.posts, key = { it.id }) { post ->
                             SwipeableCard(
                                 modifier = Modifier.fillMaxWidth(),
                                 enabled = uiState.swipeActionsEnabled,
@@ -362,13 +363,13 @@ class PostListScreen : Screen {
                                                 ),
                                             )
                                         },
-//                                        onReply = rememberCallback(model) {
-//                                            val screen = CreateCommentScreen(
-//                                                originalPost = post,
-//                                            )
-//                                            bottomSheetNavigator.show(screen)
-//                                        },
-                                        onImageClick = rememberCallbackArgs(model) { url ->
+                                        onReply = rememberCallback(model) {
+                                            val screen = CreateCommentScreen(
+                                                originalPost = post,
+                                            )
+                                            navigationCoordinator.getBottomNavigator()?.show(screen)
+                                        },
+                                        onImageClick = rememberCallbackArgs(model, post) { url ->
                                             model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
                                             navigationCoordinator.getRootNavigator()?.push(
                                                 ZoomableImageScreen(url)

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListViewModel.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListViewModel.kt
@@ -141,30 +141,46 @@ class PostListViewModel(
 
             is PostListMviModel.Intent.ChangeSort -> applySortType(intent.value)
             is PostListMviModel.Intent.ChangeListing -> applyListingType(intent.value)
-            is PostListMviModel.Intent.DownVotePost -> toggleDownVote(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is PostListMviModel.Intent.DownVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleDownVote(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is PostListMviModel.Intent.SavePost -> toggleSave(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is PostListMviModel.Intent.SavePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleSave(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is PostListMviModel.Intent.UpVotePost -> toggleUpVote(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is PostListMviModel.Intent.UpVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleUpVote(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
             PostListMviModel.Intent.HapticIndication -> hapticFeedback.vibrate()
             is PostListMviModel.Intent.HandlePostUpdate -> handlePostUpdate(intent.post)
             is PostListMviModel.Intent.DeletePost -> handlePostDelete(intent.id)
             is PostListMviModel.Intent.SharePost -> {
-                share(post = uiState.value.posts.first { it.id == intent.id })
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    share(post = post)
+                }
             }
 
             is PostListMviModel.Intent.MarkAsRead -> {
-                markAsRead(post = uiState.value.posts.first { it.id == intent.id })
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    markAsRead(post = post)
+                }
             }
 
             PostListMviModel.Intent.ClearRead -> clearRead()

--- a/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedScreen.kt
+++ b/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedScreen.kt
@@ -181,7 +181,7 @@ internal object ProfileLoggedScreen : Tab {
                                     }
                                 }
                             }
-                            items(uiState.posts) { post ->
+                            items(uiState.posts, { it.id }) { post ->
                                 PostCard(
                                     post = post,
                                     postLayout = uiState.postLayout,
@@ -288,7 +288,7 @@ internal object ProfileLoggedScreen : Tab {
                                     )
                                 }
                             }
-                            items(uiState.comments) { comment ->
+                            items(uiState.comments, { it.id }) { comment ->
                                 CommentCard(
                                     modifier = Modifier.background(MaterialTheme.colorScheme.background),
                                     comment = comment,

--- a/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedViewModel.kt
+++ b/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedViewModel.kt
@@ -115,39 +115,65 @@ class ProfileLoggedViewModel(
                 refresh()
             }
 
-            is ProfileLoggedMviModel.Intent.SharePost -> share(
-                post = uiState.value.posts.first { it.id == intent.id },
-            )
+            is ProfileLoggedMviModel.Intent.SharePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    share(post = post)
+                }
+            }
 
-            is ProfileLoggedMviModel.Intent.DownVoteComment -> toggleDownVoteComment(
-                comment = uiState.value.comments.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is ProfileLoggedMviModel.Intent.DownVoteComment -> {
+                uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
+                    toggleDownVoteComment(
+                        comment = comment,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is ProfileLoggedMviModel.Intent.DownVotePost -> toggleDownVotePost(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is ProfileLoggedMviModel.Intent.DownVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleDownVotePost(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is ProfileLoggedMviModel.Intent.SaveComment -> toggleSaveComment(
-                comment = uiState.value.comments.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is ProfileLoggedMviModel.Intent.SaveComment -> {
+                uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
+                    toggleSaveComment(
+                        comment = comment,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is ProfileLoggedMviModel.Intent.SavePost -> toggleSavePost(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is ProfileLoggedMviModel.Intent.SavePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleSavePost(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is ProfileLoggedMviModel.Intent.UpVoteComment -> toggleUpVoteComment(
-                comment = uiState.value.comments.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is ProfileLoggedMviModel.Intent.UpVoteComment -> {
+                uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
+                    toggleUpVoteComment(
+                        comment = comment,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
 
-            is ProfileLoggedMviModel.Intent.UpVotePost -> toggleUpVotePost(
-                post = uiState.value.posts.first { it.id == intent.id },
-                feedback = intent.feedback,
-            )
+            is ProfileLoggedMviModel.Intent.UpVotePost -> {
+                uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
+                    toggleUpVotePost(
+                        post = post,
+                        feedback = intent.feedback,
+                    )
+                }
+            }
         }
     }
 

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
@@ -301,7 +301,15 @@ class ExploreScreen : Screen {
                                 }
                             }
                         }
-                        items(uiState.results) { result ->
+                        items(uiState.results, key = {
+                            when (it) {
+                                is PostModel -> "post" + it.id
+                                is CommentModel -> "comment" + it.id
+                                is UserModel -> "user" + it.id
+                                is CommunityModel -> "community" + it.id
+                                else -> ""
+                            }
+                        }) { result ->
                             when (result) {
                                 is CommunityModel -> {
                                     CommunityItem(

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreViewModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreViewModel.kt
@@ -130,35 +130,65 @@ class ExploreViewModel(
             is ExploreMviModel.Intent.SetListingType -> changeListingType(intent.value)
             is ExploreMviModel.Intent.SetSortType -> changeSortType(intent.value)
             is ExploreMviModel.Intent.SetResultType -> changeResultType(intent.value)
-            is ExploreMviModel.Intent.DownVotePost -> toggleDownVote(
-                post = uiState.value.results.first { (it as? PostModel)?.id == intent.id } as PostModel,
-                feedback = intent.feedback,
-            )
+            is ExploreMviModel.Intent.DownVotePost -> {
+                uiState.value.results.firstOrNull { (it as? PostModel)?.id == intent.id }
+                    ?.also { post ->
+                        toggleDownVote(
+                            post = post as PostModel,
+                            feedback = intent.feedback,
+                        )
+                    }
+            }
 
-            is ExploreMviModel.Intent.SavePost -> toggleSave(
-                post = uiState.value.results.first { (it as? PostModel)?.id == intent.id } as PostModel,
-                feedback = intent.feedback,
-            )
+            is ExploreMviModel.Intent.SavePost -> {
+                uiState.value.results.firstOrNull { (it as? PostModel)?.id == intent.id }
+                    ?.also { post ->
+                        toggleSave(
+                            post = post as PostModel,
+                            feedback = intent.feedback,
+                        )
+                    }
+            }
 
-            is ExploreMviModel.Intent.UpVotePost -> toggleUpVote(
-                post = uiState.value.results.first { (it as? PostModel)?.id == intent.id } as PostModel,
-                feedback = intent.feedback,
-            )
+            is ExploreMviModel.Intent.UpVotePost -> {
+                uiState.value.results.firstOrNull { (it as? PostModel)?.id == intent.id }
+                    ?.also { post ->
+                        toggleUpVote(
+                            post = post as PostModel,
+                            feedback = intent.feedback,
+                        )
+                    }
+            }
 
-            is ExploreMviModel.Intent.DownVoteComment -> toggleDownVoteComment(
-                comment = uiState.value.results.first { (it as? CommentModel)?.id == intent.id } as CommentModel,
-                feedback = intent.feedback,
-            )
+            is ExploreMviModel.Intent.DownVoteComment -> {
+                uiState.value.results.firstOrNull { (it as? CommentModel)?.id == intent.id }
+                    ?.also { comment ->
+                        toggleDownVoteComment(
+                            comment = comment as CommentModel,
+                            feedback = intent.feedback,
+                        )
+                    }
+            }
 
-            is ExploreMviModel.Intent.SaveComment -> toggleSaveComment(
-                comment = uiState.value.results.first { (it as? CommentModel)?.id == intent.id } as CommentModel,
-                feedback = intent.feedback,
-            )
+            is ExploreMviModel.Intent.SaveComment -> {
+                uiState.value.results.firstOrNull { (it as? CommentModel)?.id == intent.id }
+                    ?.also { comment ->
+                        toggleSaveComment(
+                            comment = comment as CommentModel,
+                            feedback = intent.feedback,
+                        )
+                    }
+            }
 
-            is ExploreMviModel.Intent.UpVoteComment -> toggleUpVoteComment(
-                comment = uiState.value.results.first { (it as? CommentModel)?.id == intent.id } as CommentModel,
-                feedback = intent.feedback,
-            )
+            is ExploreMviModel.Intent.UpVoteComment -> {
+                uiState.value.results.firstOrNull { (it as? CommentModel)?.id == intent.id }
+                    ?.also { comment ->
+                        toggleUpVoteComment(
+                            comment = comment as CommentModel,
+                            feedback = intent.feedback,
+                        )
+                    }
+            }
         }
     }
 


### PR DESCRIPTION
When the result set changed (e.g. after changing sort type or search criterion) when opening a detail from a list led to the wrong item. This PR solves the issue by providing item unique IDs.