### PR TITLE
feat: add quote action in text toolbar

### DIFF
--- a/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/CustomTextToolbar.kt
+++ b/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/CustomTextToolbar.kt
@@ -11,10 +11,12 @@ import com.github.diegoberaldin.raccoonforlemmy.resources.MR
 
 private const val ACTION_ID_COPY = 0
 private const val ACTION_ID_SEARCH = 1
+private const val ACTION_ID_QUOTE = 2
 
 class CustomTextToolbar(
     private val view: View,
     private val onShare: () -> Unit,
+    private val onQuote: () -> Unit,
 ) : TextToolbar {
     private var actionMode: ActionMode? = null
 
@@ -46,6 +48,10 @@ class CustomTextToolbar(
                         onCopyRequested?.invoke()
                         onShare()
                     },
+                    onQuote = {
+                        onCopyRequested?.invoke()
+                        onQuote()
+                    }
                 ),
                 ActionMode.TYPE_FLOATING,
             )
@@ -60,6 +66,7 @@ internal class CustomTextActionModeCallback(
     private val rect: Rect,
     private val onCopy: () -> Unit,
     private val onShare: () -> Unit,
+    private val onQuote: () -> Unit,
 ) : ActionMode.Callback2() {
 
     override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
@@ -70,6 +77,9 @@ internal class CustomTextActionModeCallback(
             ).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
             add(
                 groupId, ACTION_ID_SEARCH, 1, MR.strings.post_action_share.resourceId
+            ).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+            add(
+                groupId, ACTION_ID_QUOTE, 2, MR.strings.action_quote.resourceId
             ).setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
         }
         return true
