### PR TITLE
fix: remove unnecessary reloads

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
@@ -164,7 +164,7 @@ class CommunityDetailScreen(
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
                     if (evt.key == key) {
-                        CommunityDetailMviModel.Intent.ChangeSort(evt.value)
+                        model.reduce(CommunityDetailMviModel.Intent.ChangeSort(evt.value))
                     }
                 }.launchIn(this)
         }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
@@ -160,20 +160,13 @@ class CommunityDetailScreen(
             }
         }
         LaunchedEffect(notificationCenter) {
+            notificationCenter.resetCache()
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
                     if (evt.key == key) {
                         CommunityDetailMviModel.Intent.ChangeSort(evt.value)
                     }
                 }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.PostCreated::class).onEach {
-                model.reduce(CommunityDetailMviModel.Intent.Refresh)
-            }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
-                model.reduce(CommunityDetailMviModel.Intent.Refresh)
-            }.launchIn(this)
         }
         LaunchedEffect(model) {
             model.effects.onEach { effect ->

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentMviModel.kt
@@ -46,7 +46,7 @@ interface CreateCommentMviModel :
 
     sealed interface Effect {
         data class AddImageToText(val url: String) : Effect
-        data object Success : Effect
+        data class Success(val new: Boolean) : Effect
         data class Failure(val message: String?) : Effect
     }
 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentScreen.kt
@@ -123,10 +123,23 @@ class CreateCommentScreen(
                         snackbarHostState.showSnackbar(effect.message ?: genericError)
                     }
 
-                    CreateCommentMviModel.Effect.Success -> {
+                    is CreateCommentMviModel.Effect.Success -> {
                         notificationCenter.send(
                             event = NotificationCenterEvent.CommentCreated,
                         )
+                        if (originalPost != null) {
+                            notificationCenter.send(
+                                event = NotificationCenterEvent.PostUpdated(
+                                    originalPost.copy(
+                                        comments = if (effect.new) {
+                                            originalPost.comments + 1
+                                        } else {
+                                            originalPost.comments
+                                        }
+                                    )
+                                ),
+                            )
+                        }
                         navigationCoordinator.hideBottomSheet()
                     }
 

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentViewModel.kt
@@ -103,7 +103,7 @@ class CreateCommentViewModel(
                 }
                 // the comment count has changed, emits update
                 emitPostUpdateNotification()
-                mvi.emitEffect(CreateCommentMviModel.Effect.Success)
+                mvi.emitEffect(CreateCommentMviModel.Effect.Success(new = editedCommentId == null))
             } catch (e: Throwable) {
                 val message = e.message
                 mvi.emitEffect(CreateCommentMviModel.Effect.Failure(message))

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/instanceinfo/InstanceInfoViewModel.kt
@@ -4,8 +4,8 @@ import com.github.diegoberaldin.raccoonforlemmy.core.architecture.DefaultMviMode
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
-import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResult
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
@@ -86,19 +86,23 @@ class InstanceInfoViewModel(
                 sortType = currentState.sortType,
                 resultType = SearchResultType.Communities,
                 limit = 50,
-            )?.filterIsInstance<CommunityModel>()
+            )?.filterIsInstance<SearchResult.Community>()
                 ?.let {
                     if (refreshing) {
                         it
                     } else {
                         // prevents accidental duplication
-                        it.filter { c1 -> currentState.communities.none { c2 -> c1.id == c2.id } }
+                        it.filter { c1 ->
+                            currentState.communities.none { c2 -> c1.model.id == c2.id }
+                        }
                     }
                 }
             if (!itemList.isNullOrEmpty()) {
                 currentPage++
             }
-            val itemsToAdd = itemList.orEmpty().filter { e -> e.instanceUrl == url }
+            val itemsToAdd = itemList.orEmpty().filter { e ->
+                e.model.instanceUrl == url
+            }.map { it.model }
             mvi.updateState {
                 it.copy(
                     communities = if (refreshing) {

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
@@ -164,6 +164,7 @@ class PostDetailScreen(
             }
         }
         LaunchedEffect(notificationCenter) {
+            notificationCenter.resetCache()
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
                     if (evt.key == key) {
@@ -173,7 +174,6 @@ class PostDetailScreen(
 
             notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
                 model.reduce(PostDetailMviModel.Intent.Refresh)
-                model.reduce(PostDetailMviModel.Intent.RefreshPost)
             }.launchIn(this)
 
             notificationCenter.subscribe(NotificationCenterEvent.PostUpdated::class).onEach {

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
@@ -153,16 +153,13 @@ class UserDetailScreen(
             }
         }
         LaunchedEffect(notificationCenter) {
+            notificationCenter.resetCache()
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
                     if (evt.key == key) {
                         model.reduce(UserDetailMviModel.Intent.ChangeSort(evt.value))
                     }
                 }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
-                model.reduce(UserDetailMviModel.Intent.Refresh)
-            }.launchIn(this)
         }
         LaunchedEffect(model) {
             model.effects.onEach {

--- a/core-notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenter.kt
+++ b/core-notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenter.kt
@@ -12,4 +12,6 @@ interface NotificationCenter {
     fun send(event: NotificationCenterEvent)
 
     fun <T : NotificationCenterEvent> subscribe(clazz: KClass<T>): Flow<T>
+
+    fun resetCache()
 }

--- a/domain-identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCase.kt
+++ b/domain-identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCase.kt
@@ -15,6 +15,7 @@ internal class DefaultLogoutUseCase(
     override suspend operator fun invoke() {
         identityRepository.clearToken()
         notificationCenter.send(NotificationCenterEvent.Logout)
+        notificationCenter.send(NotificationCenterEvent.ResetContents)
         val oldAccountId = accountRepository.getActive()?.id
         if (oldAccountId != null) {
             accountRepository.setActive(oldAccountId, false)

--- a/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/SearchResultType.kt
+++ b/domain-lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/SearchResultType.kt
@@ -7,3 +7,10 @@ sealed interface SearchResultType {
     data object Users : SearchResultType
     data object Communities : SearchResultType
 }
+
+sealed interface SearchResult {
+    data class Post(val model: PostModel) : SearchResult
+    data class Comment(val model: CommentModel) : SearchResult
+    data class User(val model: UserModel) : SearchResult
+    data class Community(val model: CommunityModel) : SearchResult
+}

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
@@ -156,14 +156,6 @@ class PostListScreen : Screen {
                         model.reduce(PostListMviModel.Intent.ChangeSort(evt.value))
                     }
                 }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
-                model.reduce(PostListMviModel.Intent.Refresh)
-            }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.PostCreated::class).onEach {
-                model.reduce(PostListMviModel.Intent.Refresh)
-            }.launchIn(this)
         }
 
         Scaffold(

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreMviModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreMviModel.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResult
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 
@@ -39,7 +40,7 @@ interface ExploreMviModel :
         val searchText: String = "",
         val listingType: ListingType = ListingType.Local,
         val sortType: SortType = SortType.Active,
-        val results: List<Any> = emptyList(),
+        val results: List<SearchResult> = emptyList(),
         val resultType: SearchResultType = SearchResultType.All,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
@@ -138,10 +138,6 @@ class ExploreScreen : Screen {
                         model.reduce(ExploreMviModel.Intent.SetSortType(evt.value))
                     }
                 }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
-                model.reduce(ExploreMviModel.Intent.Refresh)
-            }.launchIn(this)
         }
         val lazyListState = rememberLazyListState()
         LaunchedEffect(Unit) {

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
@@ -80,11 +80,9 @@ import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsR
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
-import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
-import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResult
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
-import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.github.diegoberaldin.raccoonforlemmy.feature.search.di.getExploreViewModel
 import com.github.diegoberaldin.raccoonforlemmy.feature.search.ui.ExploreTab
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
@@ -303,23 +301,23 @@ class ExploreScreen : Screen {
                         }
                         items(uiState.results, key = { getItemKey(it) }) { result ->
                             when (result) {
-                                is CommunityModel -> {
+                                is SearchResult.Community -> {
                                     CommunityItem(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .onClick(
                                                 onClick = rememberCallback {
                                                     navigationCoordinator.pushScreen(
-                                                        CommunityDetailScreen(result),
+                                                        CommunityDetailScreen(result.model),
                                                     )
                                                 },
                                             ),
-                                        community = result,
+                                        community = result.model,
                                         autoLoadImages = uiState.autoLoadImages,
                                     )
                                 }
 
-                                is PostModel -> {
+                                is SearchResult.Post -> {
                                     SwipeableCard(
                                         modifier = Modifier.fillMaxWidth(),
                                         enabled = uiState.swipeActionsEnabled,
@@ -338,10 +336,10 @@ class ExploreScreen : Screen {
                                             model.reduce(ExploreMviModel.Intent.HapticIndication)
                                         },
                                         onDismissToStart = rememberCallback(model) {
-                                            model.reduce(ExploreMviModel.Intent.UpVotePost(result.id))
+                                            model.reduce(ExploreMviModel.Intent.UpVotePost(result.model.id))
                                         },
                                         onDismissToEnd = rememberCallback(model) {
-                                            model.reduce(ExploreMviModel.Intent.DownVotePost(result.id))
+                                            model.reduce(ExploreMviModel.Intent.DownVotePost(result.model.id))
                                         },
                                         swipeContent = { direction ->
                                             val icon = when (direction) {
@@ -356,7 +354,7 @@ class ExploreScreen : Screen {
                                         },
                                         content = {
                                             PostCard(
-                                                post = result,
+                                                post = result.model,
                                                 postLayout = uiState.postLayout,
                                                 fullHeightImage = uiState.fullHeightImages,
                                                 separateUpAndDownVotes = uiState.separateUpAndDownVotes,
@@ -364,7 +362,7 @@ class ExploreScreen : Screen {
                                                 blurNsfw = uiState.blurNsfw,
                                                 onClick = rememberCallback {
                                                     navigationCoordinator.pushScreen(
-                                                        PostDetailScreen(result),
+                                                        PostDetailScreen(result.model),
                                                     )
                                                 },
                                                 onDoubleClick = if (!uiState.doubleTapActionEnabled) {
@@ -373,7 +371,7 @@ class ExploreScreen : Screen {
                                                     rememberCallback(model) {
                                                         model.reduce(
                                                             ExploreMviModel.Intent.UpVotePost(
-                                                                id = result.id,
+                                                                id = result.model.id,
                                                                 feedback = true,
                                                             ),
                                                         )
@@ -392,7 +390,7 @@ class ExploreScreen : Screen {
                                                 onUpVote = rememberCallback(model) {
                                                     model.reduce(
                                                         ExploreMviModel.Intent.UpVotePost(
-                                                            id = result.id,
+                                                            id = result.model.id,
                                                             feedback = true,
                                                         ),
                                                     )
@@ -400,7 +398,7 @@ class ExploreScreen : Screen {
                                                 onDownVote = rememberCallback(model) {
                                                     model.reduce(
                                                         ExploreMviModel.Intent.DownVotePost(
-                                                            id = result.id,
+                                                            id = result.model.id,
                                                             feedback = true,
                                                         ),
                                                     )
@@ -408,14 +406,14 @@ class ExploreScreen : Screen {
                                                 onSave = rememberCallback(model) {
                                                     model.reduce(
                                                         ExploreMviModel.Intent.SavePost(
-                                                            id = result.id,
+                                                            id = result.model.id,
                                                             feedback = true,
                                                         ),
                                                     )
                                                 },
                                                 onReply = rememberCallback {
                                                     val screen = CreateCommentScreen(
-                                                        originalPost = result,
+                                                        originalPost = result.model,
                                                     )
                                                     navigationCoordinator.showBottomSheet(screen)
                                                 },
@@ -434,7 +432,7 @@ class ExploreScreen : Screen {
                                     }
                                 }
 
-                                is CommentModel -> {
+                                is SearchResult.Comment -> {
                                     SwipeableCard(
                                         modifier = Modifier.fillMaxWidth(),
                                         enabled = uiState.swipeActionsEnabled,
@@ -463,14 +461,14 @@ class ExploreScreen : Screen {
                                         onDismissToStart = rememberCallback(model) {
                                             model.reduce(
                                                 ExploreMviModel.Intent.UpVoteComment(
-                                                    id = result.id
+                                                    id = result.model.id
                                                 ),
                                             )
                                         },
                                         onDismissToEnd = rememberCallback(model) {
                                             model.reduce(
                                                 ExploreMviModel.Intent.DownVoteComment(
-                                                    id = result.id
+                                                    id = result.model.id
                                                 ),
                                             )
                                         },
@@ -488,15 +486,15 @@ class ExploreScreen : Screen {
                                         content = {
                                             CommentCard(
                                                 modifier = Modifier.background(MaterialTheme.colorScheme.background),
-                                                comment = result,
+                                                comment = result.model,
                                                 separateUpAndDownVotes = uiState.separateUpAndDownVotes,
                                                 autoLoadImages = uiState.autoLoadImages,
                                                 hideIndent = true,
                                                 onClick = rememberCallback {
                                                     navigationCoordinator.pushScreen(
                                                         PostDetailScreen(
-                                                            post = PostModel(id = result.postId),
-                                                            highlightCommentId = result.id,
+                                                            post = PostModel(id = result.model.postId),
+                                                            highlightCommentId = result.model.id,
                                                         ),
                                                     )
                                                 },
@@ -506,7 +504,7 @@ class ExploreScreen : Screen {
                                                     rememberCallback(model) {
                                                         model.reduce(
                                                             ExploreMviModel.Intent.UpVoteComment(
-                                                                id = result.id,
+                                                                id = result.model.id,
                                                                 feedback = true,
                                                             ),
                                                         )
@@ -515,7 +513,7 @@ class ExploreScreen : Screen {
                                                 onUpVote = rememberCallback(model) {
                                                     model.reduce(
                                                         ExploreMviModel.Intent.UpVoteComment(
-                                                            id = result.id,
+                                                            id = result.model.id,
                                                             feedback = true,
                                                         ),
                                                     )
@@ -523,7 +521,7 @@ class ExploreScreen : Screen {
                                                 onDownVote = rememberCallback(model) {
                                                     model.reduce(
                                                         ExploreMviModel.Intent.DownVoteComment(
-                                                            id = result.id,
+                                                            id = result.model.id,
                                                             feedback = true,
                                                         ),
                                                     )
@@ -531,15 +529,15 @@ class ExploreScreen : Screen {
                                                 onSave = rememberCallback(model) {
                                                     model.reduce(
                                                         ExploreMviModel.Intent.SaveComment(
-                                                            id = result.id,
+                                                            id = result.model.id,
                                                             feedback = true,
                                                         ),
                                                     )
                                                 },
                                                 onReply = rememberCallback {
                                                     val screen = CreateCommentScreen(
-                                                        originalPost = PostModel(id = result.postId),
-                                                        originalComment = result,
+                                                        originalPost = PostModel(id = result.model.postId),
+                                                        originalComment = result.model,
                                                     )
                                                     navigationCoordinator.showBottomSheet(screen)
                                                 },
@@ -562,18 +560,18 @@ class ExploreScreen : Screen {
                                     )
                                 }
 
-                                is UserModel -> {
+                                is SearchResult.User -> {
                                     UserItem(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .onClick(
                                                 onClick = rememberCallback {
                                                     navigationCoordinator.pushScreen(
-                                                        UserDetailScreen(result),
+                                                        UserDetailScreen(result.model),
                                                     )
                                                 },
                                             ),
-                                        user = result,
+                                        user = result.model,
                                     )
                                 }
                             }

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityScreen.kt
@@ -130,10 +130,6 @@ class MultiCommunityScreen(
                         model.reduce(MultiCommunityMviModel.Intent.ChangeSort(evt.value))
                     }
                 }.launchIn(this)
-
-            notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
-                model.reduce(MultiCommunityMviModel.Intent.Refresh)
-            }.launchIn(this)
         }
 
         Scaffold(


### PR DESCRIPTION
This PR fixes some more problems with reloading screens after navigation, fixes a crash in the explore screen and a bug that prevented sorting from applying to the post list in community detail.