### PR TITLE
feat: add GIF support

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     implementation(libs.androidx.splashscreen)
     implementation(libs.koin.core)
     implementation(libs.koin.android)
+    implementation(libs.coil)
+    implementation(libs.coil.gif)
 
     implementation(projects.shared)
     implementation(projects.coreUtils)

--- a/androidApp/src/main/java/com/github/diegoberaldin/raccoonforlemmy/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/github/diegoberaldin/raccoonforlemmy/android/MainApplication.kt
@@ -1,6 +1,11 @@
 package com.github.diegoberaldin.raccoonforlemmy.android
 
 import android.app.Application
+import android.os.Build
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.AppInfo
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.CrashReportConfiguration
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.CrashReportWriter
@@ -10,7 +15,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 
-class MainApplication : Application() {
+class MainApplication : Application(), ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
 
@@ -42,5 +47,16 @@ class MainApplication : Application() {
                 }
             }
         }
+    }
+
+    override fun newImageLoader(): ImageLoader {
+        return ImageLoader.Builder(this)
+            .components {
+                if (Build.VERSION.SDK_INT >= 28) {
+                    add(ImageDecoderDecoder.Factory())
+                } else {
+                    add(GifDecoder.Factory())
+                }
+            }.build()
     }
 }

--- a/core-md/build.gradle.kts
+++ b/core-md/build.gradle.kts
@@ -32,9 +32,10 @@ kotlin {
                 implementation(libs.markwon.strikethrough)
                 implementation(libs.markwon.tables)
                 implementation(libs.markwon.html)
-                implementation(libs.markwon.coil)
+                implementation(libs.markwon.image)
                 implementation(libs.markwon.linkify)
-                implementation(libs.coil)
+
+                implementation(libs.android.gif.drawable)
             }
         }
         val commonMain by getting {

--- a/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/DefaultMarkwonProvider.kt
+++ b/core-md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/DefaultMarkwonProvider.kt
@@ -11,7 +11,8 @@ import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.html.HtmlPlugin
-import io.noties.markwon.image.coil.CoilImagesPlugin
+import io.noties.markwon.image.ImagesPlugin
+import io.noties.markwon.image.gif.GifMediaDecoder
 import io.noties.markwon.linkify.LinkifyPlugin
 
 class DefaultMarkwonProvider(
@@ -29,7 +30,15 @@ class DefaultMarkwonProvider(
             .usePlugin(StrikethroughPlugin.create())
             .usePlugin(TablePlugin.create(context))
             .usePlugin(HtmlPlugin.create())
-            .usePlugin(CoilImagesPlugin.create(context))
+            .usePlugin(
+                ImagesPlugin.create(
+                    object : ImagesPlugin.ImagesConfigure {
+                        override fun configureImages(plugin: ImagesPlugin) {
+                            plugin.addMediaDecoder(GifMediaDecoder.create(true))
+                        }
+                    },
+                ),
+            )
             .usePlugin(MarkwonSpoilerPlugin.create(true))
             .usePlugin(
                 ClickableImagesPlugin.create(
@@ -47,7 +56,7 @@ class DefaultMarkwonProvider(
                             onOpenUrl?.invoke(link)
                         }
                     }
-                }
+                },
             )
             .build()
     }

--- a/core-utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/StringUtils.kt
+++ b/core-utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/StringUtils.kt
@@ -7,6 +7,6 @@ expect object StringUtils {
 
 val String.looksLikeAnImage: Boolean
     get() {
-        val imageExtensions = listOf(".jpeg", ".jpg", ".png", ".webp")
+        val imageExtensions = listOf(".jpeg", ".jpg", ".png", ".webp", ".gif")
         return imageExtensions.any { this.endsWith(it) }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 androidx_activity = "1.8.1"
 androidx_crypto = "1.0.0"
 androidx_splashscreen = "1.0.1"
+android_gif_drawable = "1.2.28"
 android_gradle = "8.1.4"
 coil = "2.5.0"
 compose = "1.5.11"
@@ -42,6 +43,8 @@ androidx_splashscreen = { module = "androidx.core:core-splashscreen", version.re
 kamel = { module = "media.kamel:kamel-image", version.ref = "kamel" }
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil_compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil_gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
+android_gif_drawable = { module = "pl.droidsonroids.gif:android-gif-drawable", version.ref = "android.gif.drawable" }
 
 firebase_crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "crashlytics" }
 crashkios = { module = "co.touchlab.crashkios:crashlytics", version.ref = "crashkios" }
@@ -51,8 +54,8 @@ markwon_core = { module = "io.noties.markwon:core", version.ref = "markwon" }
 markwon_strikethrough = { module = "io.noties.markwon:ext-strikethrough", version.ref = "markwon" }
 markwon_tables = { module = "io.noties.markwon:ext-tables", version.ref = "markwon" }
 markwon_html = { module = "io.noties.markwon:html", version.ref = "markwon" }
-markwon_coil = { module = "io.noties.markwon:image-coil", version.ref = "markwon" }
 markwon_linkify = { module = "io.noties.markwon:linkify", version.ref = "markwon" }
+markwon_image = { module = "io.noties.markwon:image", version.ref = "markwon" }
 
 multiplatform_settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform.settings" }
 


### PR DESCRIPTION
As per title, this PR adds the support for GIF files both in post cards and when embedded in markdown text, such as custom emojis.

This required changing the coil images plugin for Markwon because it didn't support adding the GIF decoder to the Image Loader.