### PR TITLE
fix(api): improve Lemmy 0.19 compatibility

### DIFF
--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CommentAggregates.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CommentAggregates.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CommentAggregates(
-    @SerialName("id") val id: Int,
+    @SerialName("id") val id: Int? = null,
     @SerialName("comment_id") val commentId: CommentId,
     @SerialName("score") val score: Int,
     @SerialName("upvotes") val upvotes: Int,

--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CommunityAggregates.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CommunityAggregates.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CommunityAggregates(
-    @SerialName("id") val id: Int,
+    @SerialName("id") val id: Int? = null,
     @SerialName("community_id") val communityId: CommunityId,
     @SerialName("subscribers") val subscribers: Int,
     @SerialName("posts") val posts: Int,

--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/PersonAggregates.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/PersonAggregates.kt
@@ -5,10 +5,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PersonAggregates(
-    @SerialName("id") val id: Int,
+    @SerialName("id") val id: Int? = null,
     @SerialName("person_id") val personId: PersonId,
     @SerialName("post_count") val postCount: Int,
-    @SerialName("post_score") val postScore: Int,
+    @SerialName("post_score") val postScore: Int? = null,
     @SerialName("comment_count") val commentCount: Int,
-    @SerialName("comment_score") val commentScore: Int,
+    @SerialName("comment_score") val commentScore: Int? = null,
 )

--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/PostAggregates.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/PostAggregates.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PostAggregates(
-    @SerialName("id") val id: Int,
+    @SerialName("id") val id: Int? = null,
     @SerialName("post_id") val postId: PostId,
     @SerialName("comments") val comments: Int,
     @SerialName("score") val score: Int,

--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/SiteAggregates.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/SiteAggregates.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SiteAggregates(
-    @SerialName("id") val id: Int,
+    @SerialName("id") val id: Int? = null,
     @SerialName("site_id") val siteOd: SiteId,
     @SerialName("users") val users: Int,
     @SerialName("posts") val posts: Int,

--- a/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/SiteView.kt
+++ b/core-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/SiteView.kt
@@ -7,6 +7,6 @@ import kotlinx.serialization.Serializable
 data class SiteView(
     @SerialName("site") val site: Site,
     @SerialName("local_site") val localSite: LocalSite,
-    @SerialName("local_site_rate_limit") val localSiteRateLimit: LocalSiteRateLimit,
+    @SerialName("local_site_rate_limit") val localSiteRateLimit: LocalSiteRateLimit?,
     @SerialName("counts") val counts: SiteAggregates,
 )

--- a/domain-lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
+++ b/domain-lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
@@ -99,8 +99,8 @@ internal fun Person.toModel() = UserModel(
 internal fun PersonView.toModel() = person.toModel()
 
 internal fun PersonAggregates.toModel() = UserScoreModel(
-    postScore = postScore,
-    commentScore = commentScore,
+    postScore = postScore ?: 0,
+    commentScore = commentScore ?: 0,
 )
 
 internal fun PostView.toModel() = PostModel(

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListViewModel.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListViewModel.kt
@@ -60,8 +60,9 @@ class PostListViewModel(
                     it.copy(instance = instance)
                 }
             }.launchIn(this)
-            apiConfigRepository.instance.drop(1).onEach { instance ->
+            apiConfigRepository.instance.drop(1).onEach { _ ->
                 refresh()
+                mvi.emitEffect(PostListMviModel.Effect.BackToTop)
             }.launchIn(this)
 
             identityRepository.authToken.map { !it.isNullOrEmpty() }.onEach { isLogged ->


### PR DESCRIPTION
This PR solves some issues reported with Lemmy 0.19 instances.

The migration has already been done in #57 more than a month ago theoretically, but some fields have become optional  in the meantime (e.g. the `id` field in `PostAggregates`, `CommunityAggregates`, `CommentAggregates`, `SiteAggregates`) breaking the compatibility.

I'm waiting to see what other things the API developers broke (if any) before merging this 🤣🤣🤣