### PR TITLE
fix: instance detail

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/CommunityHeader.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/CommunityHeader.kt
@@ -14,34 +14,24 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarViewMonth
 import androidx.compose.material.icons.filled.Group
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.getPrettyNumber
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
@@ -51,8 +41,6 @@ fun CommunityHeader(
     community: CommunityModel,
     modifier: Modifier = Modifier,
     autoLoadImages: Boolean = true,
-    options: List<Option> = emptyList(),
-    onOptionSelected: ((OptionId) -> Unit)? = null,
     onOpenImage: ((String) -> Unit)? = null,
 ) {
     Box(
@@ -85,53 +73,6 @@ fun CommunityHeader(
                 )
             }
         }
-
-        Row(
-            modifier = Modifier.padding(top = Spacing.xs, end = Spacing.s).align(Alignment.TopEnd)
-        ) {
-            if (options.isNotEmpty()) {
-                var optionsExpanded by remember { mutableStateOf(false) }
-                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
-                Icon(
-                    modifier = Modifier.onGloballyPositioned {
-                        optionsOffset = it.positionInParent()
-                    }.onClick(
-                        rememberCallback {
-                            optionsExpanded = true
-                        },
-                    ),
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = null,
-                )
-                CustomDropDown(
-                    expanded = optionsExpanded,
-                    onDismiss = {
-                        optionsExpanded = false
-                    },
-                    offset = DpOffset(
-                        x = optionsOffset.x.toLocalDp(),
-                        y = optionsOffset.y.toLocalDp(),
-                        // y = (-50).dp,
-                    ),
-                ) {
-                    options.forEach { option ->
-                        Text(
-                            modifier = Modifier.padding(
-                                horizontal = Spacing.m,
-                                vertical = Spacing.s,
-                            ).onClick(
-                                rememberCallback {
-                                    optionsExpanded = false
-                                    onOptionSelected?.invoke(option.id)
-                                },
-                            ),
-                            text = option.text,
-                        )
-                    }
-                }
-            }
-        }
-
 
         Row(
             modifier = Modifier.fillMaxWidth().padding(Spacing.s).align(Alignment.Center),

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/UserHeader.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/UserHeader.kt
@@ -17,27 +17,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cake
 import androidx.compose.material.icons.filled.Padding
 import androidx.compose.material.icons.filled.Reply
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -45,7 +36,6 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.getPrettyNumber
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.prettifyDate
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 import dev.icerock.moko.resources.compose.stringResource
@@ -55,8 +45,6 @@ fun UserHeader(
     user: UserModel,
     modifier: Modifier = Modifier,
     autoLoadImages: Boolean = true,
-    options: List<Option> = emptyList(),
-    onOptionSelected: ((OptionId) -> Unit)? = null,
     onOpenImage: ((String) -> Unit)? = null,
 ) {
     Box(
@@ -86,52 +74,6 @@ fun UserHeader(
                         ),
                     ),
                 )
-            }
-        }
-
-        Row(
-            modifier = Modifier.padding(top = Spacing.xs, end = Spacing.s).align(Alignment.TopEnd)
-        ) {
-            // options menu
-            if (options.isNotEmpty()) {
-                var optionsExpanded by remember { mutableStateOf(false) }
-                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
-                Icon(
-                    modifier = Modifier.onGloballyPositioned {
-                        optionsOffset = it.positionInParent()
-                    }.onClick(
-                        rememberCallback {
-                            optionsExpanded = true
-                        },
-                    ),
-                    imageVector = Icons.Outlined.MoreVert,
-                    contentDescription = null,
-                )
-                CustomDropDown(
-                    expanded = optionsExpanded,
-                    onDismiss = {
-                        optionsExpanded = false
-                    },
-                    offset = DpOffset(
-                        x = optionsOffset.x.toLocalDp(),
-                        y = optionsOffset.y.toLocalDp(),
-                    ),
-                ) {
-                    options.forEach { option ->
-                        Text(
-                            modifier = Modifier.padding(
-                                horizontal = Spacing.m,
-                                vertical = Spacing.s,
-                            ).onClick(
-                                rememberCallback {
-                                    optionsExpanded = false
-                                    onOptionSelected?.invoke(option.id)
-                                },
-                            ),
-                            text = option.text,
-                        )
-                    }
-                }
             }
         }
 

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -21,7 +20,6 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -38,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -73,11 +70,11 @@ class InstanceInfoScreen(
     )
     @Composable
     override fun Content() {
-        val model = rememberScreenModel { getInstanceInfoViewModel(url) }
+        val instanceName = url.replace("https://", "")
+        val model = rememberScreenModel(instanceName) { getInstanceInfoViewModel(url) }
         model.bindToLifecycle(key)
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
-        val instanceName = url.replace("https://", "")
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
         val settingsRepository = remember { getSettingsRepository() }
         val settings by settingsRepository.currentSettings.collectAsState()
@@ -156,6 +153,7 @@ class InstanceInfoScreen(
                                                 SortType.New,
                                                 SortType.NewComments,
                                                 SortType.MostComments,
+                                                SortType.Old,
                                                 SortType.Top.Generic,
                                             ),
                                             expandTop = true,
@@ -226,7 +224,7 @@ class InstanceInfoScreen(
                             }
                         }
                     }
