### PR TITLE
feat: sort communities instance detail

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoMviModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 
 @Stable
 interface InstanceInfoMviModel :
@@ -13,6 +14,7 @@ interface InstanceInfoMviModel :
     sealed interface Intent {
         data object Refresh : Intent
         data object LoadNextPage : Intent
+        data class ChangeSortType(val value: SortType) : Intent
     }
 
     data class UiState(
@@ -22,8 +24,11 @@ interface InstanceInfoMviModel :
         val refreshing: Boolean = false,
         val autoLoadImages: Boolean = true,
         val loading: Boolean = false,
+        val sortType: SortType = SortType.Active,
         val communities: List<CommunityModel> = emptyList(),
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoScreen.kt
@@ -5,13 +5,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -26,6 +29,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -43,12 +48,20 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.Communi
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.ScaledContent
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getInstanceInfoViewModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SortBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.selectcommunity.CommunityItemPlaceholder
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterContractKeys
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class InstanceInfoScreen(
     private val url: String,
@@ -68,6 +81,31 @@ class InstanceInfoScreen(
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
         val settingsRepository = remember { getSettingsRepository() }
         val settings by settingsRepository.currentSettings.collectAsState()
+        val notificationCenter = remember { getNotificationCenter() }
+        val listState = rememberLazyListState()
+
+        DisposableEffect(key) {
+            notificationCenter.addObserver(
+                {
+                    (it as? SortType)?.also { sortType ->
+                        model.reduce(InstanceInfoMviModel.Intent.ChangeSortType(sortType))
+                    }
+                },
+                key, NotificationCenterContractKeys.ChangeSortType,
+            )
+            onDispose {
+                notificationCenter.removeObserver(key)
+            }
+        }
+        LaunchedEffect(model) {
+            model.effects.onEach { effect ->
+                when (effect) {
+                    InstanceInfoMviModel.Effect.BackToTop -> {
+                        listState.scrollToItem(0)
+                    }
+                }
+            }.launchIn(this)
+        }
 
         Scaffold(
             modifier = Modifier
@@ -95,6 +133,42 @@ class InstanceInfoScreen(
                             color = MaterialTheme.colorScheme.onBackground,
                         )
                     },
+                    actions = {
+                        Row {
+                            val additionalLabel = uiState.sortType.getAdditionalLabel()
+                            if (additionalLabel.isNotEmpty()) {
+                                Text(
+                                    text = buildString {
+                                        append("(")
+                                        append(additionalLabel)
+                                        append(")")
+                                    }
+                                )
+                                Spacer(modifier = Modifier.width(Spacing.s))
+                            }
+                            Image(
+                                modifier = Modifier.onClick(
+                                    rememberCallback {
+                                        val sheet = SortBottomSheet(
+                                            values = listOf(
+                                                SortType.Active,
+                                                SortType.Hot,
+                                                SortType.New,
+                                                SortType.NewComments,
+                                                SortType.MostComments,
+                                                SortType.Top.Generic,
+                                            ),
+                                            expandTop = true,
+                                        )
+                                        navigationCoordinator.getBottomNavigator()?.show(sheet)
+                                    },
+                                ),
+                                imageVector = uiState.sortType.toIcon(),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
+                    }
                 )
             },
         ) { paddingValues ->
@@ -118,6 +192,7 @@ class InstanceInfoScreen(
             ) {
                 LazyColumn(
                     modifier = Modifier.padding(top = Spacing.m),
+                    state = listState,
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
                     item {

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoScreen.kt
@@ -70,7 +70,8 @@ class InstanceInfoScreen(
         val settings by settingsRepository.currentSettings.collectAsState()
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background)
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
                 .padding(Spacing.xs),
             topBar = {
                 TopAppBar(
@@ -116,12 +117,13 @@ class InstanceInfoScreen(
                     .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(
-                    modifier = Modifier.padding(Spacing.m),
+                    modifier = Modifier.padding(top = Spacing.m),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
                     item {
                         ScaledContent {
                             Column(
+                                modifier = Modifier.padding(horizontal = Spacing.s),
                                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             ) {

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoViewModel.kt
@@ -7,6 +7,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.Ident
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 import kotlinx.coroutines.Dispatchers
@@ -55,6 +56,7 @@ class InstanceInfoViewModel(
         when (intent) {
             InstanceInfoMviModel.Intent.LoadNextPage -> loadNextPage()
             InstanceInfoMviModel.Intent.Refresh -> refresh()
+            is InstanceInfoMviModel.Intent.ChangeSortType -> changeSortType(intent.value)
         }
     }
 
@@ -82,6 +84,7 @@ class InstanceInfoViewModel(
                 page = currentPage,
                 limit = 50,
                 listingType = ListingType.Local,
+                sortType = currentState.sortType,
                 resultType = SearchResultType.Communities,
             )?.filterIsInstance<CommunityModel>()
             if (!itemList.isNullOrEmpty()) {
@@ -100,6 +103,14 @@ class InstanceInfoViewModel(
                     refreshing = false,
                 )
             }
+        }
+    }
+
+    private fun changeSortType(value: SortType) {
+        mvi.updateState { it.copy(sortType = value) }
+        mvi.scope?.launch(Dispatchers.IO) {
+            mvi.emitEffect(InstanceInfoMviModel.Effect.BackToTop)
+            refresh()
         }
     }
 }

--- a/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/ListingType.kt
+++ b/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/ListingType.kt
@@ -5,10 +5,11 @@ import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Cottage
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.runtime.Composable
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.JavaSerializable
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
 
-sealed interface ListingType {
+sealed interface ListingType : JavaSerializable {
     data object All : ListingType
     data object Subscribed : ListingType
     data object Local : ListingType

--- a/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/SortType.kt
+++ b/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/SortType.kt
@@ -12,10 +12,11 @@ import androidx.compose.material.icons.filled.Thunderstorm
 import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.JavaSerializable
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
 
-sealed interface SortType {
+sealed interface SortType : JavaSerializable {
     data object Active : SortType
     data object Hot : SortType
     data object New : SortType
@@ -105,4 +106,16 @@ fun SortType.toReadableName(): String = when (this) {
     SortType.Controversial -> stringResource(MR.strings.home_sort_type_controversial)
     SortType.Scaled -> stringResource(MR.strings.home_sort_type_scaled)
     else -> stringResource(MR.strings.home_sort_type_top)
+}
+
+@Composable
+fun SortType?.getAdditionalLabel(): String = when (this) {
+    SortType.Top.Day -> stringResource(MR.strings.home_sort_type_top_day_short)
+    SortType.Top.Month -> stringResource(MR.strings.home_sort_type_top_month_short)
+    SortType.Top.Past12Hours -> stringResource(MR.strings.home_sort_type_top_12_hours_short)
+    SortType.Top.Past6Hours -> stringResource(MR.strings.home_sort_type_top_6_hours_short)
+    SortType.Top.PastHour -> stringResource(MR.strings.home_sort_type_top_hour_short)
+    SortType.Top.Week -> stringResource(MR.strings.home_sort_type_top_week_short)
+    SortType.Top.Year -> stringResource(MR.strings.home_sort_type_top_year_short)
+    else -> ""
 }

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostsTopBar.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostsTopBar.kt
@@ -23,6 +23,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toReadableName
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
@@ -100,16 +101,7 @@ internal fun PostsTopBar(
             }
         },
         actions = {
-            val additionalLabel = when (sortType) {
-                SortType.Top.Day -> stringResource(MR.strings.home_sort_type_top_day_short)
-                SortType.Top.Month -> stringResource(MR.strings.home_sort_type_top_month_short)
-                SortType.Top.Past12Hours -> stringResource(MR.strings.home_sort_type_top_12_hours_short)
-                SortType.Top.Past6Hours -> stringResource(MR.strings.home_sort_type_top_6_hours_short)
-                SortType.Top.PastHour -> stringResource(MR.strings.home_sort_type_top_hour_short)
-                SortType.Top.Week -> stringResource(MR.strings.home_sort_type_top_week_short)
-                SortType.Top.Year -> stringResource(MR.strings.home_sort_type_top_year_short)
-                else -> ""
-            }
+            val additionalLabel = sortType.getAdditionalLabel()
             if (additionalLabel.isNotEmpty()) {
                 Text(
                     text = buildString {

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreTopBar.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreTopBar.kt
@@ -23,6 +23,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toReadableName
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
@@ -94,16 +95,7 @@ internal fun ExploreTopBar(
             }
         },
         actions = {
-            val additionalLabel = when (sortType) {
-                SortType.Top.Day -> stringResource(MR.strings.home_sort_type_top_day_short)
-                SortType.Top.Month -> stringResource(MR.strings.home_sort_type_top_month_short)
-                SortType.Top.Past12Hours -> stringResource(MR.strings.home_sort_type_top_12_hours_short)
-                SortType.Top.Past6Hours -> stringResource(MR.strings.home_sort_type_top_6_hours_short)
-                SortType.Top.PastHour -> stringResource(MR.strings.home_sort_type_top_hour_short)
-                SortType.Top.Week -> stringResource(MR.strings.home_sort_type_top_week_short)
-                SortType.Top.Year -> stringResource(MR.strings.home_sort_type_top_year_short)
-                else -> ""
-            }
+            val additionalLabel = sortType.getAdditionalLabel()
             if (additionalLabel.isNotEmpty()) {
                 Text(
                     text = buildString {

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityScreen.kt
@@ -82,6 +82,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsR
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.feature.search.di.getMultiCommunityViewModel
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
@@ -169,16 +170,7 @@ class MultiCommunityScreen(
                     },
                     actions = {
                         Row {
-                            val additionalLabel = when (sortType) {
-                                SortType.Top.Day -> stringResource(MR.strings.home_sort_type_top_day_short)
-                                SortType.Top.Month -> stringResource(MR.strings.home_sort_type_top_month_short)
-                                SortType.Top.Past12Hours -> stringResource(MR.strings.home_sort_type_top_12_hours_short)
-                                SortType.Top.Past6Hours -> stringResource(MR.strings.home_sort_type_top_6_hours_short)
-                                SortType.Top.PastHour -> stringResource(MR.strings.home_sort_type_top_hour_short)
-                                SortType.Top.Week -> stringResource(MR.strings.home_sort_type_top_week_short)
-                                SortType.Top.Year -> stringResource(MR.strings.home_sort_type_top_year_short)
-                                else -> ""
-                            }
+                            val additionalLabel = sortType.getAdditionalLabel()
                             if (additionalLabel.isNotEmpty()) {
                                 Text(
                                     text = buildString {
@@ -193,9 +185,7 @@ class MultiCommunityScreen(
                                 Image(
                                     modifier = Modifier.onClick(
                                         rememberCallback {
-                                            val sheet = SortBottomSheet(
-                                                expandTop = true,
-                                            )
+                                            val sheet = SortBottomSheet(expandTop = true)
                                             navigationCoordinator.getBottomNavigator()?.show(sheet)
                                         },
                                     ),


### PR DESCRIPTION
This PR adds the possibility to sort communities in the instance detail screen, with some of the ordering that seem to work:

- Active
- Hot
- New
- New comments
- Most comments
- Top (every interval).