### PR TITLE
fix: inbox opening detail and loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ rb_c, OverfedRaccoon, Jailbrick3d, everdred…
 - get it on [Obtainium](https://github.com/ImranR98/Obtainium/releases) by simply adding this
   repo `https://github.com/diegoberaldin/RaccoonForLemmy`
 
+On Obtaininum, you can enable the "Include prereleases" switch to get access to the releases that
+are not marked as stable.
+
 ## Want to leave your feedback or report a bug?
 
 - open an issue on this

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsMviModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsMviModel.kt
@@ -35,5 +35,6 @@ interface InboxMentionsMviModel :
 
     sealed interface Effect {
         data class UpdateUnreadItems(val value: Int) : Effect
+        data object BackToTop : Effect
     }
 }

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsScreen.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsScreen.kt
@@ -90,6 +90,10 @@ class InboxMentionsScreen : Tab {
                     is InboxMentionsMviModel.Effect.UpdateUnreadItems -> {
                         navigationCoordinator.setInboxUnread(effect.value)
                     }
+
+                    InboxMentionsMviModel.Effect.BackToTop -> {
+                        lazyListState.scrollToItem(0)
+                    }
                 }
             }.launchIn(this)
         }
@@ -131,7 +135,10 @@ class InboxMentionsScreen : Tab {
                         )
                     }
                 }
-                items(uiState.mentions) { mention ->
+                items(
+                    items = uiState.mentions,
+                    key = { it.id.toString() + uiState.unreadOnly },
+                ) { mention ->
                     val endColor = MaterialTheme.colorScheme.secondary
                     val startColor = MaterialTheme.colorScheme.tertiary
                     SwipeableCard(

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/messages/InboxMessagesMviModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/messages/InboxMessagesMviModel.kt
@@ -27,5 +27,6 @@ interface InboxMessagesMviModel :
 
     sealed interface Effect {
         data class UpdateUnreadItems(val value: Int) : Effect
+        data object BackToTop : Effect
     }
 }

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/messages/InboxMessagesScreen.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/messages/InboxMessagesScreen.kt
@@ -72,6 +72,10 @@ class InboxMessagesScreen : Tab {
                     is InboxMessagesMviModel.Effect.UpdateUnreadItems -> {
                         navigationCoordinator.setInboxUnread(effect.value)
                     }
+
+                    InboxMessagesMviModel.Effect.BackToTop -> {
+                        lazyListState.scrollToItem(0)
+                    }
                 }
             }.launchIn(this)
         }
@@ -106,7 +110,10 @@ class InboxMessagesScreen : Tab {
                         )
                     }
                 }
-                items(uiState.chats) { chat ->
+                items(
+                    items = uiState.chats,
+                    key = { it.id.toString() + uiState.unreadOnly },
+                ) { chat ->
                     val otherUser = if (chat.creator?.id == uiState.currentUserId) {
                         chat.recipient
                     } else {

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesMviModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesMviModel.kt
@@ -35,5 +35,6 @@ interface InboxRepliesMviModel :
 
     sealed interface Effect {
         data class UpdateUnreadItems(val value: Int) : Effect
+        data object BackToTop : Effect
     }
 }

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesScreen.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesScreen.kt
@@ -89,6 +89,10 @@ class InboxRepliesScreen : Tab {
                     is InboxRepliesMviModel.Effect.UpdateUnreadItems -> {
                         navigationCoordinator.setInboxUnread(effect.value)
                     }
+
+                    InboxRepliesMviModel.Effect.BackToTop -> {
+                        lazyListState.scrollToItem(0)
+                    }
                 }
             }.launchIn(this)
         }
@@ -130,7 +134,10 @@ class InboxRepliesScreen : Tab {
                         )
                     }
                 }
-                items(uiState.replies) { reply ->
+                items(
+                    items = uiState.replies,
+                    key = { it.id.toString() + uiState.unreadOnly },
+                ) { reply ->
                     val endColor = MaterialTheme.colorScheme.secondary
                     val startColor = MaterialTheme.colorScheme.tertiary
                     SwipeableCard(


### PR DESCRIPTION
In the inbox screens, after chaning the filters (read/unread) if you tried to open an item you could end up opening the item that occupied that position before the filter change.

This PR solves that problem and introduces automatic scroll to top when filters are changed like in the rest of the app sections, this behaviour was added later and the inbox screen had been left behind.