-                    if (uiState.loading && uiState.communities.isEmpty()) {
+                    if (uiState.communities.isEmpty()) {
                         items(5) {
                             CommunityItemPlaceholder()
                         }
@@ -251,17 +249,6 @@ class InstanceInfoScreen(
                     item {
                         if (!uiState.loading && !uiState.refreshing && uiState.canFetchMore) {
                             model.reduce(InstanceInfoMviModel.Intent.LoadNextPage)
-                        }
-                        if (uiState.loading && !uiState.refreshing) {
-                            Box(
-                                modifier = Modifier.fillMaxWidth().padding(Spacing.xs),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(25.dp),
-                                    color = MaterialTheme.colorScheme.primary,
-                                )
-                            }
                         }
                     }
                 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsViewModel.kt
@@ -122,7 +122,8 @@ class SavedItemsViewModel(
         currentPage = 1
         mvi.updateState {
             it.copy(
-                canFetchMore = true, refreshing = true
+                canFetchMore = true,
+                refreshing = true,
             )
         }
         loadNextPage()

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/managesubscriptions/ManageSubscriptionsMviModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/managesubscriptions/ManageSubscriptionsMviModel.kt
@@ -16,6 +16,7 @@ interface ManageSubscriptionsMviModel :
     }
 
     data class UiState(
+        val initial: Boolean = true,
         val refreshing: Boolean = false,
         val multiCommunities: List<MultiCommunityModel> = emptyList(),
         val communities: List<CommunityModel> = emptyList(),

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/managesubscriptions/ManageSubscriptionsScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/managesubscriptions/ManageSubscriptionsScreen.kt
@@ -61,6 +61,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.Swipeab
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getDrawerCoordinator
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getFabNestedScrollConnection
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.selectcommunity.CommunityItemPlaceholder
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.rememberCallbackArgs
@@ -256,6 +257,11 @@ class ManageSubscriptionsScreen : Screen {
                             )
                         }
                     }
+                    if (uiState.initial) {
+                        items(5) {
+                            CommunityItemPlaceholder()
+                        }
+                    }
                     items(uiState.communities) { community ->
                         val endColor = MaterialTheme.colorScheme.secondary
                         SwipeableCard(
@@ -301,9 +307,9 @@ class ManageSubscriptionsScreen : Screen {
                         )
                     }
 
-                    if (uiState.multiCommunities.isEmpty() && uiState.communities.isEmpty()) {
+                    if (uiState.multiCommunities.isEmpty() && uiState.communities.isEmpty() && !uiState.initial) {
                         item {
-                            androidx.compose.material.Text(
+                            Text(
                                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.xs),
                                 textAlign = TextAlign.Center,
                                 text = stringResource(MR.strings.message_empty_list),
@@ -314,13 +320,15 @@ class ManageSubscriptionsScreen : Screen {
                     }
                 }
 
-                PullRefreshIndicator(
-                    refreshing = uiState.refreshing,
-                    state = pullRefreshState,
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    backgroundColor = MaterialTheme.colorScheme.background,
-                    contentColor = MaterialTheme.colorScheme.onBackground,
-                )
+                if (!uiState.initial) {
+                    PullRefreshIndicator(
+                        refreshing = uiState.refreshing,
+                        state = pullRefreshState,
+                        modifier = Modifier.align(Alignment.TopCenter),
+                        backgroundColor = MaterialTheme.colorScheme.background,
+                        contentColor = MaterialTheme.colorScheme.onBackground,
+                    )
+                }
             }
         }
     }

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/managesubscriptions/ManageSubscriptionsViewModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/managesubscriptions/ManageSubscriptionsViewModel.kt
@@ -88,6 +88,7 @@ class ManageSubscriptionsViewModel(
             mvi.updateState {
                 it.copy(
                     refreshing = false,
+                    initial = false,
                     communities = communities,
                     multiCommunities = multiCommunitites,
                 )


### PR DESCRIPTION
This PR adds the "old" sort option for communities in instance detail, improves the loading of such elements and moves the ℹ️ buttons to a 🚦 button in the app bar in both community and user detail.