### PR TITLE
feat: enable support for third action in swipe cards

### DIFF
--- a/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/data/CommentBarTheme.kt
+++ b/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/data/CommentBarTheme.kt
@@ -50,3 +50,11 @@ fun CommentBarTheme?.toDownVoteColor(): Color = when (this) {
     CommentBarTheme.Blue -> Color(0xFF9400D3)
     else -> Color.Transparent
 }
+
+fun CommentBarTheme?.toReplyColor(): Color = when (this) {
+    CommentBarTheme.Rainbow -> Color(0xFFFF5722)
+    CommentBarTheme.Red -> Color(0xFF8BC34A)
+    CommentBarTheme.Green -> Color(0xFFFF9800)
+    CommentBarTheme.Blue -> Color(0xFF388E3C)
+    else -> Color.Transparent
+}

--- a/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/repository/DefaultThemeRepository.kt
+++ b/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/repository/DefaultThemeRepository.kt
@@ -20,6 +20,7 @@ internal class DefaultThemeRepository : ThemeRepository {
     override val customSeedColor = MutableStateFlow<Color?>(null)
     override val upvoteColor = MutableStateFlow<Color?>(null)
     override val downvoteColor = MutableStateFlow<Color?>(null)
+    override val replyColor = MutableStateFlow<Color?>(null)
     override val postLayout = MutableStateFlow<PostLayout>(PostLayout.Card)
     override val commentBarTheme = MutableStateFlow<CommentBarTheme>(CommentBarTheme.Blue)
 
@@ -70,6 +71,10 @@ internal class DefaultThemeRepository : ThemeRepository {
 
     override fun changeDownvoteColor(color: Color?) {
         downvoteColor.value = color
+    }
+
+    override fun changeReplyColor(color: Color?) {
+        replyColor.value = color
     }
 
     override fun changePostLayout(value: PostLayout) {

--- a/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/repository/ThemeRepository.kt
+++ b/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/repository/ThemeRepository.kt
@@ -21,6 +21,7 @@ interface ThemeRepository {
     val customSeedColor: StateFlow<Color?>
     val upvoteColor: StateFlow<Color?>
     val downvoteColor: StateFlow<Color?>
+    val replyColor: StateFlow<Color?>
     val postLayout: StateFlow<PostLayout>
     val commentBarTheme: StateFlow<CommentBarTheme>
 
@@ -45,6 +46,8 @@ interface ThemeRepository {
     fun changeUpvoteColor(color: Color?)
 
     fun changeDownvoteColor(color: Color?)
+
+    fun changeReplyColor(color: Color?)
 
     fun changePostLayout(value: PostLayout)
 

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -42,7 +42,7 @@ sealed interface NotificationCenterEvent {
     data class CommentUpdated(val model: CommentModel) : NotificationCenterEvent
     data class PostDeleted(val model: PostModel) : NotificationCenterEvent
     data class ChangeColor(val color: Color?) : NotificationCenterEvent
-    data class ChangeVoteColor(val color: Color?, val downvote: Boolean) : NotificationCenterEvent
+    data class ChangeActionColor(val color: Color?, val actionType: Int) : NotificationCenterEvent
     data class ChangeZombieScrollAmount(val value: Float) : NotificationCenterEvent
     data class MultiCommunityCreated(val model: MultiCommunityModel) : NotificationCenterEvent
     data object CloseDialog : NotificationCenterEvent

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
@@ -37,6 +37,6 @@ data class SettingsModel(
     val zombieModeScrollAmount: Float = 55f,
     val markAsReadWhileScrolling: Boolean = false,
     val commentBarTheme: Int = 0,
-    val sharePostOriginal: Boolean = true,
+    val replyColor: Int? = null,
     val searchPostTitleOnly: Boolean = false,
 ) : JavaSerializable

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -42,7 +42,7 @@ private object KeyStoreKeys {
     const val ZombieModeScrollAmount = "zombieModeScrollAmount"
     const val MarkAsReadWhileScrolling = "markAsReadWhileScrolling"
     const val CommentBarTheme = "commentBarTheme"
-    const val SharePostOriginal = "sharePostOriginal"
+    const val ReplyColor = "replyColor"
     const val SearchPostTitleOnly = "searchPostTitleOnly"
     const val ContentFontFamily = "contentFontFamily"
 }
@@ -89,7 +89,7 @@ internal class DefaultSettingsRepository(
                 zombieModeScrollAmount = settings.zombieModeScrollAmount.toDouble(),
                 markAsReadWhileScrolling = if (settings.markAsReadWhileScrolling) 1 else 0,
                 commentBarTheme = settings.commentBarTheme.toLong(),
-                sharePostOriginal = if (settings.sharePostOriginal) 1 else 0,
+                replyColor = settings.replyColor?.toLong(),
                 searchPostTitleOnly = if (settings.searchPostTitleOnly) 1 else 0,
                 contentFontFamily = settings.contentFontFamily.toLong(),
             )
@@ -131,7 +131,7 @@ internal class DefaultSettingsRepository(
                     zombieModeScrollAmount = keyStore[KeyStoreKeys.ZombieModeScrollAmount, 55f],
                     markAsReadWhileScrolling = keyStore[KeyStoreKeys.MarkAsReadWhileScrolling, false],
                     commentBarTheme = keyStore[KeyStoreKeys.CommentBarTheme, 0],
-                    sharePostOriginal = keyStore[KeyStoreKeys.SharePostOriginal, true],
+                    replyColor = if (!keyStore.containsKey(KeyStoreKeys.ReplyColor)) null else keyStore[KeyStoreKeys.ReplyColor, 0],
                     searchPostTitleOnly = keyStore[KeyStoreKeys.SearchPostTitleOnly, false],
                     contentFontFamily = keyStore[KeyStoreKeys.ContentFontFamily, 0],
                 )
@@ -210,10 +210,11 @@ internal class DefaultSettingsRepository(
                     settings.markAsReadWhileScrolling,
                 )
                 keyStore.save(KeyStoreKeys.CommentBarTheme, settings.commentBarTheme)
-                keyStore.save(
-                    KeyStoreKeys.SharePostOriginal,
-                    settings.sharePostOriginal,
-                )
+                if (settings.replyColor != null) {
+                    keyStore.save(KeyStoreKeys.ReplyColor, settings.replyColor)
+                } else {
+                    keyStore.remove(KeyStoreKeys.ReplyColor)
+                }
                 keyStore.save(
                     KeyStoreKeys.SearchPostTitleOnly,
                     settings.searchPostTitleOnly,
@@ -251,7 +252,7 @@ internal class DefaultSettingsRepository(
                     zombieModeScrollAmount = settings.zombieModeScrollAmount.toDouble(),
                     markAsReadWhileScrolling = if (settings.markAsReadWhileScrolling) 1L else 0L,
                     commentBarTheme = settings.commentBarTheme.toLong(),
-                    sharePostOriginal = if (settings.sharePostOriginal) 1L else 0L,
+                    replyColor = settings.replyColor?.toLong(),
                     searchPostTitleOnly = if (settings.searchPostTitleOnly) 1L else 0L,
                     contentFontFamily = settings.contentFontFamily.toLong(),
                 )
@@ -294,7 +295,7 @@ private fun GetBy.toModel() = SettingsModel(
     zombieModeScrollAmount = zombieModeScrollAmount.toFloat(),
     markAsReadWhileScrolling = markAsReadWhileScrolling != 0L,
     commentBarTheme = commentBarTheme.toInt(),
-    sharePostOriginal = sharePostOriginal != 0L,
+    replyColor = replyColor?.toInt(),
     searchPostTitleOnly = searchPostTitleOnly != 0L,
     contentFontFamily = contentFontFamily.toInt(),
 )

--- a/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
@@ -29,7 +29,7 @@ CREATE TABLE SettingsEntity (
     zombieModeScrollAmount REAL NOT NULL DEFAULT 100,
     markAsReadWhileScrolling INTEGER NOT NULL DEFAULT 0,
     commentBarTheme INTEGER NOT NULL DEFAULT 0,
-    sharePostOriginal INTEGER NOT NULL DEFAULT 1,
+    replyColor INTEGER DEFAULT NULL,
     searchPostTitleOnly INTEGER NOT NULL DEFAULT 0,
     contentFontFamily INTEGER NOT NULL DEFAULT 0,
     account_id INTEGER,
@@ -68,7 +68,7 @@ INSERT OR IGNORE INTO SettingsEntity (
     zombieModeScrollAmount,
     markAsReadWhileScrolling,
     commentBarTheme,
-    sharePostOriginal,
+    replyColor,
     searchPostTitleOnly,
     contentFontFamily,
     account_id
@@ -139,7 +139,7 @@ SET theme = ?,
     zombieModeScrollAmount = ?,
     markAsReadWhileScrolling = ?,
     commentBarTheme = ?,
-    sharePostOriginal = ?,
+    replyColor = ?,
     searchPostTitleOnly = ?,
     contentFontFamily = ?
 WHERE account_id = ?;
@@ -176,7 +176,7 @@ SELECT
     zombieModeScrollAmount,
     markAsReadWhileScrolling,
     commentBarTheme,
-    sharePostOriginal,
+    replyColor,
     searchPostTitleOnly,
     contentFontFamily
 FROM SettingsEntity

--- a/core/persistence/src/commonMain/sqldelight/migrations/18.sqm
+++ b/core/persistence/src/commonMain/sqldelight/migrations/18.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE SettingsEntity
+RENAME COLUMN  sharePostOriginal TO replyColor;

--- a/feature/search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
@@ -85,7 +85,6 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResult
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
 import com.github.diegoberaldin.raccoonforlemmy.feature.search.di.getExploreViewModel
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
-import com.github.diegoberaldin.raccoonforlemmy.unit.createcomment.CreateCommentScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.web.WebViewScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import dev.icerock.moko.resources.compose.stringResource
@@ -421,13 +420,6 @@ class ExploreScreen : Screen {
                                                         )
                                                     }
                                                 },
-                                                onReply = rememberCallback {
-                                                    if (uiState.isLogged) {
-                                                        detailOpener.openPostDetail(
-                                                            result.model,
-                                                        )
-                                                    }
-                                                },
                                                 onOpenImage = rememberCallbackArgs { url ->
                                                     navigationCoordinator.pushScreen(
                                                         ZoomableImageScreen(url),
@@ -559,18 +551,6 @@ class ExploreScreen : Screen {
                                                                 feedback = true,
                                                             ),
                                                         )
-                                                    }
-                                                },
-                                                onReply = rememberCallback {
-                                                    if (uiState.isLogged) {
-                                                        with(navigationCoordinator) {
-                                                            setBottomSheetGesturesEnabled(false)
-                                                            val screen = CreateCommentScreen(
-                                                                originalPost = PostModel(id = result.model.postId),
-                                                                originalComment = result.model,
-                                                            )
-                                                            showBottomSheet(screen)
-                                                        }
                                                     }
                                                 },
                                                 onOpenCommunity = rememberCallbackArgs { community, instance ->

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
@@ -39,6 +39,7 @@ interface SettingsMviModel :
         data class ChangeCustomSeedColor(val value: Color?) : Intent
         data class ChangeUpvoteColor(val value: Color?) : Intent
         data class ChangeDownvoteColor(val value: Color?) : Intent
+        data class ChangeReplyColor(val value: Color?) : Intent
         data class ChangeCrashReportEnabled(val value: Boolean) : Intent
         data class ChangeVoteFormat(val value: VoteFormat) : Intent
         data class ChangeAutoLoadImages(val value: Boolean) : Intent
@@ -59,6 +60,7 @@ interface SettingsMviModel :
         val customSeedColor: Color? = null,
         val upvoteColor: Color? = null,
         val downvoteColor: Color? = null,
+        val replyColor: Color? = null,
         val uiFontScale: FontScale = FontScale.Normal,
         val contentFontScale: FontScale = FontScale.Normal,
         val contentFontFamily: UiFontFamily = UiFontFamily.Poppins,

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -253,7 +253,7 @@ class SettingsScreen : Screen {
                         value = uiState.upvoteColor ?: MaterialTheme.colorScheme.primary,
                         onTap = rememberCallback {
                             val screen = VoteThemeBottomSheet(
-                                downvote = false,
+                                actionType = 0,
                             )
                             navigationCoordinator.showBottomSheet(screen)
                         },
@@ -263,7 +263,17 @@ class SettingsScreen : Screen {
                         value = uiState.downvoteColor ?: MaterialTheme.colorScheme.tertiary,
                         onTap = rememberCallback {
                             val screen = VoteThemeBottomSheet(
-                                downvote = true,
+                                actionType = 1,
+                            )
+                            navigationCoordinator.showBottomSheet(screen)
+                        },
+                    )
+                    SettingsColorRow(
+                        title = stringResource(MR.strings.settings_reply_color),
+                        value = uiState.replyColor ?: MaterialTheme.colorScheme.secondary,
+                        onTap = rememberCallback {
+                            val screen = VoteThemeBottomSheet(
+                                actionType = 2,
                             )
                             navigationCoordinator.showBottomSheet(screen)
                         },

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
@@ -90,6 +90,9 @@ class SettingsViewModel(
             themeRepository.downvoteColor.onEach { value ->
                 mvi.updateState { it.copy(downvoteColor = value) }
             }.launchIn(this)
+            themeRepository.replyColor.onEach { value ->
+                mvi.updateState { it.copy(replyColor = value) }
+            }.launchIn(this)
             themeRepository.commentBarTheme.onEach { value ->
                 mvi.updateState { it.copy(commentBarTheme = value) }
             }.launchIn(this)
@@ -167,12 +170,12 @@ class SettingsViewModel(
                 .onEach { evt ->
                     changeCommentBarTheme(evt.value)
                 }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.ChangeVoteColor::class)
+            notificationCenter.subscribe(NotificationCenterEvent.ChangeActionColor::class)
                 .onEach { evt ->
-                    if (evt.downvote) {
-                        changeDownvoteColor(evt.color)
-                    } else {
-                        changeUpvoteColor(evt.color)
+                    when (evt.actionType) {
+                        2 -> changeReplyColor(evt.color)
+                        1 -> changeDownvoteColor(evt.color)
+                        else -> changeUpvoteColor(evt.color)
                     }
                 }.launchIn(this)
 
@@ -313,6 +316,10 @@ class SettingsViewModel(
 
             is SettingsMviModel.Intent.ChangeDownvoteColor -> {
                 changeDownvoteColor(intent.value)
+            }
+
+            is SettingsMviModel.Intent.ChangeReplyColor -> {
+                changeReplyColor(intent.value)
             }
 
             is SettingsMviModel.Intent.ChangeHideNavigationBarWhileScrolling -> {
@@ -500,6 +507,16 @@ class SettingsViewModel(
         mvi.scope?.launch(Dispatchers.IO) {
             val settings = settingsRepository.currentSettings.value.copy(
                 downvoteColor = value?.toArgb()
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeReplyColor(value: Color?) {
+        themeRepository.changeReplyColor(value)
+        mvi.scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                replyColor = value?.toArgb()
             )
             saveSettings(settings)
         }

--- a/resources/src/commonMain/resources/MR/ar/strings.xml
+++ b/resources/src/commonMain/resources/MR/ar/strings.xml
@@ -283,4 +283,5 @@
     <string name="user_info_moderates">مشرف</string>
     <string name="user_info_admin">مدير</string>
     <string name="settings_about_chat_matrix">الدردشة على Matrix</string>
+    <string name="settings_reply_color">لون عمل الرد</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/base/strings.xml
+++ b/resources/src/commonMain/resources/MR/base/strings.xml
@@ -314,4 +314,5 @@
     <string name="user_info_moderates">Moderator of</string>
     <string name="user_info_admin">administrator</string>
     <string name="settings_about_chat_matrix">Chat on Matrix</string>
+    <string name="settings_reply_color">Reply action color</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/bg/strings.xml
+++ b/resources/src/commonMain/resources/MR/bg/strings.xml
@@ -293,4 +293,5 @@
     <string name="user_info_moderates">Модератор на</string>
     <string name="user_info_admin">администратор</string>
     <string name="settings_about_chat_matrix">Чат в Matrix</string>
+    <string name="settings_reply_color">цвят на отговора</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/cs/strings.xml
+++ b/resources/src/commonMain/resources/MR/cs/strings.xml
@@ -285,4 +285,5 @@
     <string name="user_info_moderates">Moderátor</string>
     <string name="user_info_admin">správce</string>
     <string name="settings_about_chat_matrix">Chat na Matrixu</string>
+    <string name="settings_reply_color">Barva akce odpovědi</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/da/strings.xml
+++ b/resources/src/commonMain/resources/MR/da/strings.xml
@@ -285,4 +285,5 @@
     <string name="user_info_moderates">Moderator af</string>
     <string name="user_info_admin">administrator</string>
     <string name="settings_about_chat_matrix">Chat på Matrix</string>
+    <string name="settings_reply_color">Farve på svarhandling</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/de/strings.xml
+++ b/resources/src/commonMain/resources/MR/de/strings.xml
@@ -293,4 +293,5 @@
     <string name="user_info_moderates">Moderator von</string>
     <string name="user_info_admin">Administrator</string>
     <string name="settings_about_chat_matrix">Chatten Sie auf Matrix</string>
+    <string name="settings_reply_color">Farbe der Antwortaktion</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/el/strings.xml
+++ b/resources/src/commonMain/resources/MR/el/strings.xml
@@ -294,4 +294,5 @@
     <string name="user_info_moderates">Συντονιστής των</string>
     <string name="user_info_admin">διαχειριστής</string>
     <string name="settings_about_chat_matrix">Συνομιλία στο Matrix</string>
+    <string name="settings_reply_color">Χρώμα της ενέργειας απάντησης</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/eo/strings.xml
+++ b/resources/src/commonMain/resources/MR/eo/strings.xml
@@ -284,4 +284,5 @@
     <string name="user_info_moderates">Moderatoro de</string>
     <string name="user_info_admin">administranto</string>
     <string name="settings_about_chat_matrix">Babilu sur Matrix</string>
+    <string name="settings_reply_color">Koloro de responda ago</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/es/strings.xml
+++ b/resources/src/commonMain/resources/MR/es/strings.xml
@@ -289,4 +289,5 @@
     <string name="user_info_moderates">Moderador de</string>
     <string name="user_info_admin">administrador</string>
     <string name="settings_about_chat_matrix">Chat en Matrix</string>
+    <string name="settings_reply_color">Color de la acción de respuesta</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/et/strings.xml
+++ b/resources/src/commonMain/resources/MR/et/strings.xml
@@ -285,4 +285,5 @@
     <string name="user_info_moderates">Moderaator</string>
     <string name="user_info_admin">administraator</string>
     <string name="settings_about_chat_matrix">Vestelge Matrixis</string>
+    <string name="settings_reply_color">Vastuse toimingu värv</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fi/strings.xml
+++ b/resources/src/commonMain/resources/MR/fi/strings.xml
@@ -285,4 +285,5 @@
     <string name="user_info_moderates">Moderaattori</string>
     <string name="user_info_admin">järjestelmänvalvoja</string>
     <string name="settings_about_chat_matrix">Chat Matrixissa</string>
+    <string name="settings_reply_color">Vastaustoiminnon väri</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fr/strings.xml
+++ b/resources/src/commonMain/resources/MR/fr/strings.xml
@@ -290,4 +290,5 @@
     <string name="user_info_moderates">Modérateur de</string>
     <string name="user_info_admin">administrateur</string>
     <string name="settings_about_chat_matrix">Discutez sur Matrix</string>
+    <string name="settings_reply_color">Couleur de l\'action de réponse</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ga/strings.xml
+++ b/resources/src/commonMain/resources/MR/ga/strings.xml
@@ -294,4 +294,5 @@
     <string name="user_info_moderates">Modhnóir na</string>
     <string name="user_info_admin">riarthóir</string>
     <string name="settings_about_chat_matrix">Comhrá ar Matrix</string>
+    <string name="settings_reply_color">Dath an ghnímh freagartha</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hr/strings.xml
+++ b/resources/src/commonMain/resources/MR/hr/strings.xml
@@ -290,4 +290,5 @@
     <string name="user_info_moderates">Moderator od</string>
     <string name="user_info_admin">administrator</string>
     <string name="settings_about_chat_matrix">Chat na Matrixu</string>
+    <string name="settings_reply_color">Boja radnje odgovora</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hu/strings.xml
+++ b/resources/src/commonMain/resources/MR/hu/strings.xml
@@ -289,4 +289,5 @@
     <string name="user_info_moderates">Moderátora</string>
     <string name="user_info_admin">adminisztrátor</string>
     <string name="settings_about_chat_matrix">Chat a Matrixon</string>
+    <string name="settings_reply_color">Válaszművelet színe</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/it/strings.xml
+++ b/resources/src/commonMain/resources/MR/it/strings.xml
@@ -289,4 +289,5 @@
     <string name="user_info_moderates">Moderatore di</string>
     <string name="user_info_admin">amministratore</string>
     <string name="settings_about_chat_matrix">Chat su Matrix</string>
+    <string name="settings_reply_color">Colore azione di risposta</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lt/strings.xml
+++ b/resources/src/commonMain/resources/MR/lt/strings.xml
@@ -287,4 +287,5 @@
     <string name="user_info_moderates">Moderatorius</string>
     <string name="user_info_admin">administratorius</string>
     <string name="settings_about_chat_matrix">Pokalbis Matrix</string>
+    <string name="settings_reply_color">Atsakymo veiksmo spalva</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lv/strings.xml
+++ b/resources/src/commonMain/resources/MR/lv/strings.xml
@@ -289,4 +289,5 @@
     <string name="user_info_moderates">Moderators no</string>
     <string name="user_info_admin">administrators</string>
     <string name="settings_about_chat_matrix">Tērzējiet Matrix</string>
+    <string name="settings_reply_color">Atbildes darbības krāsa</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/mt/strings.xml
+++ b/resources/src/commonMain/resources/MR/mt/strings.xml
@@ -290,4 +290,5 @@
     <string name="user_info_moderates">Moderatur ta\'</string>
     <string name="user_info_admin">amministratur</string>
     <string name="settings_about_chat_matrix">Chat fuq Matrix</string>
+    <string name="settings_reply_color">Kulur ta\' azzjoni ta\' risposta</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/nl/strings.xml
+++ b/resources/src/commonMain/resources/MR/nl/strings.xml
@@ -288,4 +288,5 @@
     <string name="user_info_moderates">Moderator van</string>
     <string name="user_info_admin">beheerder</string>
     <string name="settings_about_chat_matrix">Chatten op Matrix</string>
+    <string name="settings_reply_color">Kleur van antwoordactie</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/no/strings.xml
+++ b/resources/src/commonMain/resources/MR/no/strings.xml
@@ -287,4 +287,5 @@
     <string name="user_info_moderates">Moderator for</string>
     <string name="user_info_admin">administrator</string>
     <string name="settings_about_chat_matrix">Chat på Matrix</string>
+    <string name="settings_reply_color">Fargen på svarhandlingen</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pl/strings.xml
+++ b/resources/src/commonMain/resources/MR/pl/strings.xml
@@ -288,4 +288,5 @@
     <string name="user_info_moderates">Moderator</string>
     <string name="user_info_admin">administrator</string>
     <string name="settings_about_chat_matrix">Czat na Matrixie</string>
+    <string name="settings_reply_color">Kolor akcji odpowiedzi</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pt/strings.xml
+++ b/resources/src/commonMain/resources/MR/pt/strings.xml
@@ -287,4 +287,5 @@
     <string name="user_info_moderates">Moderador de</string>
     <string name="user_info_admin">administrador</string>
     <string name="settings_about_chat_matrix">Conversar no Matrix</string>
+    <string name="settings_reply_color">Cor da ação de resposta</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ro/strings.xml
+++ b/resources/src/commonMain/resources/MR/ro/strings.xml
@@ -286,4 +286,5 @@
     <string name="user_info_moderates">Moderator al</string>
     <string name="user_info_admin">administrator</string>
     <string name="settings_about_chat_matrix">Chat pe Matrix</string>
+    <string name="settings_reply_color">Culoare acțiunii de răspuns</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ru/strings.xml
+++ b/resources/src/commonMain/resources/MR/ru/strings.xml
@@ -288,4 +288,5 @@
     <string name="user_info_moderates">Модератор</string>
     <string name="user_info_admin">администратор</string>
     <string name="settings_about_chat_matrix">чат в Matrix</string>
+    <string name="settings_reply_color">Цвет действия ответа</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/se/strings.xml
+++ b/resources/src/commonMain/resources/MR/se/strings.xml
@@ -286,4 +286,5 @@
     <string name="user_info_moderates">Moderator för</string>
     <string name="user_info_admin">administratör</string>
     <string name="settings_about_chat_matrix">Chatta på Matrix</string>
+    <string name="settings_reply_color">Färg på svarsåtgärd</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sk/strings.xml
+++ b/resources/src/commonMain/resources/MR/sk/strings.xml
@@ -287,4 +287,5 @@
     <string name="user_info_moderates">Moderátorka</string>
     <string name="user_info_admin">správca</string>
     <string name="settings_about_chat_matrix">Chat na Matrixe</string>
+    <string name="settings_reply_color">Farba akcie odpovede</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sl/strings.xml
+++ b/resources/src/commonMain/resources/MR/sl/strings.xml
@@ -285,4 +285,5 @@
     <string name="user_info_moderates">Moderator od</string>
     <string name="user_info_admin">skrbnik</string>
     <string name="settings_about_chat_matrix">Klepet na Matrixu</string>
+    <string name="settings_reply_color">Barva dejanja odgovora</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sq/strings.xml
+++ b/resources/src/commonMain/resources/MR/sq/strings.xml
@@ -291,4 +291,5 @@
     <string name="user_info_moderates">Moderator i</string>
     <string name="user_info_admin">administratori</string>
     <string name="settings_about_chat_matrix">Bisedoni në Matrix</string>
+    <string name="settings_reply_color">Ngjyra e veprimit të përgjigjes</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/tr/strings.xml
+++ b/resources/src/commonMain/resources/MR/tr/strings.xml
@@ -288,4 +288,5 @@
     <string name="user_info_moderates">Moderatörü</string>
     <string name="user_info_admin">yönetici</string>
     <string name="settings_about_chat_matrix">Matrix\'te sohbet</string>
+    <string name="settings_reply_color">yanıt eyleminin rengi</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/uk/strings.xml
+++ b/resources/src/commonMain/resources/MR/uk/strings.xml
@@ -287,4 +287,5 @@
     <string name="user_info_moderates">Модератор</string>
     <string name="user_info_admin">адміністратор</string>
     <string name="settings_about_chat_matrix">чат на Matrix</string>
+    <string name="settings_reply_color">колір дії відповіді</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/App.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/App.kt
@@ -120,6 +120,7 @@ fun App(onLoadingFinished: () -> Unit = {}) {
             with(themeRepository) {
                 changeUpvoteColor(currentSettings.upvoteColor?.let { Color(it) })
                 changeDownvoteColor(currentSettings.downvoteColor?.let { Color(it) })
+                changeReplyColor(currentSettings.replyColor?.let { Color(it) })
             }
         }
 
@@ -153,6 +154,7 @@ fun App(onLoadingFinished: () -> Unit = {}) {
             with(themeRepository) {
                 changeUpvoteColor(settings.upvoteColor?.let { Color(it) })
                 changeDownvoteColor(settings.downvoteColor?.let { Color(it) })
+                changeReplyColor(settings.replyColor?.let { Color(it) })
             }
         }
     }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Reply
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.SyncDisabled
 import androidx.compose.material.icons.outlined.AddCircleOutline
@@ -156,6 +157,7 @@ class CommunityDetailScreen(
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
+        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         var rawContent by remember { mutableStateOf<Any?>(null) }
         val settingsRepository = remember { getSettingsRepository() }
@@ -540,6 +542,13 @@ class CommunityDetailScreen(
                                         DismissDirection.EndToStart,
                                     )
                                 },
+                                enableSecondAction = rememberCallbackArgs { value ->
+                                    if (!uiState.isLogged) {
+                                        false
+                                    } else {
+                                        value == DismissValue.DismissedToStart
+                                    }
+                                },
                                 backgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
                                         DismissValue.DismissedToStart -> upvoteColor
@@ -548,6 +557,12 @@ class CommunityDetailScreen(
                                         DismissValue.DismissedToEnd -> downvoteColor
                                             ?: defaultDownVoteColor
 
+                                        else -> Color.Transparent
+                                    }
+                                },
+                                secondBackgroundColor = rememberCallbackArgs { direction ->
+                                    when (direction) {
+                                        DismissValue.DismissedToStart -> defaultSecondActionColor
                                         else -> Color.Transparent
                                     }
                                 },
@@ -562,6 +577,17 @@ class CommunityDetailScreen(
                                         tint = Color.White,
                                     )
                                 },
+                                secondSwipeContent = { direction ->
+                                    val icon = when (direction) {
+                                        DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
+                                        DismissDirection.EndToStart -> Icons.Default.Reply
+                                    }
+                                    Icon(
+                                        imageVector = icon,
+                                        contentDescription = null,
+                                        tint = Color.White,
+                                    )
+                                },
                                 onGestureBegin = rememberCallback(model) {
                                     model.reduce(CommunityDetailMviModel.Intent.HapticIndication)
                                 },
@@ -569,6 +595,15 @@ class CommunityDetailScreen(
                                     model.reduce(
                                         CommunityDetailMviModel.Intent.UpVotePost(post.id),
                                     )
+                                },
+                                onSecondDismissToStart = rememberCallback(model) {
+                                    with(navigationCoordinator) {
+                                        setBottomSheetGesturesEnabled(false)
+                                        val screen = CreateCommentScreen(
+                                            originalPost = post,
+                                        )
+                                        showBottomSheet(screen)
+                                    }
                                 },
                                 onDismissToEnd = rememberCallback(model) {
                                     model.reduce(

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -156,8 +156,9 @@ class CommunityDetailScreen(
         val themeRepository = remember { getThemeRepository() }
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
+        val replyColor by themeRepository.replyColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
-        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
+        val defaultReplyColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         var rawContent by remember { mutableStateOf<Any?>(null) }
         val settingsRepository = remember { getSettingsRepository() }
@@ -562,7 +563,9 @@ class CommunityDetailScreen(
                                 },
                                 secondBackgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
-                                        DismissValue.DismissedToStart -> defaultSecondActionColor
+                                        DismissValue.DismissedToStart -> replyColor
+                                            ?: defaultReplyColor
+
                                         else -> Color.Transparent
                                     }
                                 },

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -102,8 +102,9 @@ class MultiCommunityScreen(
         val themeRepository = remember { getThemeRepository() }
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
+        val replyColor by themeRepository.replyColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
-        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
+        val defaultReplyColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
@@ -274,7 +275,7 @@ class MultiCommunityScreen(
                             },
                             secondBackgroundColor = rememberCallbackArgs { direction ->
                                 when (direction) {
-                                    DismissValue.DismissedToStart -> defaultSecondActionColor
+                                    DismissValue.DismissedToStart -> replyColor ?: defaultReplyColor
                                     else -> Color.Transparent
                                 }
                             },

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.ArrowCircleDown
 import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.Reply
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -77,6 +78,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallb
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.resources.MR
+import com.github.diegoberaldin.raccoonforlemmy.unit.createcomment.CreateCommentScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.createreport.CreateReportScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.multicommunity.di.getMultiCommunityViewModel
 import com.github.diegoberaldin.raccoonforlemmy.unit.web.WebViewScreen
@@ -101,6 +103,7 @@ class MultiCommunityScreen(
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
+        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
@@ -251,6 +254,13 @@ class MultiCommunityScreen(
                         SwipeableCard(
                             modifier = Modifier.fillMaxWidth(),
                             enabled = uiState.swipeActionsEnabled,
+                            enableSecondAction = rememberCallbackArgs { value ->
+                                if (!uiState.isLogged) {
+                                    false
+                                } else {
+                                    value == DismissValue.DismissedToStart
+                                }
+                            },
                             backgroundColor = {
                                 when (it) {
                                     DismissValue.DismissedToStart -> upvoteColor
@@ -262,11 +272,26 @@ class MultiCommunityScreen(
                                     DismissValue.Default -> Color.Transparent
                                 }
                             },
+                            secondBackgroundColor = rememberCallbackArgs { direction ->
+                                when (direction) {
+                                    DismissValue.DismissedToStart -> defaultSecondActionColor
+                                    else -> Color.Transparent
+                                }
+                            },
                             onGestureBegin = rememberCallback(model) {
                                 model.reduce(MultiCommunityMviModel.Intent.HapticIndication)
                             },
                             onDismissToStart = {
                                 model.reduce(MultiCommunityMviModel.Intent.UpVotePost(post.id))
+                            },
+                            onSecondDismissToStart = rememberCallback(model) {
+                                with(navigationCoordinator) {
+                                    setBottomSheetGesturesEnabled(false)
+                                    val screen = CreateCommentScreen(
+                                        originalPost = post,
+                                    )
+                                    showBottomSheet(screen)
+                                }
                             },
                             onDismissToEnd = {
                                 model.reduce(MultiCommunityMviModel.Intent.DownVotePost(post.id))
@@ -275,6 +300,17 @@ class MultiCommunityScreen(
                                 val icon = when (direction) {
                                     DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
                                     DismissDirection.EndToStart -> Icons.Default.ArrowCircleUp
+                                }
+                                Icon(
+                                    imageVector = icon,
+                                    contentDescription = null,
+                                    tint = Color.White,
+                                )
+                            },
+                            secondSwipeContent = { direction ->
+                                val icon = when (direction) {
+                                    DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
+                                    DismissDirection.EndToStart -> Icons.Default.Reply
                                 }
                                 Icon(
                                     imageVector = icon,

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -230,9 +230,6 @@ object ProfileLoggedScreen : Tab {
                                             )
                                         )
                                     },
-                                    onReply = rememberCallback {
-                                        detailOpener.openPostDetail(post)
-                                    },
                                     options = buildList {
                                         add(
                                             Option(
@@ -373,12 +370,6 @@ object ProfileLoggedScreen : Tab {
                                                 id = comment.id,
                                                 feedback = true
                                             )
-                                        )
-                                    },
-                                    onReply = rememberCallback {
-                                        detailOpener.openPostDetail(
-                                            post = PostModel(id = comment.postId),
-                                            highlightCommentId = comment.id,
                                         )
                                     },
                                     options = buildList {

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.ArrowCircleDown
 import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.Reply
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.SyncDisabled
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
@@ -108,6 +109,7 @@ class PostListScreen : Screen {
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
+        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         val lazyListState = rememberLazyListState()
         val drawerCoordinator = remember { getDrawerCoordinator() }
@@ -308,6 +310,13 @@ class PostListScreen : Screen {
                                         DismissDirection.EndToStart,
                                     )
                                 },
+                                enableSecondAction = rememberCallbackArgs { value ->
+                                    if (!uiState.isLogged) {
+                                        false
+                                    } else {
+                                        value == DismissValue.DismissedToStart
+                                    }
+                                },
                                 backgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
                                         DismissValue.DismissedToStart -> upvoteColor
@@ -319,11 +328,26 @@ class PostListScreen : Screen {
                                         DismissValue.Default -> Color.Transparent
                                     }
                                 },
+                                secondBackgroundColor = rememberCallbackArgs { direction ->
+                                    when (direction) {
+                                        DismissValue.DismissedToStart -> defaultSecondActionColor
+                                        else -> Color.Transparent
+                                    }
+                                },
                                 onGestureBegin = rememberCallback(model) {
                                     model.reduce(PostListMviModel.Intent.HapticIndication)
                                 },
                                 onDismissToStart = rememberCallback(model) {
                                     model.reduce(PostListMviModel.Intent.UpVotePost(post.id))
+                                },
+                                onSecondDismissToStart = rememberCallback(model) {
+                                    with(navigationCoordinator) {
+                                        setBottomSheetGesturesEnabled(false)
+                                        val screen = CreateCommentScreen(
+                                            originalPost = post,
+                                        )
+                                        showBottomSheet(screen)
+                                    }
                                 },
                                 onDismissToEnd = rememberCallback(model) {
                                     model.reduce(PostListMviModel.Intent.DownVotePost(post.id))
@@ -332,6 +356,17 @@ class PostListScreen : Screen {
                                     val icon = when (direction) {
                                         DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
                                         DismissDirection.EndToStart -> Icons.Default.ArrowCircleUp
+                                    }
+                                    Icon(
+                                        imageVector = icon,
+                                        contentDescription = null,
+                                        tint = Color.White,
+                                    )
+                                },
+                                secondSwipeContent = { direction ->
+                                    val icon = when (direction) {
+                                        DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
+                                        DismissDirection.EndToStart -> Icons.Default.Reply
                                     }
                                     Icon(
                                         imageVector = icon,

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -108,8 +108,9 @@ class PostListScreen : Screen {
         val themeRepository = remember { getThemeRepository() }
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
+        val replyColor by themeRepository.replyColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
-        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
+        val defaultReplyColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         val lazyListState = rememberLazyListState()
         val drawerCoordinator = remember { getDrawerCoordinator() }
@@ -330,7 +331,9 @@ class PostListScreen : Screen {
                                 },
                                 secondBackgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
-                                        DismissValue.DismissedToStart -> defaultSecondActionColor
+                                        DismissValue.DismissedToStart -> replyColor
+                                            ?: defaultReplyColor
+
                                         else -> Color.Transparent
                                     }
                                 },

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -144,8 +144,9 @@ class UserDetailScreen(
         val themeRepository = remember { getThemeRepository() }
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
+        val replyColor by themeRepository.replyColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
-        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
+        val defaultReplyColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         val navigationCoordinator = remember { getNavigationCoordinator() }
         var rawContent by remember { mutableStateOf<Any?>(null) }
@@ -452,7 +453,9 @@ class UserDetailScreen(
                                 },
                                 secondBackgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
-                                        DismissValue.DismissedToStart -> defaultSecondActionColor
+                                        DismissValue.DismissedToStart -> replyColor
+                                            ?: defaultReplyColor
+
                                         else -> Color.Transparent
                                     }
                                 },
@@ -721,7 +724,9 @@ class UserDetailScreen(
                                 },
                                 secondBackgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
-                                        DismissValue.DismissedToStart -> defaultSecondActionColor
+                                        DismissValue.DismissedToStart -> replyColor
+                                            ?: defaultReplyColor
+
                                         else -> Color.Transparent
                                     }
                                 },

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Reply
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -144,6 +145,7 @@ class UserDetailScreen(
         val upvoteColor by themeRepository.upvoteColor.collectAsState()
         val downvoteColor by themeRepository.downvoteColor.collectAsState()
         val defaultUpvoteColor = MaterialTheme.colorScheme.primary
+        val defaultSecondActionColor = MaterialTheme.colorScheme.secondary
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
         val navigationCoordinator = remember { getNavigationCoordinator() }
         var rawContent by remember { mutableStateOf<Any?>(null) }
@@ -430,6 +432,13 @@ class UserDetailScreen(
                                         DismissDirection.EndToStart,
                                     )
                                 },
+                                enableSecondAction = rememberCallbackArgs { value ->
+                                    if (!uiState.isLogged) {
+                                        false
+                                    } else {
+                                        value == DismissValue.DismissedToStart
+                                    }
+                                },
                                 backgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
                                         DismissValue.DismissedToStart -> upvoteColor
@@ -438,6 +447,12 @@ class UserDetailScreen(
                                         DismissValue.DismissedToEnd -> downvoteColor
                                             ?: defaultDownVoteColor
 
+                                        else -> Color.Transparent
+                                    }
+                                },
+                                secondBackgroundColor = rememberCallbackArgs { direction ->
+                                    when (direction) {
+                                        DismissValue.DismissedToStart -> defaultSecondActionColor
                                         else -> Color.Transparent
                                     }
                                 },
@@ -453,6 +468,17 @@ class UserDetailScreen(
                                         tint = Color.White,
                                     )
                                 },
+                                secondSwipeContent = { direction ->
+                                    val icon = when (direction) {
+                                        DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
+                                        DismissDirection.EndToStart -> Icons.Default.Reply
+                                    }
+                                    Icon(
+                                        imageVector = icon,
+                                        contentDescription = null,
+                                        tint = Color.White,
+                                    )
+                                },
                                 onGestureBegin = rememberCallback(model) {
                                     model.reduce(UserDetailMviModel.Intent.HapticIndication)
                                 },
@@ -460,6 +486,15 @@ class UserDetailScreen(
                                     model.reduce(
                                         UserDetailMviModel.Intent.UpVotePost(post.id),
                                     )
+                                },
+                                onSecondDismissToStart = rememberCallback(model) {
+                                    with(navigationCoordinator) {
+                                        setBottomSheetGesturesEnabled(false)
+                                        val screen = CreateCommentScreen(
+                                            originalPost = post,
+                                        )
+                                        showBottomSheet(screen)
+                                    }
                                 },
                                 onDismissToEnd = rememberCallback(model) {
                                     model.reduce(
@@ -666,6 +701,13 @@ class UserDetailScreen(
                                         DismissDirection.EndToStart,
                                     )
                                 },
+                                enableSecondAction = rememberCallbackArgs { value ->
+                                    if (!uiState.isLogged) {
+                                        false
+                                    } else {
+                                        value == DismissValue.DismissedToStart
+                                    }
+                                },
                                 backgroundColor = rememberCallbackArgs { direction ->
                                     when (direction) {
                                         DismissValue.DismissedToStart -> upvoteColor
@@ -674,6 +716,12 @@ class UserDetailScreen(
                                         DismissValue.DismissedToEnd -> downvoteColor
                                             ?: defaultDownVoteColor
 
+                                        else -> Color.Transparent
+                                    }
+                                },
+                                secondBackgroundColor = rememberCallbackArgs { direction ->
+                                    when (direction) {
+                                        DismissValue.DismissedToStart -> defaultSecondActionColor
                                         else -> Color.Transparent
                                     }
                                 },
@@ -688,6 +736,17 @@ class UserDetailScreen(
                                         tint = Color.White,
                                     )
                                 },
+                                secondSwipeContent = { direction ->
+                                    val icon = when (direction) {
+                                        DismissDirection.StartToEnd -> Icons.Default.ArrowCircleDown
+                                        DismissDirection.EndToStart -> Icons.Default.Reply
+                                    }
+                                    Icon(
+                                        imageVector = icon,
+                                        contentDescription = null,
+                                        tint = Color.White,
+                                    )
+                                },
                                 onGestureBegin = rememberCallback(model) {
                                     model.reduce(UserDetailMviModel.Intent.HapticIndication)
                                 },
@@ -695,6 +754,16 @@ class UserDetailScreen(
                                     model.reduce(
                                         UserDetailMviModel.Intent.UpVoteComment(comment.id),
                                     )
+                                },
+                                onSecondDismissToStart = rememberCallback(model) {
+                                    with(navigationCoordinator) {
+                                        setBottomSheetGesturesEnabled(false)
+                                        val screen = CreateCommentScreen(
+                                            originalPost = PostModel(id = comment.postId),
+                                            originalComment = comment,
+                                        )
+                                        showBottomSheet(screen)
+                                    }
                                 },
                                 onDismissToEnd = rememberCallback(model) {
                                     model.reduce(


### PR DESCRIPTION
This PR add the support for third and fourth swipe actions, in order to provide a quick way to reply to posts and comments as required in #268.

<div align="center">
<video src="https://github.com/diegoberaldin/RaccoonForLemmy/assets/2738294/96b61434-8ced-4990-911d-79d4248803e2"  width="310" />
</div>