### PR TITLE
chore: update sqlcipher

### DIFF
--- a/core/persistence/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/DefaultDriverFactory.kt
+++ b/core/persistence/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/DefaultDriverFactory.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.entities.AppDatabase
-import net.sqlcipher.database.SupportFactory
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 
 internal class DefaultDriverFactory(
     private val context: Context,
@@ -16,8 +16,9 @@ internal class DefaultDriverFactory(
     }
 
     override fun createDriver(): SqlDriver {
+        System.loadLibrary("sqlcipher")
         val key = keyProvider.getKey()
-        val supportFactory = SupportFactory(key)
+        val supportFactory = SupportOpenHelperFactory(key)
         return AndroidSqliteDriver(
             factory = supportFactory,
             schema = AppDatabase.Schema,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ markwon = "4.6.2"
 materialKolor = "1.3.0"
 moko_resources = "0.23.0"
 multiplatform_settings = "1.1.1"
-sqlcipher = "4.5.4"
+sqlcipher = "4.5.5"
 sqldelight = "2.0.1"
 voyager = "1.0.0"
 
@@ -92,7 +92,7 @@ voyager_transition = { module = "cafe.adriel.voyager:voyager-transitions", versi
 voyager_koin = { module = "cafe.adriel.voyager:voyager-koin", version.ref = "voyager" }
 voyager_androidx = { module = "cafe.adriel.voyager:voyager-koin", version.ref = "voyager" }
 
-sqlcipher = { module = "net.zetetic:android-database-sqlcipher", version.ref = "sqlcipher" }
+sqlcipher = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }
 sqldelight_android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight_native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 


### PR DESCRIPTION
This PR migrates from the deprecated `android-database-sqlcipher` to the new `sqlcipher-android` library.