### PR TITLE
feat: multiple vote formats

### DIFF
--- a/core-appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/data/VoteFormat.kt
+++ b/core-appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/data/VoteFormat.kt
@@ -1,0 +1,107 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.appearance.data
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import com.github.diegoberaldin.raccoonforlemmy.resources.MR
+import dev.icerock.moko.resources.compose.stringResource
+
+sealed interface VoteFormat {
+    data object Aggregated : VoteFormat
+    data object Separated : VoteFormat
+    data object Percentage : VoteFormat
+}
+
+fun VoteFormat.toLong(): Long = when (this) {
+    VoteFormat.Percentage -> 2L
+    VoteFormat.Separated -> 1L
+    VoteFormat.Aggregated -> 0L
+}
+
+fun Long.toVoteFormat(): VoteFormat = when (this) {
+    2L -> VoteFormat.Percentage
+    1L -> VoteFormat.Separated
+    else -> VoteFormat.Aggregated
+}
+
+@Composable
+fun VoteFormat.toReadableName(): String = when (this) {
+    VoteFormat.Aggregated -> stringResource(MR.strings.settings_vote_format_aggregated)
+    VoteFormat.Percentage -> stringResource(MR.strings.settings_vote_format_percentage)
+    VoteFormat.Separated -> stringResource(MR.strings.settings_vote_format_separated)
+}
+
+fun formatToReadableValue(
+    voteFormat: VoteFormat,
+    score: Int,
+    upvotes: Int,
+    downvotes: Int,
+    upvoteColor: Color,
+    downvoteColor: Color,
+    upVoted: Boolean = false,
+    downVoted: Boolean = false,
+): AnnotatedString = buildAnnotatedString {
+    when (voteFormat) {
+        VoteFormat.Percentage -> {
+            val totalVotes = upvotes + downvotes
+            val percVote = if (totalVotes == 0) 0.0 else upvotes.toDouble() / totalVotes
+            val text = "${(percVote * 100).toInt()} %"
+            append(text)
+            if (upVoted) {
+                addStyle(
+                    style = SpanStyle(color = upvoteColor),
+                    start = 0,
+                    end = text.length
+                )
+            } else if (downVoted) {
+                addStyle(
+                    style = SpanStyle(color = downvoteColor),
+                    start = 0,
+                    end = length
+                )
+            }
+        }
+
+        VoteFormat.Separated -> {
+            val upvoteText = upvotes.toString()
+            append(upvoteText)
+            if (upVoted) {
+                addStyle(
+                    style = SpanStyle(color = upvoteColor),
+                    start = 0,
+                    end = upvoteText.length
+                )
+            }
+            append(" / ")
+            val downvoteText = downvotes.toString()
+            append(downvoteText)
+            if (downVoted) {
+                addStyle(
+                    style = SpanStyle(color = downvoteColor),
+                    start = upvoteText.length + 3,
+                    end = upvoteText.length + 3 + downvoteText.length
+                )
+            }
+        }
+
+        else -> {
+            val text = score.toString()
+            append(text)
+            if (upVoted) {
+                addStyle(
+                    style = SpanStyle(color = upvoteColor),
+                    start = 0,
+                    end = text.length
+                )
+            } else if (downVoted) {
+                addStyle(
+                    style = SpanStyle(color = downvoteColor),
+                    start = 0,
+                    end = length
+                )
+            }
+        }
+    }
+}

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.communitydetail
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -53,7 +54,7 @@ interface CommunityDetailMviModel :
         val doubleTapActionEnabled: Boolean = false,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
         val zombieModeActive: Boolean = false,
         val moderators: List<UserModel> = emptyList(),

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailScreen.kt
@@ -556,7 +556,7 @@ class CommunityDetailScreen(
                                         isFromModerator = uiState.moderators.containsId(post.creator?.id),
                                         postLayout = uiState.postLayout,
                                         fullHeightImage = uiState.fullHeightImages,
-                                        separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                        voteFormat = uiState.voteFormat,
                                         autoLoadImages = uiState.autoLoadImages,
                                         blurNsfw = when {
                                             uiState.community.nsfw -> false

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/communitydetail/CommunityDetailViewModel.kt
@@ -72,7 +72,7 @@ class CommunityDetailViewModel(
                         doubleTapActionEnabled = settings.enableDoubleTapAction,
                         sortType = settings.defaultPostSortType.toSortType(),
                         fullHeightImages = settings.fullHeightImages,
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                     )
                 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/CollapsedCommentCard.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/CollapsedCommentCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -29,7 +30,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommentR
 fun CollapsedCommentCard(
     comment: CommentModel,
     modifier: Modifier = Modifier,
-    separateUpAndDownVotes: Boolean = false,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     autoLoadImages: Boolean = true,
     options: List<Option> = emptyList(),
     onOpenCreator: ((UserModel) -> Unit)? = null,
@@ -81,7 +82,7 @@ fun CollapsedCommentCard(
                 PostCardFooter(
                     modifier = Modifier.padding(top = Spacing.xs),
                     score = comment.score,
-                    separateUpAndDownVotes = separateUpAndDownVotes,
+                    voteFormat = voteFormat,
                     upvotes = comment.upvotes,
                     downvotes = comment.downvotes,
                     saved = comment.saved,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/CommentCard.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/CommentCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -34,7 +35,7 @@ private const val INDENT_AMOUNT = 3
 fun CommentCard(
     comment: CommentModel,
     modifier: Modifier = Modifier,
-    separateUpAndDownVotes: Boolean = false,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     hideAuthor: Boolean = false,
     hideCommunity: Boolean = true,
     hideIndent: Boolean = false,
@@ -104,7 +105,7 @@ fun CommentCard(
                 PostCardFooter(
                     modifier = Modifier.padding(top = Spacing.xs),
                     score = comment.score,
-                    separateUpAndDownVotes = separateUpAndDownVotes,
+                    voteFormat = voteFormat,
                     upvotes = comment.upvotes,
                     downvotes = comment.downvotes,
                     saved = comment.saved,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/InboxCard.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/InboxCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
@@ -32,7 +33,7 @@ fun InboxCard(
     mention: PersonMentionModel,
     type: InboxCardType,
     autoLoadImages: Boolean = true,
-    separateUpAndDownVotes: Boolean = true,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     postLayout: PostLayout = PostLayout.Card,
     options: List<Option> = emptyList(),
     onOpenPost: (PostModel) -> Unit,
@@ -91,7 +92,7 @@ fun InboxCard(
                 score = mention.score,
                 upvotes = mention.upvotes,
                 downvotes = mention.downvotes,
-                separateUpAndDownVotes = separateUpAndDownVotes,
+                voteFormat = voteFormat,
                 upVoted = mention.myVote > 0,
                 downVoted = mention.myVote < 0,
                 options = options,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/InboxReplySubtitle.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/InboxReplySubtitle.kt
@@ -32,12 +32,12 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.formatToReadableValue
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -60,7 +60,7 @@ fun InboxReplySubtitle(
     upvotes: Int = 0,
     downvotes: Int = 0,
     options: List<Option> = emptyList(),
-    separateUpAndDownVotes: Boolean = false,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     upVoted: Boolean = false,
     downVoted: Boolean = false,
     onOpenCommunity: ((CommunityModel) -> Unit)? = null,
@@ -225,49 +225,16 @@ fun InboxReplySubtitle(
                     ),
                 )
                 Text(
-                    text = buildAnnotatedString {
-                        if (separateUpAndDownVotes) {
-                            val upvoteText = upvotes.toString()
-                            append(upvoteText)
-                            if (upVoted) {
-                                addStyle(
-                                    style = SpanStyle(color = upvoteColor ?: defaultUpvoteColor),
-                                    start = 0,
-                                    end = upvoteText.length
-                                )
-                            }
-                            append(" / ")
-                            val downvoteText = downvotes.toString()
-                            append(downvoteText)
-                            if (downVoted) {
-                                addStyle(
-                                    style = SpanStyle(
-                                        color = downvoteColor ?: defaultDownVoteColor
-                                    ),
-                                    start = upvoteText.length + 3,
-                                    end = upvoteText.length + 3 + downvoteText.length
-                                )
-                            }
-                        } else {
-                            val text = score.toString()
-                            append(text)
-                            if (upVoted) {
-                                addStyle(
-                                    style = SpanStyle(color = upvoteColor ?: defaultUpvoteColor),
-                                    start = 0,
-                                    end = text.length
-                                )
-                            } else if (downVoted) {
-                                addStyle(
-                                    style = SpanStyle(
-                                        color = downvoteColor ?: defaultDownVoteColor
-                                    ),
-                                    start = 0,
-                                    end = length
-                                )
-                            }
-                        }
-                    },
+                    text = formatToReadableValue(
+                        voteFormat = voteFormat,
+                        score = score,
+                        upvotes = upvotes,
+                        downvotes = downvotes,
+                        upvoteColor = upvoteColor ?: defaultUpvoteColor,
+                        downvoteColor = downvoteColor ?: defaultDownVoteColor,
+                        upVoted = upVoted,
+                        downVoted = downVoted,
+                    ),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onBackground,
                 )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/PostCard.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/PostCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getNavigationCoordinator
@@ -52,7 +53,7 @@ fun PostCard(
     autoLoadImages: Boolean = true,
     hideAuthor: Boolean = false,
     postLayout: PostLayout = PostLayout.Card,
-    separateUpAndDownVotes: Boolean = false,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     includeFullBody: Boolean = false,
     fullHeightImage: Boolean = true,
     limitBodyHeight: Boolean = false,
@@ -95,7 +96,7 @@ fun PostCard(
                 },
                 showBody = includeFullBody || postLayout == PostLayout.Full,
                 limitBodyHeight = limitBodyHeight,
-                separateUpAndDownVotes = separateUpAndDownVotes,
+                voteFormat = voteFormat,
                 autoLoadImages = autoLoadImages,
                 roundedCornerImage = postLayout == PostLayout.Card,
                 fullHeightImage = fullHeightImage,
@@ -118,7 +119,7 @@ fun PostCard(
                 isFromModerator = isFromModerator,
                 hideAuthor = hideAuthor,
                 blurNsfw = blurNsfw,
-                separateUpAndDownVotes = separateUpAndDownVotes,
+                voteFormat = voteFormat,
                 autoLoadImages = autoLoadImages,
                 options = options,
                 onOpenCommunity = onOpenCommunity,
@@ -144,7 +145,7 @@ private fun CompactPost(
     autoLoadImages: Boolean = true,
     hideAuthor: Boolean,
     blurNsfw: Boolean,
-    separateUpAndDownVotes: Boolean,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     options: List<Option> = emptyList(),
     onOpenCommunity: ((CommunityModel) -> Unit)? = null,
     onOpenCreator: ((UserModel) -> Unit)? = null,
@@ -204,7 +205,7 @@ private fun CompactPost(
         }
         PostCardFooter(
             comments = post.comments,
-            separateUpAndDownVotes = separateUpAndDownVotes,
+            voteFormat = voteFormat,
             score = post.score,
             upvotes = post.upvotes,
             downvotes = post.downvotes,
@@ -230,7 +231,7 @@ private fun ExtendedPost(
     autoLoadImages: Boolean = true,
     hideAuthor: Boolean = false,
     blurNsfw: Boolean = true,
-    separateUpAndDownVotes: Boolean = false,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     showBody: Boolean = false,
     limitBodyHeight: Boolean = false,
     fullHeightImage: Boolean = true,
@@ -361,7 +362,7 @@ private fun ExtendedPost(
         PostCardFooter(
             modifier = Modifier.padding(top = Spacing.xs),
             comments = post.comments,
-            separateUpAndDownVotes = separateUpAndDownVotes,
+            voteFormat = voteFormat,
             score = post.score,
             upvotes = post.upvotes,
             downvotes = post.downvotes,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/PostCardFooter.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/PostCardFooter.kt
@@ -30,10 +30,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.formatToReadableValue
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -45,7 +45,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 @Composable
 fun PostCardFooter(
     modifier: Modifier = Modifier,
-    separateUpAndDownVotes: Boolean = false,
+    voteFormat: VoteFormat = VoteFormat.Aggregated,
     comments: Int? = null,
     date: String? = null,
     score: Int = 0,
@@ -162,45 +162,16 @@ fun PostCardFooter(
                 ),
             )
             Text(
-                text = buildAnnotatedString {
-                    if (separateUpAndDownVotes) {
-                        val upvoteText = upvotes.toString()
-                        append(upvoteText)
-                        if (upVoted) {
-                            addStyle(
-                                style = SpanStyle(color = upvoteColor ?: defaultUpvoteColor),
-                                start = 0,
-                                end = upvoteText.length
-                            )
-                        }
-                        append(" / ")
-                        val downvoteText = downvotes.toString()
-                        append(downvoteText)
-                        if (downVoted) {
-                            addStyle(
-                                style = SpanStyle(color = downvoteColor ?: defaultDownVoteColor),
-                                start = upvoteText.length + 3,
-                                end = upvoteText.length + 3 + downvoteText.length
-                            )
-                        }
-                    } else {
-                        val text = score.toString()
-                        append(text)
-                        if (upVoted) {
-                            addStyle(
-                                style = SpanStyle(color = upvoteColor ?: defaultUpvoteColor),
-                                start = 0,
-                                end = text.length
-                            )
-                        } else if (downVoted) {
-                            addStyle(
-                                style = SpanStyle(color = downvoteColor ?: defaultDownVoteColor),
-                                start = 0,
-                                end = length
-                            )
-                        }
-                    }
-                },
+                text = formatToReadableValue(
+                    voteFormat = voteFormat,
+                    score = score,
+                    upvotes = upvotes,
+                    downvotes = downvotes,
+                    upvoteColor = upvoteColor ?: defaultUpvoteColor,
+                    downvoteColor = downvoteColor ?: defaultDownVoteColor,
+                    upVoted = upVoted,
+                    downVoted = downVoted,
+                ),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onBackground,
             )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.createcomment
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.createpost.CreatePostSection
 import dev.icerock.moko.resources.desc.StringDesc
@@ -35,7 +36,7 @@ interface CreateCommentMviModel :
     data class UiState(
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val textError: StringDesc? = null,
         val loading: Boolean = false,
         val section: CreatePostSection = CreatePostSection.Edit,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentScreen.kt
@@ -286,7 +286,7 @@ class CreateCommentScreen(
                                 modifier = referenceModifier,
                                 comment = originalComment,
                                 hideIndent = true,
-                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                voteFormat = uiState.voteFormat,
                                 autoLoadImages = uiState.autoLoadImages,
                                 options = buildList {
                                     add(
@@ -313,7 +313,7 @@ class CreateCommentScreen(
                                 post = originalPost,
                                 limitBodyHeight = true,
                                 blurNsfw = false,
-                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                voteFormat = uiState.voteFormat,
                                 autoLoadImages = uiState.autoLoadImages,
                                 options = buildList {
                                     add(

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createcomment/CreateCommentViewModel.kt
@@ -40,7 +40,7 @@ class CreateCommentViewModel(
             settingsRepository.currentSettings.onEach { settings ->
                 mvi.updateState {
                     it.copy(
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createpost/CreatePostMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createpost/CreatePostMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.createpost
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import dev.icerock.moko.resources.desc.StringDesc
@@ -65,7 +66,7 @@ interface CreatePostMviModel :
         val section: CreatePostSection = CreatePostSection.Edit,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
     )
 

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createpost/CreatePostScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createpost/CreatePostScreen.kt
@@ -458,7 +458,7 @@ class CreatePostScreen(
                         postLayout = uiState.postLayout,
                         fullHeightImage = uiState.fullHeightImages,
                         includeFullBody = true,
-                        separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                        voteFormat = uiState.voteFormat,
                         autoLoadImages = uiState.autoLoadImages,
                     )
                 }

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createpost/CreatePostViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/createpost/CreatePostViewModel.kt
@@ -35,7 +35,7 @@ class CreatePostViewModel(
             settingsRepository.currentSettings.onEach { settings ->
                 mvi.updateState {
                     it.copy(
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/VoteFormatBottomSheet.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/VoteFormatBottomSheet.kt
@@ -1,0 +1,89 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import cafe.adriel.voyager.core.screen.Screen
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toReadableName
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.BottomSheetHandle
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
+import com.github.diegoberaldin.raccoonforlemmy.resources.MR
+import dev.icerock.moko.resources.compose.stringResource
+
+class VoteFormatBottomSheet : Screen {
+
+    @Composable
+    override fun Content() {
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val notificationCenter = remember { getNotificationCenter() }
+
+        Column(
+            modifier = Modifier.padding(
+                top = Spacing.s,
+                start = Spacing.s,
+                end = Spacing.s,
+                bottom = Spacing.m,
+            ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                BottomSheetHandle()
+                Text(
+                    modifier = Modifier.padding(start = Spacing.s, top = Spacing.s),
+                    text = stringResource(MR.strings.settings_vote_format),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                val values = listOf(
+                    VoteFormat.Aggregated,
+                    VoteFormat.Separated,
+                    VoteFormat.Percentage,
+                )
+                Column(
+                    modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xxxs),
+                ) {
+                    for (value in values) {
+                        Row(
+                            modifier = Modifier.padding(
+                                horizontal = Spacing.s,
+                                vertical = Spacing.m,
+                            ).fillMaxWidth().onClick(
+                                onClick = rememberCallback {
+                                    notificationCenter.send(
+                                        NotificationCenterEvent.ChangeVoteFormat(value)
+                                    )
+                                    navigationCoordinator.hideBottomSheet()
+                                },
+                            ),
+                        ) {
+                            Text(
+                                text = value.toReadableName(),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.postdetail
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -52,7 +53,7 @@ interface PostDetailMviModel :
         val doubleTapActionEnabled: Boolean = true,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
         val moderators: List<UserModel> = emptyList(),
     )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailScreen.kt
@@ -321,7 +321,7 @@ class PostDetailScreen(
                                 postLayout = uiState.postLayout,
                                 fullHeightImage = uiState.fullHeightImages,
                                 includeFullBody = true,
-                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                voteFormat = uiState.voteFormat,
                                 autoLoadImages = uiState.autoLoadImages,
                                 blurNsfw = false,
                                 onOpenCommunity = rememberCallbackArgs { community ->
@@ -655,7 +655,7 @@ class PostDetailScreen(
                                                             }
                                                         },
                                                     comment = comment,
-                                                    separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                                    voteFormat = uiState.voteFormat,
                                                     autoLoadImages = uiState.autoLoadImages,
                                                     onToggleExpanded = rememberCallback(model) {
                                                         model.reduce(

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/postdetail/PostDetailViewModel.kt
@@ -83,7 +83,7 @@ class PostDetailViewModel(
                         swipeActionsEnabled = settings.enableSwipeActions,
                         doubleTapActionEnabled = settings.enableDoubleTapAction,
                         sortType = settings.defaultCommentSortType.toSortType(),
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.saveditems
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -40,7 +41,7 @@ interface SavedItemsMviModel :
         val comments: List<CommentModel> = emptyList(),
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
     )
 

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsScreen.kt
@@ -236,7 +236,7 @@ class SavedItemsScreen : Screen {
                                     post = post,
                                     postLayout = uiState.postLayout,
                                     fullHeightImage = uiState.fullHeightImages,
-                                    separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                    voteFormat = uiState.voteFormat,
                                     autoLoadImages = uiState.autoLoadImages,
                                     blurNsfw = uiState.blurNsfw,
                                     onClick = {
@@ -358,7 +358,7 @@ class SavedItemsScreen : Screen {
                             items(uiState.comments) { comment ->
                                 CommentCard(
                                     comment = comment,
-                                    separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                    voteFormat = uiState.voteFormat,
                                     autoLoadImages = uiState.autoLoadImages,
                                     hideIndent = true,
                                     onClick = {

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/saveditems/SavedItemsViewModel.kt
@@ -48,7 +48,7 @@ class SavedItemsViewModel(
             settingsRepository.currentSettings.onEach { settings ->
                 mvi.updateState {
                     it.copy(
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailMviModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.userdetail
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -49,7 +50,7 @@ interface UserDetailMviModel :
         val doubleTapActionEnabled: Boolean = true,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
     )
 

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailScreen.kt
@@ -458,7 +458,7 @@ class UserDetailScreen(
                                         postLayout = uiState.postLayout,
                                         fullHeightImage = uiState.fullHeightImages,
                                         blurNsfw = uiState.blurNsfw,
-                                        separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                        voteFormat = uiState.voteFormat,
                                         autoLoadImages = uiState.autoLoadImages,
                                         onClick = rememberCallback {
                                             navigationCoordinator.pushScreen(
@@ -669,7 +669,7 @@ class UserDetailScreen(
                                     CommentCard(
                                         modifier = Modifier.background(MaterialTheme.colorScheme.background),
                                         comment = comment,
-                                        separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                        voteFormat = uiState.voteFormat,
                                         autoLoadImages = uiState.autoLoadImages,
                                         hideCommunity = false,
                                         hideAuthor = true,

--- a/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailViewModel.kt
+++ b/core-commonui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/userdetail/UserDetailViewModel.kt
@@ -69,7 +69,7 @@ class UserDetailViewModel(
                         swipeActionsEnabled = settings.enableSwipeActions,
                         doubleTapActionEnabled = settings.enableDoubleTapAction,
                         sortType = settings.defaultPostSortType.toSortType(),
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/core-notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core-notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiFontFamily
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiTheme
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.MultiCommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
@@ -31,6 +32,7 @@ sealed interface NotificationCenterEvent {
     data class ChangeZombieInterval(val value: Duration) : NotificationCenterEvent
     data class ChangeLanguage(val value: String) : NotificationCenterEvent
     data class ChangePostLayout(val value: PostLayout) : NotificationCenterEvent
+    data class ChangeVoteFormat(val value: VoteFormat) : NotificationCenterEvent
     data object Logout : NotificationCenterEvent
     data object PostCreated : NotificationCenterEvent
     data object CommentCreated : NotificationCenterEvent

--- a/core-persistence/build.gradle.kts
+++ b/core-persistence/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
 
                 implementation(libs.koin.core)
 
+                implementation(projects.coreAppearance)
                 implementation(projects.corePreferences)
                 implementation(projects.coreUtils)
             }

--- a/core-persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
+++ b/core-persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
@@ -1,5 +1,6 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.persistence.data
 
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.JavaSerializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -27,7 +28,7 @@ data class SettingsModel(
     val downvoteColor: Int? = null,
     val postLayout: Int = 0,
     val fullHeightImages: Boolean = true,
-    val separateUpAndDownVotes: Boolean = false,
+    val voteFormat: VoteFormat = VoteFormat.Aggregated,
     val autoLoadImages: Boolean = true,
     val autoExpandComments: Boolean = true,
     val hideNavigationBarWhileScrolling: Boolean = true,

--- a/core-persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core-persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -1,5 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository
 
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toLong
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toVoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.DatabaseProvider
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.GetBy
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.SettingsModel
@@ -72,7 +74,7 @@ internal class DefaultSettingsRepository(
                 customSeedColor = settings.customSeedColor?.toLong(),
                 account_id = accountId,
                 postLayout = settings.postLayout.toLong(),
-                separateUpAndDownVotes = if (settings.separateUpAndDownVotes) 1 else 0,
+                separateUpAndDownVotes = settings.voteFormat.toLong(),
                 autoLoadImages = if (settings.autoLoadImages) 1 else 0,
                 autoExpandComments = if (settings.autoExpandComments) 1 else 0,
                 fullHeightImages = if (settings.fullHeightImages) 1 else 0,
@@ -110,7 +112,7 @@ internal class DefaultSettingsRepository(
                     enableDoubleTapAction = keyStore[KeyStoreKeys.EnableDoubleTapAction, false],
                     customSeedColor = if (!keyStore.containsKey(KeyStoreKeys.CustomSeedColor)) null else keyStore[KeyStoreKeys.CustomSeedColor, 0],
                     postLayout = keyStore[KeyStoreKeys.PostLayout, 0],
-                    separateUpAndDownVotes = keyStore[KeyStoreKeys.SeparateUpAndDownVotes, false],
+                    voteFormat = keyStore[KeyStoreKeys.SeparateUpAndDownVotes, 0L].toVoteFormat(),
                     autoLoadImages = keyStore[KeyStoreKeys.AutoLoadImages, true],
                     autoExpandComments = keyStore[KeyStoreKeys.AutoExpandComments, true],
                     fullHeightImages = keyStore[KeyStoreKeys.FullHeightImages, true],
@@ -165,7 +167,7 @@ internal class DefaultSettingsRepository(
                     keyStore.remove(KeyStoreKeys.CustomSeedColor)
                 }
                 keyStore.save(KeyStoreKeys.PostLayout, settings.postLayout)
-                keyStore.save(KeyStoreKeys.SeparateUpAndDownVotes, settings.separateUpAndDownVotes)
+                keyStore.save(KeyStoreKeys.SeparateUpAndDownVotes, settings.voteFormat.toLong())
                 keyStore.save(KeyStoreKeys.AutoLoadImages, settings.autoLoadImages)
                 keyStore.save(KeyStoreKeys.AutoExpandComments, settings.autoExpandComments)
                 keyStore.save(KeyStoreKeys.FullHeightImages, settings.fullHeightImages)
@@ -215,7 +217,7 @@ internal class DefaultSettingsRepository(
                     enableDoubleTapAction = if (settings.enableDoubleTapAction) 1L else 0L,
                     customSeedColor = settings.customSeedColor?.toLong(),
                     postLayout = settings.postLayout.toLong(),
-                    separateUpAndDownVotes = if (settings.separateUpAndDownVotes) 1L else 0L,
+                    separateUpAndDownVotes = settings.voteFormat.toLong(),
                     autoLoadImages = if (settings.autoLoadImages) 1L else 0L,
                     autoExpandComments = if (settings.autoExpandComments) 1L else 0L,
                     fullHeightImages = if (settings.fullHeightImages) 1L else 0L,
@@ -255,7 +257,7 @@ private fun GetBy.toModel() = SettingsModel(
     enableDoubleTapAction = enableDoubleTapAction != 0L,
     customSeedColor = customSeedColor?.toInt(),
     postLayout = postLayout.toInt(),
-    separateUpAndDownVotes = separateUpAndDownVotes != 0L,
+    voteFormat = separateUpAndDownVotes.toVoteFormat(),
     autoLoadImages = autoLoadImages != 0L,
     autoExpandComments = autoExpandComments != 0L,
     fullHeightImages = fullHeightImages != 0L,

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListMviModel.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.home.postlist
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -47,7 +48,7 @@ interface PostListMviModel :
         val doubleTapActionEnabled: Boolean = false,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
         val zombieModeActive: Boolean = false,
     )

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListScreen.kt
@@ -357,7 +357,7 @@ class PostListScreen : Screen {
                                         post = post,
                                         postLayout = uiState.postLayout,
                                         fullHeightImage = uiState.fullHeightImages,
-                                        separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                        voteFormat = uiState.voteFormat,
                                         autoLoadImages = uiState.autoLoadImages,
                                         blurNsfw = uiState.blurNsfw,
                                         onClick = rememberCallback(model) {

--- a/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListViewModel.kt
+++ b/feature-home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/postlist/PostListViewModel.kt
@@ -81,7 +81,7 @@ class PostListViewModel(
                         blurNsfw = settings.blurNsfw,
                         swipeActionsEnabled = settings.enableSwipeActions,
                         doubleTapActionEnabled = settings.enableDoubleTapAction,
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsMviModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.inbox.mentions
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PersonMentionModel
 
@@ -30,7 +31,7 @@ interface InboxMentionsMviModel :
         val swipeActionsEnabled: Boolean = true,
         val postLayout: PostLayout = PostLayout.Card,
         val autoLoadImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = true,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
     )
 
     sealed interface Effect {

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsScreen.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsScreen.kt
@@ -179,7 +179,7 @@ class InboxMentionsScreen : Tab {
                                 postLayout = uiState.postLayout,
                                 type = InboxCardType.Mention,
                                 autoLoadImages = uiState.autoLoadImages,
-                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                voteFormat = uiState.voteFormat,
                                 onOpenPost = rememberCallbackArgs { post ->
                                     navigationCoordinator.pushScreen(
                                         PostDetailScreen(

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsViewModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/mentions/InboxMentionsViewModel.kt
@@ -59,7 +59,7 @@ class InboxMentionsViewModel(
                     it.copy(
                         swipeActionsEnabled = settings.enableSwipeActions,
                         autoLoadImages = settings.autoLoadImages,
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                     )
                 }
             }.launchIn(this)

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesMviModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.inbox.replies
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PersonMentionModel
 
@@ -30,7 +31,7 @@ interface InboxRepliesMviModel :
         val postLayout: PostLayout = PostLayout.Card,
         val swipeActionsEnabled: Boolean = true,
         val autoLoadImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = true,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
     )
 
     sealed interface Effect {

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesScreen.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesScreen.kt
@@ -178,7 +178,7 @@ class InboxRepliesScreen : Tab {
                                 postLayout = uiState.postLayout,
                                 type = InboxCardType.Reply,
                                 autoLoadImages = uiState.autoLoadImages,
-                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                voteFormat = uiState.voteFormat,
                                 onOpenPost = rememberCallbackArgs { post ->
                                     navigationCoordinator.pushScreen(
                                         PostDetailScreen(

--- a/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesViewModel.kt
+++ b/feature-inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/inbox/replies/InboxRepliesViewModel.kt
@@ -62,7 +62,7 @@ class InboxRepliesViewModel(
                     it.copy(
                         swipeActionsEnabled = settings.enableSwipeActions,
                         autoLoadImages = settings.autoLoadImages,
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                     )
                 }
             }.launchIn(this)

--- a/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedMviModel.kt
+++ b/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedMviModel.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.profile.logged
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -38,7 +39,7 @@ interface ProfileLoggedMviModel :
         val comments: List<CommentModel> = emptyList(),
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
     )
 

--- a/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedScreen.kt
+++ b/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedScreen.kt
@@ -174,7 +174,7 @@ internal object ProfileLoggedScreen : Tab {
                                     post = post,
                                     postLayout = uiState.postLayout,
                                     fullHeightImage = uiState.fullHeightImages,
-                                    separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                    voteFormat = uiState.voteFormat,
                                     autoLoadImages = uiState.autoLoadImages,
                                     hideAuthor = true,
                                     blurNsfw = false,
@@ -304,7 +304,7 @@ internal object ProfileLoggedScreen : Tab {
                                 CommentCard(
                                     modifier = Modifier.background(MaterialTheme.colorScheme.background),
                                     comment = comment,
-                                    separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                    voteFormat = uiState.voteFormat,
                                     autoLoadImages = uiState.autoLoadImages,
                                     hideCommunity = false,
                                     hideAuthor = true,

--- a/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedViewModel.kt
+++ b/feature-profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/logged/ProfileLoggedViewModel.kt
@@ -68,7 +68,7 @@ class ProfileLoggedViewModel(
             settingsRepository.currentSettings.onEach { settings ->
                 mvi.updateState {
                     it.copy(
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreMviModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreMviModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.search.main
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResult
@@ -44,7 +45,7 @@ interface ExploreMviModel :
         val resultType: SearchResultType = SearchResultType.All,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
     )
 

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
@@ -352,7 +352,7 @@ class ExploreScreen : Screen {
                                                 post = result.model,
                                                 postLayout = uiState.postLayout,
                                                 fullHeightImage = uiState.fullHeightImages,
-                                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                                voteFormat = uiState.voteFormat,
                                                 autoLoadImages = uiState.autoLoadImages,
                                                 blurNsfw = uiState.blurNsfw,
                                                 onClick = rememberCallback {
@@ -482,7 +482,7 @@ class ExploreScreen : Screen {
                                             CommentCard(
                                                 modifier = Modifier.background(MaterialTheme.colorScheme.background),
                                                 comment = result.model,
-                                                separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                                voteFormat = uiState.voteFormat,
                                                 autoLoadImages = uiState.autoLoadImages,
                                                 hideIndent = true,
                                                 onClick = rememberCallback {

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreViewModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreViewModel.kt
@@ -72,7 +72,7 @@ class ExploreViewModel(
                 mvi.updateState {
                     it.copy(
                         blurNsfw = settings.blurNsfw,
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                         swipeActionsEnabled = settings.enableSwipeActions,

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityMviModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityMviModel.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.search.multicommunity.d
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
@@ -36,7 +37,7 @@ interface MultiCommunityMviModel :
         val swipeActionsEnabled: Boolean = true,
         val postLayout: PostLayout = PostLayout.Card,
         val fullHeightImages: Boolean = true,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = true,
     )
 

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityScreen.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityScreen.kt
@@ -299,7 +299,7 @@ class MultiCommunityScreen(
                                     post = post,
                                     postLayout = uiState.postLayout,
                                     fullHeightImage = uiState.fullHeightImages,
-                                    separateUpAndDownVotes = uiState.separateUpAndDownVotes,
+                                    voteFormat = uiState.voteFormat,
                                     autoLoadImages = uiState.autoLoadImages,
                                     blurNsfw = uiState.blurNsfw,
                                     onClick = {

--- a/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/feature-search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/multicommunity/detail/MultiCommunityViewModel.kt
@@ -55,7 +55,7 @@ class MultiCommunityViewModel(
                     it.copy(
                         blurNsfw = settings.blurNsfw,
                         swipeActionsEnabled = settings.enableSwipeActions,
-                        separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                        voteFormat = settings.voteFormat,
                         autoLoadImages = settings.autoLoadImages,
                         fullHeightImages = settings.fullHeightImages,
                     )

--- a/feature-settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
+++ b/feature-settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
@@ -6,6 +6,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.FontScale
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiFontFamily
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiTheme
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
@@ -37,7 +38,7 @@ interface SettingsMviModel :
         data class ChangeUpvoteColor(val value: Color?) : Intent
         data class ChangeDownvoteColor(val value: Color?) : Intent
         data class ChangeCrashReportEnabled(val value: Boolean) : Intent
-        data class ChangeSeparateUpAndDownVotes(val value: Boolean) : Intent
+        data class ChangeVoteFormat(val value: VoteFormat) : Intent
         data class ChangeAutoLoadImages(val value: Boolean) : Intent
         data class ChangeAutoExpandComments(val value: Boolean) : Intent
         data class ChangeFullHeightImages(val value: Boolean) : Intent
@@ -72,7 +73,7 @@ interface SettingsMviModel :
         val enableSwipeActions: Boolean = true,
         val enableDoubleTapAction: Boolean = true,
         val crashReportEnabled: Boolean = false,
-        val separateUpAndDownVotes: Boolean = false,
+        val voteFormat: VoteFormat = VoteFormat.Aggregated,
         val autoLoadImages: Boolean = false,
         val autoExpandComments: Boolean = false,
         val fullHeightImages: Boolean = false,

--- a/feature-settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature-settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -59,6 +59,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.PostLayoutB
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SliderBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SortBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.ThemeBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.VoteFormatBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
@@ -201,6 +202,10 @@ class SettingsScreen : Screen {
             notificationCenter.subscribe(NotificationCenterEvent.ChangeInboxType::class)
                 .onEach { evt ->
                     model.reduce(SettingsMviModel.Intent.ChangeDefaultInboxUnreadOnly(evt.unreadOnly))
+                }.launchIn(this)
+            notificationCenter.subscribe(NotificationCenterEvent.ChangeVoteFormat::class)
+                .onEach { evt ->
+                    model.reduce(SettingsMviModel.Intent.ChangeVoteFormat(evt.value))
                 }.launchIn(this)
         }
 
@@ -366,16 +371,13 @@ class SettingsScreen : Screen {
                         },
                     )
 
-                    // separate upvotes and downvotes
-                    SettingsSwitchRow(
-                        title = stringResource(MR.strings.settings_separate_up_and_downvotes),
-                        value = uiState.separateUpAndDownVotes,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeSeparateUpAndDownVotes(
-                                    value
-                                )
-                            )
+                    // vote format
+                    SettingsRow(
+                        title = stringResource(MR.strings.settings_vote_format),
+                        value = uiState.voteFormat.toReadableName(),
+                        onTap = {
+                            val sheet = VoteFormatBottomSheet()
+                            navigationCoordinator.showBottomSheet(sheet)
                         },
                     )
 

--- a/feature-settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
+++ b/feature-settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.toArgb
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiFontFamily
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiTheme
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toFontScale
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -108,7 +109,7 @@ class SettingsViewModel(
                 enableSwipeActions = settings.enableSwipeActions,
                 enableDoubleTapAction = settings.enableDoubleTapAction,
                 crashReportEnabled = crashReportConfiguration.isEnabled(),
-                separateUpAndDownVotes = settings.separateUpAndDownVotes,
+                voteFormat = settings.voteFormat,
                 autoLoadImages = settings.autoLoadImages,
                 autoExpandComments = settings.autoExpandComments,
                 fullHeightImages = settings.fullHeightImages,
@@ -194,8 +195,8 @@ class SettingsViewModel(
                 changeCrashReportEnabled(intent.value)
             }
 
-            is SettingsMviModel.Intent.ChangeSeparateUpAndDownVotes -> {
-                changeSeparateUpAndDownVotes(intent.value)
+            is SettingsMviModel.Intent.ChangeVoteFormat -> {
+                changeVoteFormat(intent.value)
             }
 
             is SettingsMviModel.Intent.ChangeAutoLoadImages -> {
@@ -440,11 +441,11 @@ class SettingsViewModel(
         mvi.updateState { it.copy(crashReportEnabled = value) }
     }
 
-    private fun changeSeparateUpAndDownVotes(value: Boolean) {
-        mvi.updateState { it.copy(separateUpAndDownVotes = value) }
+    private fun changeVoteFormat(value: VoteFormat) {
+        mvi.updateState { it.copy(voteFormat = value) }
         mvi.scope?.launch {
             val settings = settingsRepository.currentSettings.value.copy(
-                separateUpAndDownVotes = value
+                voteFormat = value
             )
             saveSettings(settings)
         }

--- a/resources/src/commonMain/resources/MR/ar/strings.xml
+++ b/resources/src/commonMain/resources/MR/ar/strings.xml
@@ -207,7 +207,6 @@
     <string name="settings_section_debug">تصحيح الأخطاء</string>
     <string name="settings_section_feed">المنشورات والتعليقات</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">أصوات مؤيدة/أصوات معارضة منفصلة</string>
     <string name="settings_theme_black">الظلام (أموليد)</string>
     <string name="settings_theme_dark">داكن</string>
     <string name="settings_theme_light">فاتح</string>
@@ -245,4 +244,8 @@
     <string name="settings_default_inbox_type">نوع البريد الوارد الافتراضي</string>
     <string name="mod_action_add_mod">إضافة مشرف</string>
     <string name="mod_action_remove_mod">إزالة المشرف</string>
+    <string name="settings_vote_format">تنسيق التصويت</string>
+    <string name="settings_vote_format_aggregated">إجمالي</string>
+    <string name="settings_vote_format_separated">متفرق</string>
+    <string name="settings_vote_format_percentage">نسبة مئوية</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/base/strings.xml
+++ b/resources/src/commonMain/resources/MR/base/strings.xml
@@ -238,7 +238,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Posts and comments</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Separate upvotes / downvotes</string>
     <string name="settings_theme_black">Pure black</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_light">Light</string>
@@ -274,4 +273,8 @@
     <string name="settings_default_inbox_type">Default inbox type</string>
     <string name="mod_action_add_mod">Add moderator</string>
     <string name="mod_action_remove_mod">Remove moderator</string>
+    <string name="settings_vote_format">Vote format</string>
+    <string name="settings_vote_format_aggregated">Aggregate</string>
+    <string name="settings_vote_format_separated">Separate</string>
+    <string name="settings_vote_format_percentage">Percentage</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/bg/strings.xml
+++ b/resources/src/commonMain/resources/MR/bg/strings.xml
@@ -215,8 +215,6 @@
     <string name="settings_section_debug">Отстраняване на дефекти</string>
     <string name="settings_section_feed">Публикации и коментари</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Отделни положителни / отрицателни гласове
-    </string>
     <string name="settings_theme_black">Тъмно (AMOLED)</string>
     <string name="settings_theme_dark">Тъмно</string>
     <string name="settings_theme_light">Светло</string>
@@ -256,4 +254,8 @@
     <string name="settings_default_inbox_type">Тип входяща кутия по подразбиране</string>
     <string name="mod_action_add_mod">Добавете модератор</string>
     <string name="mod_action_remove_mod">Премахване на модератора</string>
+    <string name="settings_vote_format">Формат на гласуване</string>
+    <string name="settings_vote_format_aggregated">Агрегат</string>
+    <string name="settings_vote_format_separated">Отделно</string>
+    <string name="settings_vote_format_percentage">Процент</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/cs/strings.xml
+++ b/resources/src/commonMain/resources/MR/cs/strings.xml
@@ -209,7 +209,6 @@
     <string name="settings_section_debug">Ladění</string>
     <string name="settings_section_feed">Příspěvky a komentáře</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Oddělte upvotes / downvotes</string>
     <string name="settings_theme_black">Tmavý (AMOLED)</string>
     <string name="settings_theme_dark">Tmavý</string>
     <string name="settings_theme_light">Světlý</string>
@@ -247,4 +246,8 @@
     <string name="settings_default_inbox_type">Výchozí typ doručené pošty</string>
     <string name="mod_action_add_mod">Přidat moderátora</string>
     <string name="mod_action_remove_mod">Odstranit moderátora</string>
+    <string name="settings_vote_format">Formát hlasování</string>
+    <string name="settings_vote_format_aggregated">Agregát</string>
+    <string name="settings_vote_format_separated">Samostatný</string>
+    <string name="settings_vote_format_percentage">Procento</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/da/strings.xml
+++ b/resources/src/commonMain/resources/MR/da/strings.xml
@@ -210,7 +210,6 @@
     <string name="settings_section_debug">Debugging</string>
     <string name="settings_section_feed">Indlæg og kommentarer</string>
     <string name="settings_section_nsfw">nsfw</string>
-    <string name="settings_separate_up_and_downvotes">Separate upvotes/downvotes</string>
     <string name="settings_theme_black">Mørk (AMOLED)</string>
     <string name="settings_theme_dark">Mørk</string>
     <string name="settings_theme_light">Let</string>
@@ -247,4 +246,8 @@
     <string name="settings_default_inbox_type">Standard indbakketype</string>
     <string name="mod_action_add_mod">Tilføje moderator</string>
     <string name="mod_action_remove_mod">Fjern moderator</string>
+    <string name="settings_vote_format">Afstemningsformat</string>
+    <string name="settings_vote_format_aggregated">Samlet</string>
+    <string name="settings_vote_format_separated">Adskille</string>
+    <string name="settings_vote_format_percentage">Procent</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/de/strings.xml
+++ b/resources/src/commonMain/resources/MR/de/strings.xml
@@ -213,7 +213,6 @@
     <string name="settings_section_debug">Debuggen</string>
     <string name="settings_section_feed">Beiträge und Kommentare</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Separate Upvotes/Downvotes</string>
     <string name="settings_theme_black">Dunkles (AMOLED)</string>
     <string name="settings_theme_dark">Dunkles</string>
     <string name="settings_theme_light">Licht</string>
@@ -253,4 +252,8 @@
     <string name="settings_default_inbox_type">Standard-Posteingangstyp</string>
     <string name="mod_action_add_mod">Moderator hinzufügen</string>
     <string name="mod_action_remove_mod">Moderator entfernen</string>
+    <string name="settings_vote_format">Abstimmungsformat</string>
+    <string name="settings_vote_format_aggregated">Aggregat</string>
+    <string name="settings_vote_format_separated">Separate</string>
+    <string name="settings_vote_format_percentage">Prozentsatz</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/el/strings.xml
+++ b/resources/src/commonMain/resources/MR/el/strings.xml
@@ -213,8 +213,6 @@
     <string name="settings_section_debug">Αποσφαλμάτωση</string>
     <string name="settings_section_feed">Αναρτήσεις και σχόλια</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Χωριστές ψήφοι ανοδικές / καταδικαστικές
-    </string>
     <string name="settings_theme_black">Σκοτεινό (AMOLED)</string>
     <string name="settings_theme_dark">Σκοτεινό</string>
     <string name="settings_theme_light">Φωτεινό</string>
@@ -257,4 +255,8 @@
     <string name="settings_default_inbox_type">Προεπιλεγμένος τύπος εισερχομένων</string>
     <string name="mod_action_add_mod">Προσθήκη συντονιστή</string>
     <string name="mod_action_remove_mod">Κατάργηση συντονιστή</string>
+    <string name="settings_vote_format">Μορφή ψηφοφορίας</string>
+    <string name="settings_vote_format_aggregated">Σύνολο</string>
+    <string name="settings_vote_format_separated">Ξεχωριστό</string>
+    <string name="settings_vote_format_percentage">Ποσοστό</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/eo/strings.xml
+++ b/resources/src/commonMain/resources/MR/eo/strings.xml
@@ -209,7 +209,6 @@
     <string name="settings_section_debug">Sencimigi</string>
     <string name="settings_section_feed">Afiŝoj kaj komentoj</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Apartigi porvoĉojn / kontraŭvoĉojn</string>
     <string name="settings_theme_black">Malhela (AMOLED)</string>
     <string name="settings_theme_dark">Malhela</string>
     <string name="settings_theme_light">Hela</string>
@@ -246,4 +245,8 @@
     <string name="settings_default_inbox_type">Defaŭlta enirkesto tipo</string>
     <string name="mod_action_add_mod">Aldoni moderigilon</string>
     <string name="mod_action_remove_mod">Forigi moderigilon</string>
+    <string name="settings_vote_format">Voĉdona formato</string>
+    <string name="settings_vote_format_aggregated">Entute</string>
+    <string name="settings_vote_format_separated">Apartigite</string>
+    <string name="settings_vote_format_percentage">Procento</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/es/strings.xml
+++ b/resources/src/commonMain/resources/MR/es/strings.xml
@@ -211,8 +211,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Publicaciones y comentarios</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Mostrar votos positivos / negativos
-    </string>
     <string name="settings_theme_black">Oscuro (AMOLED)</string>
     <string name="settings_theme_dark">Oscuro</string>
     <string name="settings_theme_light">Claro</string>
@@ -252,4 +250,8 @@
     <string name="settings_default_inbox_type">Mensajes predefinidos</string>
     <string name="mod_action_add_mod">Agregar moderador</string>
     <string name="mod_action_remove_mod">Eliminar moderador</string>
+    <string name="settings_vote_format">Formato votos</string>
+    <string name="settings_vote_format_aggregated">Agregado</string>
+    <string name="settings_vote_format_separated">Separado</string>
+    <string name="settings_vote_format_percentage">Porcentaje</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/et/strings.xml
+++ b/resources/src/commonMain/resources/MR/et/strings.xml
@@ -209,7 +209,6 @@
     <string name="settings_section_debug">Silumine</string>
     <string name="settings_section_feed">Postitused ja kommentaarid</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Eraldi üles- / allahääled</string>
     <string name="settings_theme_black">Tume (AMOLED)</string>
     <string name="settings_theme_dark">Tume</string>
     <string name="settings_theme_light">Valgus</string>
@@ -247,4 +246,8 @@
     <string name="settings_default_inbox_type">Vaikepostkasti tüüp</string>
     <string name="mod_action_add_mod">Lisa moderaator</string>
     <string name="mod_action_remove_mod">Eemalda moderaator</string>
+    <string name="settings_vote_format">Hääletuse formaat</string>
+    <string name="settings_vote_format_aggregated">Agregaat</string>
+    <string name="settings_vote_format_separated">Eraldi</string>
+    <string name="settings_vote_format_percentage">Protsent</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fi/strings.xml
+++ b/resources/src/commonMain/resources/MR/fi/strings.xml
@@ -209,7 +209,6 @@
     <string name="settings_section_debug">Testaa</string>
     <string name="settings_section_feed">Julkaisut ja kommentit</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Erilliset ylä-/ alaäänet</string>
     <string name="settings_theme_black">Tumma (AMOLED)</string>
     <string name="settings_theme_dark">Tumma</string>
     <string name="settings_theme_light">Valo</string>
@@ -247,4 +246,8 @@
     <string name="settings_default_inbox_type">Oletuspostilaatikon tyyppi</string>
     <string name="mod_action_add_mod">Lisää moderaattori</string>
     <string name="mod_action_remove_mod">Poista moderaattori</string>
+    <string name="settings_vote_format">Äänestysmuoto</string>
+    <string name="settings_vote_format_aggregated">Aggregaatti</string>
+    <string name="settings_vote_format_separated">Erillinen</string>
+    <string name="settings_vote_format_percentage">Prosenttiosuus</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fr/strings.xml
+++ b/resources/src/commonMain/resources/MR/fr/strings.xml
@@ -211,8 +211,6 @@
     <string name="settings_section_debug">Débogage</string>
     <string name="settings_section_feed">Publications et commentaires</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Séparer les votes positifs et négatifs
-    </string>
     <string name="settings_theme_black">Sombre (AMOLED)</string>
     <string name="settings_theme_dark">Sombre</string>
     <string name="settings_theme_light">Lumineux</string>
@@ -251,4 +249,8 @@
     <string name="settings_default_inbox_type">Type de boîte par défaut</string>
     <string name="mod_action_add_mod">Ajouter modérateur</string>
     <string name="mod_action_remove_mod">Supprimer modérateur</string>
+    <string name="settings_vote_format">Format du vote</string>
+    <string name="settings_vote_format_aggregated">Agrégat</string>
+    <string name="settings_vote_format_separated">Séparé</string>
+    <string name="settings_vote_format_percentage">Pourcentage</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ga/strings.xml
+++ b/resources/src/commonMain/resources/MR/ga/strings.xml
@@ -216,7 +216,6 @@
     <string name="settings_section_debug">Dífhabhtú</string>
     <string name="settings_section_feed">Poist agus tuairimí</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Suasvótaí/íosvótaí ar leith</string>
     <string name="settings_theme_black">Íon - dubh</string>
     <string name="settings_theme_dark">Dorcha</string>
     <string name="settings_theme_light">Solas</string>
@@ -256,4 +255,8 @@
     </string>
     <string name="mod_action_add_mod">Modhnóir a chur leis</string>
     <string name="mod_action_remove_mod">Bain modhnóir</string>
+    <string name="settings_vote_format">Formáid vóta</string>
+    <string name="settings_vote_format_aggregated">Comhiomlán</string>
+    <string name="settings_vote_format_separated">Scartha</string>
+    <string name="settings_vote_format_percentage">Céatadán</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hr/strings.xml
+++ b/resources/src/commonMain/resources/MR/hr/strings.xml
@@ -212,7 +212,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Objave i komentari</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Odvojeni glasovi za / protiv</string>
     <string name="settings_theme_black">Tamni (AMOLED)</string>
     <string name="settings_theme_dark">Tamni</string>
     <string name="settings_theme_light">Lagano</string>
@@ -252,4 +251,8 @@
     <string name="settings_default_inbox_type">Zadana vrsta pristigle pošte</string>
     <string name="mod_action_add_mod">Dodaj moderatora</string>
     <string name="mod_action_remove_mod">Ukloniti moderatora</string>
+    <string name="settings_vote_format">Format glasovanja</string>
+    <string name="settings_vote_format_aggregated">Agregat</string>
+    <string name="settings_vote_format_separated">Odvojeni</string>
+    <string name="settings_vote_format_percentage">Postotak</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hu/strings.xml
+++ b/resources/src/commonMain/resources/MR/hu/strings.xml
@@ -211,7 +211,6 @@
     <string name="settings_section_debug">Hibaelhárítás</string>
     <string name="settings_section_feed">Bejegyzések és megjegyzések</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Külön pozitív és negatív szavazatokat</string>
     <string name="settings_theme_black">Sötét (AMOLED)</string>
     <string name="settings_theme_dark">Sötét</string>
     <string name="settings_theme_light">Enyhe</string>
@@ -251,4 +250,8 @@
     <string name="settings_default_inbox_type">Alapértelmezett beérkező levelek típusa</string>
     <string name="mod_action_add_mod">Moderátor hozzáadása</string>
     <string name="mod_action_remove_mod">Moderátor eltávolítása</string>
+    <string name="settings_vote_format">Szavazás formátuma</string>
+    <string name="settings_vote_format_aggregated">Összesített</string>
+    <string name="settings_vote_format_separated">Különálló</string>
+    <string name="settings_vote_format_percentage">Százalék</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/it/strings.xml
+++ b/resources/src/commonMain/resources/MR/it/strings.xml
@@ -212,7 +212,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Post e commenti</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Distingui voti positivi / negativi</string>
     <string name="settings_theme_black">Scuro (AMOLED)</string>
     <string name="settings_theme_dark">Scuro</string>
     <string name="settings_theme_light">Chiaro</string>
@@ -251,4 +250,8 @@
     <string name="settings_default_inbox_type">Tipo inbox predefinito</string>
     <string name="mod_action_add_mod">Aggiungi moderatore</string>
     <string name="mod_action_remove_mod">Rimuovi moderatore</string>
+    <string name="settings_vote_format">Formato voti</string>
+    <string name="settings_vote_format_aggregated">Aggregato</string>
+    <string name="settings_vote_format_separated">Separato</string>
+    <string name="settings_vote_format_percentage">Percentuale</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lt/strings.xml
+++ b/resources/src/commonMain/resources/MR/lt/strings.xml
@@ -210,7 +210,6 @@
     <string name="settings_section_debug">Derinti</string>
     <string name="settings_section_feed">Įrašai ir komentarai</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Atskiri balsai už/ prieš</string>
     <string name="settings_theme_black">Tamsus (AMOLED)</string>
     <string name="settings_theme_dark">Tamsus</string>
     <string name="settings_theme_light">Šviesiai</string>
@@ -249,4 +248,8 @@
     <string name="settings_default_inbox_type">Numatytasis gautųjų tipas</string>
     <string name="mod_action_add_mod">Pridėti moderatorių</string>
     <string name="mod_action_remove_mod">Pašalinti moderatorių</string>
+    <string name="settings_vote_format">Balsavimo formatas</string>
+    <string name="settings_vote_format_aggregated">Suvestinė</string>
+    <string name="settings_vote_format_separated">Atskirai</string>
+    <string name="settings_vote_format_percentage">Procentas</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lv/strings.xml
+++ b/resources/src/commonMain/resources/MR/lv/strings.xml
@@ -212,7 +212,6 @@
     <string name="settings_section_debug">Atkļūdot</string>
     <string name="settings_section_feed">Ziņas un komentāri</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Atsevišķas upvotes / downvotes</string>
     <string name="settings_theme_black">Tumša (AMOLED)</string>
     <string name="settings_theme_dark">Tumša</string>
     <string name="settings_theme_light">Apgaismojums</string>
@@ -251,4 +250,8 @@
     <string name="settings_default_inbox_type">Noklusējuma iesūtnes veids</string>
     <string name="mod_action_add_mod">Pievienot moderatoru</string>
     <string name="mod_action_remove_mod">Noņemt moderatoru</string>
+    <string name="settings_vote_format">Balsošanas formāts</string>
+    <string name="settings_vote_format_aggregated">Agregāts</string>
+    <string name="settings_vote_format_separated">Atsevišķi</string>
+    <string name="settings_vote_format_percentage">Procenti</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/mt/strings.xml
+++ b/resources/src/commonMain/resources/MR/mt/strings.xml
@@ -211,7 +211,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Posts u kummenti</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Voti upvotes / downvotes separati</string>
     <string name="settings_theme_black">Skur (AMOLED)</string>
     <string name="settings_theme_dark">Skur</string>
     <string name="settings_theme_light">Ċar</string>
@@ -252,4 +251,8 @@
     <string name="settings_default_inbox_type">Tip default ta \'inbox</string>
     <string name="mod_action_add_mod">Żid moderatur</string>
     <string name="mod_action_remove_mod">Neħħi moderatur</string>
+    <string name="settings_vote_format">Format tal-vot</string>
+    <string name="settings_vote_format_aggregated">Aggregat</string>
+    <string name="settings_vote_format_separated">Separati</string>
+    <string name="settings_vote_format_percentage">Persentaġġ</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/nl/strings.xml
+++ b/resources/src/commonMain/resources/MR/nl/strings.xml
@@ -211,7 +211,6 @@
     <string name="settings_section_debug">Fouten opsporen</string>
     <string name="settings_section_feed">Berichten en reacties</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Aparte upvotes / downvotes</string>
     <string name="settings_theme_black">Pure Black</string>
     <string name="settings_theme_dark">Donker</string>
     <string name="settings_theme_light">Verlichting</string>
@@ -250,4 +249,8 @@
     <string name="settings_default_inbox_type">Standaardtype inbox</string>
     <string name="mod_action_add_mod">Moderator toevoegen</string>
     <string name="mod_action_remove_mod">Moderator verwijderen</string>
+    <string name="settings_vote_format">Stemformaat</string>
+    <string name="settings_vote_format_aggregated">Totaal</string>
+    <string name="settings_vote_format_separated">Verschillend</string>
+    <string name="settings_vote_format_percentage">Percentage</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/no/strings.xml
+++ b/resources/src/commonMain/resources/MR/no/strings.xml
@@ -212,7 +212,6 @@
     <string name="settings_section_debug">Feilsøk</string>
     <string name="settings_section_feed">Innlegg og merknader</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Separate upvotes / downvotes</string>
     <string name="settings_theme_black">Mørk (AMOLED)</string>
     <string name="settings_theme_dark">Mørk</string>
     <string name="settings_theme_light">Lys</string>
@@ -249,4 +248,8 @@
     <string name="settings_default_inbox_type">Standard innbokstype</string>
     <string name="mod_action_add_mod">Legg til moderator</string>
     <string name="mod_action_remove_mod">Fjern moderator</string>
+    <string name="settings_vote_format">Stemmeformat</string>
+    <string name="settings_vote_format_aggregated">Samlet</string>
+    <string name="settings_vote_format_separated">Skille</string>
+    <string name="settings_vote_format_percentage">Prosentdel</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pl/strings.xml
+++ b/resources/src/commonMain/resources/MR/pl/strings.xml
@@ -212,7 +212,6 @@
     <string name="settings_section_debug">Debugowanie</string>
     <string name="settings_section_feed">Posty i komentarze</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Oddzielne głosy w górę i w dół</string>
     <string name="settings_theme_black">Ciemny (AMOLED)</string>
     <string name="settings_theme_dark">Ciemny</string>
     <string name="settings_theme_light">Świetlny</string>
@@ -250,4 +249,8 @@
     <string name="settings_default_inbox_type">Domyślny typ skrzynki odbiorczej</string>
     <string name="mod_action_add_mod">Dodaj moderatora</string>
     <string name="mod_action_remove_mod">Usuń moderatora</string>
+    <string name="settings_vote_format">Format głosowania</string>
+    <string name="settings_vote_format_aggregated">Agregat</string>
+    <string name="settings_vote_format_separated">Oddzielny</string>
+    <string name="settings_vote_format_percentage">Odsetek</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pt/strings.xml
+++ b/resources/src/commonMain/resources/MR/pt/strings.xml
@@ -210,7 +210,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Publicaçoes e comentários</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Separar votos positivos e negativos</string>
     <string name="settings_theme_black">Escuro (AMOLED)</string>
     <string name="settings_theme_dark">Escuro</string>
     <string name="settings_theme_light">Claro</string>
@@ -249,4 +248,8 @@
     <string name="settings_default_inbox_type">Tipo de caixa padrão</string>
     <string name="mod_action_add_mod">Adicionar moderador</string>
     <string name="mod_action_remove_mod">Remover moderador</string>
+    <string name="settings_vote_format">Formato votos</string>
+    <string name="settings_vote_format_aggregated">Agregado</string>
+    <string name="settings_vote_format_separated">Separado</string>
+    <string name="settings_vote_format_percentage">Percentagem</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ro/strings.xml
+++ b/resources/src/commonMain/resources/MR/ro/strings.xml
@@ -211,7 +211,6 @@
     <string name="settings_section_debug">Depanare</string>
     <string name="settings_section_feed">Postări și comentării</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Distinge voturi pozitive și negative</string>
     <string name="settings_theme_black">Întunecată (AMOLED)</string>
     <string name="settings_theme_dark">Întunecată</string>
     <string name="settings_theme_light">Ușoară</string>
@@ -248,4 +247,8 @@
     <string name="settings_default_inbox_type">Tipul implicit de inbox</string>
     <string name="mod_action_add_mod">Adaugă moderator</string>
     <string name="mod_action_remove_mod">Elimină moderator</string>
+    <string name="settings_vote_format">Format voturilor</string>
+    <string name="settings_vote_format_aggregated">Agregat</string>
+    <string name="settings_vote_format_separated">Separat</string>
+    <string name="settings_vote_format_percentage">Procent</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/se/strings.xml
+++ b/resources/src/commonMain/resources/MR/se/strings.xml
@@ -211,7 +211,6 @@
     <string name="settings_section_debug">Felsökning</string>
     <string name="settings_section_feed">Inlägg och kommentarer</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Separata uppröster / nedröster</string>
     <string name="settings_theme_black">Mörk (AMOLED)</string>
     <string name="settings_theme_dark">Mörk</string>
     <string name="settings_theme_light">Ljus</string>
@@ -248,4 +247,8 @@
     <string name="settings_default_inbox_type">Standardtyp av inkorg</string>
     <string name="mod_action_add_mod">Lägg till moderator</string>
     <string name="mod_action_remove_mod">Ta bort moderator</string>
+    <string name="settings_vote_format">Röstformat</string>
+    <string name="settings_vote_format_aggregated">Aggregat</string>
+    <string name="settings_vote_format_separated">Separat</string>
+    <string name="settings_vote_format_percentage">Procentsats</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sk/strings.xml
+++ b/resources/src/commonMain/resources/MR/sk/strings.xml
@@ -211,7 +211,6 @@
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_feed">Príspevky a komentáre</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Oddeliť upvotes / downvotes</string>
     <string name="settings_theme_black">Tmavá (AMOLED)</string>
     <string name="settings_theme_dark">Tmavá</string>
     <string name="settings_theme_light">Svetlo</string>
@@ -249,4 +248,8 @@
     <string name="settings_default_inbox_type">Predvolený typ doručenej pošty</string>
     <string name="mod_action_add_mod">Pridať moderátora</string>
     <string name="mod_action_remove_mod">Odstrániť moderátora</string>
+    <string name="settings_vote_format">Formát hlasovania</string>
+    <string name="settings_vote_format_aggregated">Agregátne</string>
+    <string name="settings_vote_format_separated">Samostatné</string>
+    <string name="settings_vote_format_percentage">Percento</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sl/strings.xml
+++ b/resources/src/commonMain/resources/MR/sl/strings.xml
@@ -210,7 +210,6 @@
     <string name="settings_section_debug">Debugiranje</string>
     <string name="settings_section_feed">Objave in komentarji</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Ločeni glasovi za/proti</string>
     <string name="settings_theme_black">Tema (AMOLED)</string>
     <string name="settings_theme_dark">Tema</string>
     <string name="settings_theme_light">Luč</string>
@@ -247,4 +246,8 @@
     <string name="settings_default_inbox_type">privzeta vrsta mape Prejeto</string>
     <string name="mod_action_add_mod">Dodaj moderatorja</string>
     <string name="mod_action_remove_mod">Odstrani moderatorja</string>
+    <string name="settings_vote_format">Oblika glasovanja</string>
+    <string name="settings_vote_format_aggregated">Agregat</string>
+    <string name="settings_vote_format_separated">Ločeno</string>
+    <string name="settings_vote_format_percentage">Odstotek</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sq/strings.xml
+++ b/resources/src/commonMain/resources/MR/sq/strings.xml
@@ -241,8 +241,7 @@
     <string name="settings_section_debug">Korrigjo</string>
     <string name="settings_section_feed">Postime dhe komente</string>
     <string name="settings_section_nsfw">NSFW</string>
-    <string name="settings_separate_up_and_downvotes">Ndani votat e sipërme/të poshtme</string>
-    <string name="settings_theme_black">E zezë e pastër</string>
+    <string name="settings_theme_black">E errët (AMOLED)</string>
     <string name="settings_theme_dark">E errët</string>
     <string name="settings_theme_light">Drita</string>
     <string name="settings_ui_font_family">Shkronja e ndërfaqes së përdoruesit</string>
@@ -281,4 +280,8 @@
     <string name="settings_default_inbox_type">Lloji i paracaktuar i kutisë së mesazheve</string>
     <string name="mod_action_add_mod">Shtoni moderator</string>
     <string name="mod_action_remove_mod">Hiqni moderatorin</string>
+    <string name="settings_vote_format">Formati i votimit</string>
+    <string name="settings_vote_format_aggregated">Agregat</string>
+    <string name="settings_vote_format_separated">Të ndara</string>
+    <string name="settings_vote_format_percentage">Përqindje</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/tr/strings.xml
+++ b/resources/src/commonMain/resources/MR/tr/strings.xml
@@ -210,7 +210,6 @@
     <string name="settings_section_debug">Hata ayıklama</string>
     <string name="settings_section_feed">Gönderiler ve yorumlar</string>
     <string name="settings_section_nsfw">Sakıncalı İçerik</string>
-    <string name="settings_separate_up_and_downvotes">Ayrı artı /eksi oylar</string>
     <string name="settings_theme_black">Saf siyah</string>
     <string name="settings_theme_dark">Karanlık</string>
     <string name="settings_theme_light">Işık</string>
@@ -250,4 +249,8 @@
     <string name="settings_default_inbox_type">Varsayılan gelen kutusu türü</string>
     <string name="mod_action_add_mod">Moderatör ekleyin</string>
     <string name="mod_action_remove_mod">Moderatörü kaldır</string>
+    <string name="settings_vote_format">Oy formatı</string>
+    <string name="settings_vote_format_aggregated">Agrega</string>
+    <string name="settings_vote_format_separated">Ayırmak</string>
+    <string name="settings_vote_format_percentage">Yüzde</string>
 </resources>


### PR DESCRIPTION
This PR adds the possibility to display the upvote/downvote ration in three formats:
- aggregate (default, current option): the result is the score resulting by the algebraic sum upvotes + downvotes
- separate: upvotes and downvotes are shown separately
- percentage: the value is a percentage (upvotes / total votes)