@@ -86,6 +96,11 @@ internal class CustomTextActionModeCallback(
 
             ACTION_ID_SEARCH -> {
                 onShare()
+                true
+            }
+
+            ACTION_ID_QUOTE -> {
+                onQuote()
                 true
             }
 

--- a/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
+++ b/core-commonui/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
@@ -161,9 +161,11 @@ actual fun getSelectCommunityViewModel(): SelectCommunityMviModel {
 @Composable
 actual fun getCustomTextToolbar(
     onShare: () -> Unit,
+    onQuote: () -> Unit,
 ): TextToolbar {
     return CustomTextToolbar(
         view = LocalView.current,
         onShare = onShare,
+        onQuote = onQuote,
     )
 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
@@ -759,6 +759,21 @@ class CommunityDetailScreen(
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalPost = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
 
@@ -768,6 +783,21 @@ class CommunityDetailScreen(
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalComment = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
             }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentScreen.kt
@@ -77,6 +77,7 @@ class CreateCommentScreen(
     private val originalPost: PostModel? = null,
     private val originalComment: CommentModel? = null,
     private val editedComment: CommentModel? = null,
+    private val initialText: String? = null,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -98,7 +99,11 @@ class CreateCommentScreen(
         var openImagePicker by remember { mutableStateOf(false) }
         var rawContent by remember { mutableStateOf<Any?>(null) }
         var textFieldValue by remember {
-            mutableStateOf(TextFieldValue(text = editedComment?.text.orEmpty()))
+            mutableStateOf(
+                TextFieldValue(
+                    text = (initialText ?: editedComment?.text).orEmpty()
+                )
+            )
         }
         val commentFocusRequester = remember { FocusRequester() }
         val focusManager = LocalFocusManager.current

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
@@ -81,6 +81,7 @@ expect fun getCreateReportViewModel(
 @Composable
 expect fun getCustomTextToolbar(
     onShare: () -> Unit,
+    onQuote: () -> Unit,
 ): TextToolbar
 
 expect fun getSelectCommunityViewModel(): SelectCommunityMviModel

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/RawContentDialog.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/RawContentDialog.kt
@@ -39,12 +39,17 @@ fun RawContentDialog(
     url: String? = null,
     text: String? = null,
     onDismiss: (() -> Unit)? = null,
+    onQuote: ((String?) -> Unit)? = null,
 ) {
     val clipboardManager = LocalClipboardManager.current
     val shareHelper = remember { getShareHelper() }
     val onShareLambda = rememberCallback {
         val query = clipboardManager.getText()?.text.orEmpty()
         shareHelper.share(query, "text/plain")
+    }
+    val onQuoteLambda = rememberCallback {
+        val query = clipboardManager.getText()?.text.orEmpty()
+        onQuote?.invoke(query)
     }
 
     AlertDialog(
@@ -80,6 +85,7 @@ fun RawContentDialog(
                             CompositionLocalProvider(
                                 LocalTextToolbar provides getCustomTextToolbar(
                                     onShare = onShareLambda,
+                                    onQuote = onQuoteLambda,
                                 )
                             ) {
                                 SelectionContainer {
@@ -108,6 +114,7 @@ fun RawContentDialog(
                             CompositionLocalProvider(
                                 LocalTextToolbar provides getCustomTextToolbar(
                                     onShare = onShareLambda,
+                                    onQuote = onQuoteLambda,
                                 )
                             ) {
                                 SelectionContainer {
@@ -137,6 +144,7 @@ fun RawContentDialog(
                             CompositionLocalProvider(
                                 LocalTextToolbar provides getCustomTextToolbar(
                                     onShare = onShareLambda,
+                                    onQuote = onQuoteLambda,
                                 )
                             ) {
                                 SelectionContainer {

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
@@ -958,6 +958,21 @@ class PostDetailScreen(
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalPost = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
 
@@ -967,6 +982,21 @@ class PostDetailScreen(
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalComment = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
             }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsScreen.kt
@@ -105,6 +105,7 @@ class SavedItemsScreen : Screen {
         var rawContent by remember { mutableStateOf<Any?>(null) }
         val settingsRepository = remember { getSettingsRepository() }
         val settings by settingsRepository.currentSettings.collectAsState()
+        val navigationCoordinator = remember { getNavigationCoordinator() }
 
         DisposableEffect(key) {
             drawerCoordinator.setGesturesEnabled(false)
@@ -498,6 +499,21 @@ class SavedItemsScreen : Screen {
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalPost = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
 
@@ -507,6 +523,21 @@ class SavedItemsScreen : Screen {
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalComment = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
             }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
@@ -851,6 +851,21 @@ class UserDetailScreen(
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalPost = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
 
@@ -860,6 +875,21 @@ class UserDetailScreen(
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalComment = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
             }

--- a/core-commonui/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
+++ b/core-commonui/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/di/Utils.kt
@@ -187,6 +187,7 @@ object CommonUiViewModelHelper : KoinComponent {
 @Composable
 actual fun getCustomTextToolbar(
     onShare: () -> Unit,
+    onQuote: () -> Unit,
 ): TextToolbar {
     return LocalTextToolbar.current
 }

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
@@ -573,6 +573,21 @@ class PostListScreen : Screen {
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalPost = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
             }

--- a/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedScreen.kt
+++ b/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedScreen.kt
@@ -446,6 +446,21 @@ internal object ProfileLoggedScreen : Tab {
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalPost = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
 
@@ -455,6 +470,21 @@ internal object ProfileLoggedScreen : Tab {
                         onDismiss = {
                             rawContent = null
                         },
+                        onQuote = { quotation ->
+                            rawContent = null
+                            if (quotation != null) {
+                                val screen =
+                                    CreateCommentScreen(
+                                        originalComment = content,
+                                        initialText = buildString {
+                                            append("> ")
+                                            append(quotation)
+                                            append("\n\n")
+                                        }
+                                    )
+                                navigationCoordinator.showBottomSheet(screen)
+                            }
+                        }
                     )
                 }
             }

--- a/resources/src/commonMain/resources/MR/base/strings.xml
+++ b/resources/src/commonMain/resources/MR/base/strings.xml
@@ -241,8 +241,9 @@
     <string name="settings_ui_font_scale">UI text size</string>
     <string name="settings_ui_theme">UI theme</string>
     <string name="settings_upvote_color">Upvote color</string>
-    <string name="settings_hide_navigation_bar">Hide navigation bar when scrolling</string>
+    <string name="settings_hide_navigation_bar">Hide navigation bar while scrolling</string>
     <string name="settings_zombie_mode_interval">Zombie mode interval duration</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie mode scroll amount</string>
     <string name="settings_mark_as_read_while_scrolling">Mark posts as read while scrolling</string>
+    <string name="action_quote">Quote…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/bg/strings.xml
+++ b/resources/src/commonMain/resources/MR/bg/strings.xml
@@ -245,7 +245,8 @@
     </string>
     <string name="settings_zombie_mode_interval">Продължителност на интервала в режим Зомби</string>
     <string name="settings_zombie_mode_scroll_amount">Сума за превъртане в режим на зомби</string>
-    <string name="settings_mark_as_read_while_scrolling">Маркирайте публикациите като прочетени,
-        докато превъртате
+    <string name="settings_mark_as_read_while_scrolling">Маркирайте публикациите като прочетени при
+        превъртате
     </string>
+    <string name="action_quote">цитат…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/cs/strings.xml
+++ b/resources/src/commonMain/resources/MR/cs/strings.xml
@@ -228,10 +228,11 @@
     <string name="settings_ui_font_scale">Velikost textu uživatelského rozhraní</string>
     <string name="settings_ui_theme">Motiv uživatelského rozhraní</string>
     <string name="settings_upvote_color">Barva upvote</string>
-    <string name="settings_hide_navigation_bar">Skrýt navigační panel při posouvání</string>
+    <string name="settings_hide_navigation_bar">Skrýt navigační panel při rolování</string>
     <string name="settings_zombie_mode_interval">Trvání intervalu režimu Zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Množství posouvání v zombie režimu</string>
     <string name="settings_mark_as_read_while_scrolling">Označte příspěvky jako přečtené při
         rolování
     </string>
+    <string name="action_quote">Citát…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/da/strings.xml
+++ b/resources/src/commonMain/resources/MR/da/strings.xml
@@ -218,9 +218,10 @@
     <string name="settings_ui_font_scale">UI-tekststørrelse</string>
     <string name="settings_ui_theme">UI tema</string>
     <string name="settings_upvote_color">Upvote farve</string>
-    <string name="settings_hide_navigation_bar">Skjul navigationslinjen, når du ruller</string>
+    <string name="settings_hide_navigation_bar">Skjul navigationslinjen, mens du ruller</string>
     <string name="settings_zombie_mode_interval">Varighed af Zombie-tilstandsinterval</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie-tilstand scroll beløb</string>
     <string name="settings_mark_as_read_while_scrolling">Marker indlæg som læst, mens du ruller
     </string>
+    <string name="action_quote">Citere…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/de/strings.xml
+++ b/resources/src/commonMain/resources/MR/de/strings.xml
@@ -227,4 +227,5 @@
     <string name="settings_mark_as_read_while_scrolling">Markieren Sie Beiträge beim Scrollen als
         gelesen
     </string>
+    <string name="action_quote">Zitat…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/el/strings.xml
+++ b/resources/src/commonMain/resources/MR/el/strings.xml
@@ -231,4 +231,5 @@
     <string name="settings_mark_as_read_while_scrolling">Επισήμανση αναρτήσεων ως αναγνωσμένων κατά
         την κύλιση
     </string>
+    <string name="action_quote">Παράσου…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/es/strings.xml
+++ b/resources/src/commonMain/resources/MR/es/strings.xml
@@ -229,4 +229,5 @@
     <string name="settings_mark_as_read_while_scrolling">Marcar publicaciones como leídas al
         desplazarse
     </string>
+    <string name="action_quote">Citar…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/et/strings.xml
+++ b/resources/src/commonMain/resources/MR/et/strings.xml
@@ -242,4 +242,5 @@
     <string name="settings_zombie_mode_scroll_amount">Zombirežiimi kerimise kogus</string>
     <string name="settings_mark_as_read_while_scrolling">Märkige postitused kerimise ajal loetuks
     </string>
+    <string name="action_quote">Tsiteeri…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fi/strings.xml
+++ b/resources/src/commonMain/resources/MR/fi/strings.xml
@@ -231,6 +231,7 @@
     <string name="settings_hide_navigation_bar">Piilota navigointipalkki vieritettäessä</string>
     <string name="settings_zombie_mode_interval">Zombitilan aikavälin kesto</string>
     <string name="settings_zombie_mode_scroll_amount">Zombitilan vieritysmäärä</string>
-    <string name="settings_mark_as_read_while_scrolling">Merkitse viestit luetuiksi vierittäessäsi
+    <string name="settings_mark_as_read_while_scrolling">Merkitse viestit luetuiksi vieritettäessä
     </string>
+    <string name="action_quote">Lainata…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fr/strings.xml
+++ b/resources/src/commonMain/resources/MR/fr/strings.xml
@@ -227,4 +227,5 @@
     <string name="settings_mark_as_read_while_scrolling">Marquer les messages comme lus lors du
         défilement
     </string>
+    <string name="action_quote">Citer…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ga/strings.xml
+++ b/resources/src/commonMain/resources/MR/ga/strings.xml
@@ -252,7 +252,8 @@
     </string>
     <string name="settings_zombie_mode_interval">Fad eatramh an mhóid Zombaí</string>
     <string name="settings_zombie_mode_scroll_amount">Méid scrollaithe an mhóid Zombie</string>
-    <string name="settings_mark_as_read_while_scrolling">Marcáil postálacha mar léite agus iad ag
+    <string name="settings_mark_as_read_while_scrolling">Marcáil postálacha mar léite agus tú ag
         scrollú
     </string>
+    <string name="action_quote">Athfhriotail…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hr/strings.xml
+++ b/resources/src/commonMain/resources/MR/hr/strings.xml
@@ -237,7 +237,7 @@
     <string name="settings_ui_font_scale">Veličina teksta korisničkog sučelja</string>
     <string name="settings_ui_theme">Tema korisničkog sučelja</string>
     <string name="settings_upvote_color">Boja za glasanje</string>
-    <string name="settings_hide_navigation_bar">Sakrij navigacijsku traku prilikom pomicanja
+    <string name="settings_hide_navigation_bar">Sakrij navigacijsku traku tijekom pomicanja
     </string>
     <string name="settings_zombie_mode_interval">Trajanje intervala zombi načina rada</string>
     <string name="settings_zombie_mode_scroll_amount">Količina pomicanja u zombi načinu rada
@@ -245,4 +245,5 @@
     <string name="settings_mark_as_read_while_scrolling">Označite postove kao pročitane tijekom
         pomicanja
     </string>
+    <string name="action_quote">Citat…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hu/strings.xml
+++ b/resources/src/commonMain/resources/MR/hu/strings.xml
@@ -242,4 +242,5 @@
     <string name="settings_mark_as_read_while_scrolling">Bejegyzések megjelölése olvasottként
         görgetés közben
     </string>
+    <string name="action_quote">Idézet…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/it/strings.xml
+++ b/resources/src/commonMain/resources/MR/it/strings.xml
@@ -226,4 +226,5 @@
     <string name="settings_zombie_mode_scroll_amount">Ampiezza scroll modalità zombie</string>
     <string name="settings_mark_as_read_while_scrolling">Segna post come letti durante lo scroll
     </string>
+    <string name="action_quote">Cita…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lt/strings.xml
+++ b/resources/src/commonMain/resources/MR/lt/strings.xml
@@ -242,10 +242,11 @@
     <string name="settings_ui_font_scale">Vartotojo sąsajos teksto dydis</string>
     <string name="settings_ui_theme">Vartotojo sąsajos tema</string>
     <string name="settings_upvote_color">Atnaujinti spalvą</string>
-    <string name="settings_hide_navigation_bar">Slenkant slėpti naršymo juostą</string>
+    <string name="settings_hide_navigation_bar">Slinkdami slėpti naršymo juostą</string>
     <string name="settings_zombie_mode_interval">Zombių režimo intervalo trukmė</string>
     <string name="settings_zombie_mode_scroll_amount">Zombių režimo slinkties kiekis</string>
     <string name="settings_mark_as_read_while_scrolling">Slinkdami pažymėkite įrašus kaip
         skaitytus
     </string>
+    <string name="action_quote">Citata…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lv/strings.xml
+++ b/resources/src/commonMain/resources/MR/lv/strings.xml
@@ -240,10 +240,12 @@
     <string name="settings_ui_font_scale">Lietotāja interfeisa teksta lielums</string>
     <string name="settings_ui_theme">UI tēmas</string>
     <string name="settings_upvote_color">Upvote krāsa</string>
-    <string name="settings_hide_navigation_bar">Ritinot paslēpt navigācijas joslu</string>
+    <string name="settings_hide_navigation_bar">Ritinot paslēpt navigācijas ritināšanas laikā
+    </string>
     <string name="settings_zombie_mode_interval">Zombiju režīma intervāla ilgums</string>
     <string name="settings_zombie_mode_scroll_amount">Zombiju režīma ritināšanas apjoms</string>
     <string name="settings_mark_as_read_while_scrolling">Atzīmējiet ziņas kā izlasītas ritināšanas
         laikā
     </string>
+    <string name="action_quote">Citāts…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/nl/strings.xml
+++ b/resources/src/commonMain/resources/MR/nl/strings.xml
@@ -234,4 +234,5 @@
     <string name="settings_mark_as_read_while_scrolling">Markeer berichten als gelezen tijdens het
         scrollen
     </string>
+    <string name="action_quote">Citaat…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/no/strings.xml
+++ b/resources/src/commonMain/resources/MR/no/strings.xml
@@ -231,9 +231,10 @@
     <string name="settings_ui_font_scale">UI-tekststørrelse</string>
     <string name="settings_ui_theme">UI-tema</string>
     <string name="settings_upvote_color">Upvote-farge</string>
-    <string name="settings_hide_navigation_bar">Skjul navigasjonsfeltet når du ruller</string>
+    <string name="settings_hide_navigation_bar">Skjul navigasjonsfeltet mens du ruller</string>
     <string name="settings_zombie_mode_interval">Zombie-modus intervallvarighet</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie-modus rullebeløp</string>
     <string name="settings_mark_as_read_while_scrolling">Merk innlegg som lest mens du ruller
     </string>
+    <string name="action_quote">Sitat…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pl/strings.xml
+++ b/resources/src/commonMain/resources/MR/pl/strings.xml
@@ -225,4 +225,5 @@
     <string name="settings_mark_as_read_while_scrolling">Oznacz posty jako przeczytane podczas
         przewijania
     </string>
+    <string name="action_quote">Cytat…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pt/strings.xml
+++ b/resources/src/commonMain/resources/MR/pt/strings.xml
@@ -224,4 +224,5 @@
     <string name="settings_mark_as_read_while_scrolling">Marcar postagens como lidas durante ao
         rolar
     </string>
+    <string name="action_quote">Citar…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ro/strings.xml
+++ b/resources/src/commonMain/resources/MR/ro/strings.xml
@@ -224,4 +224,5 @@
     <string name="settings_zombie_mode_scroll_amount">Extensia de derulare modului zombie</string>
     <string name="settings_mark_as_read_while_scrolling">Marchează postările ca citite la derulare
     </string>
+    <string name="action_quote">Citează…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/se/strings.xml
+++ b/resources/src/commonMain/resources/MR/se/strings.xml
@@ -230,9 +230,10 @@
     <string name="settings_ui_font_scale">UI-textstorlek</string>
     <string name="settings_ui_theme">Användargränssnittstema</string>
     <string name="settings_upvote_color">Uppröstningsfärg</string>
-    <string name="settings_hide_navigation_bar">Dölj navigeringsfältet när du bläddrar</string>
+    <string name="settings_hide_navigation_bar">Dölj navigeringsfältet när du rullar</string>
     <string name="settings_zombie_mode_interval">Zombielägesintervallets varaktighet</string>
     <string name="settings_zombie_mode_scroll_amount">Zombieläge rullningsmängd</string>
     <string name="settings_mark_as_read_while_scrolling">Markera inlägg som lästa medan du rullar
     </string>
+    <string name="action_quote">Citat…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sk/strings.xml
+++ b/resources/src/commonMain/resources/MR/sk/strings.xml
@@ -230,10 +230,11 @@
     <string name="settings_ui_font_scale">Veľkosť textu používateľského rozhrania</string>
     <string name="settings_ui_theme">Téma používateľského rozhrania</string>
     <string name="settings_upvote_color">Upvote farba</string>
-    <string name="settings_hide_navigation_bar">Skryť navigačný panel pri posúvaní</string>
+    <string name="settings_hide_navigation_bar">Skryť navigačný panel pri rolovaní</string>
     <string name="settings_zombie_mode_interval">Trvanie intervalu režimu zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Množstvo posúvania v zombie režime</string>
     <string name="settings_mark_as_read_while_scrolling">Označte príspevky ako prečítané pri
         rolovaní
     </string>
+    <string name="action_quote">Citovať…</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sl/strings.xml
+++ b/resources/src/commonMain/resources/MR/sl/strings.xml
@@ -235,9 +235,10 @@
     <string name="settings_ui_font_scale">Velikost besedila uporabniškega vmesnika</string>
     <string name="settings_ui_theme">Tema uporabniškega vmesnika</string>
     <string name="settings_upvote_color">Barva za glasovanje navzgor</string>
-    <string name="settings_hide_navigation_bar">Med drsenjem skrij navigacijsko vrstico</string>
+    <string name="settings_hide_navigation_bar">Med pomikanjem skrij navigacijsko vrstico</string>
     <string name="settings_zombie_mode_interval">Trajanje intervala v zombi načinu</string>
     <string name="settings_zombie_mode_scroll_amount">Količina drsenja v zombi načinu</string>
     <string name="settings_mark_as_read_while_scrolling">Med pomikanjem označi objave kot prebrane
     </string>
+    <string name="action_quote">Kvota…</string>
 </resources>


### PR DESCRIPTION
With this PR it will be possible to select portions of text in the "See raw…" dialog and insert them as a Mardown quotation in a reply to the post (or the comment) that was opened in the raw conent dialog.