### PR TITLE
enhancement(app): reintroduce screen transitions

### DIFF
--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -121,6 +122,9 @@ class CommunityDetailScreen(
     private val community: CommunityModel,
     private val otherInstance: String = "",
 ) : Screen {
+
+    override val key: ScreenKey
+        get() = super.key + community.id.toString()
 
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -119,6 +120,9 @@ class PostDetailScreen(
     private val highlightCommentId: Int? = null,
     private val isMod: Boolean = false,
 ) : Screen {
+
+    override val key: ScreenKey
+        get() = super.key + post.id.toString()
 
     @OptIn(
         ExperimentalMaterial3Api::class,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -115,6 +116,9 @@ class UserDetailScreen(
     private val user: UserModel,
     private val otherInstance: String = "",
 ) : Screen {
+
+    override val key: ScreenKey
+        get() = super.key + user.id.toString()
 
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/App.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/App.kt
@@ -32,10 +32,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import cafe.adriel.voyager.navigator.CurrentScreen
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.bottomSheet.BottomSheetNavigator
 import cafe.adriel.voyager.navigator.tab.TabNavigator
+import cafe.adriel.voyager.transitions.SlideTransition
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiTheme
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toPostLayout
@@ -246,7 +246,8 @@ fun App() {
         ) {
             BottomSheetNavigator(
                 sheetShape = RoundedCornerShape(
-                    topStart = CornerSize.xl, topEnd = CornerSize.xl
+                    topStart = CornerSize.xl,
+                    topEnd = CornerSize.xl
                 ),
                 sheetBackgroundColor = MaterialTheme.colorScheme.background,
             ) { bottomNavigator ->
@@ -261,16 +262,19 @@ fun App() {
                         }
                     },
                 ) {
-                    Navigator(screen = MainScreen, onBackPressed = {
-                        val callback = navigationCoordinator.getCanGoBackCallback()
-                        callback?.let { it() } ?: true
-                    }) { navigator ->
+                    Navigator(
+                        screen = MainScreen,
+                        onBackPressed = {
+                            val callback = navigationCoordinator.getCanGoBackCallback()
+                            callback?.let { it() } ?: true
+                        },
+                    ) { navigator ->
                         LaunchedEffect(Unit) {
                             navigationCoordinator.setRootNavigator(navigator)
                         }
 
                         if (hasBeenInitialized) {
-                            CurrentScreen()
+                            SlideTransition(navigator)
                         } else {
                             Box(
                                 modifier = Modifier


### PR DESCRIPTION
This PR reintroduces the sliding transitions between screens that were removed due to an issue with opening related posts (cross-posts).
If custom unique keys are provided by content, two adjacent PostDetailScreen can now sit in the navigation stack with transitions, so it was possible to reintroduce them.