### PR TITLE
enhancement: infinite scrolling

### DIFF
--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -321,5 +321,5 @@ private fun GetBy.toModel() = SettingsModel(
     contentFontFamily = contentFontFamily.toInt(),
     edgeToEdge = edgeToEdge != 0L,
     postBodyMaxLines = postBodyMaxLines?.toInt(),
-    infiniteScrollEnabled = edgeToEdge != 0L,
+    infiniteScrollEnabled = infiniteScrollEnabled != 0L,
 )

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
@@ -53,7 +53,7 @@ interface SettingsMviModel :
         data class ChangeSearchPostTitleOnly(val value: Boolean) : Intent
         data class ChangeEdgeToEdge(val value: Boolean) : Intent
         data class ChangePostBodyMaxLines(val value: Int) : Intent
-        data class ChangeInfiniteScrollEnabled(val value: Boolean) : Intent
+        data class ChangeInfiniteScrollDisabled(val value: Boolean) : Intent
     }
 
     data class UiState(
@@ -96,7 +96,7 @@ interface SettingsMviModel :
         val searchPostTitleOnly: Boolean = false,
         val edgeToEdge: Boolean = true,
         val postBodyMaxLines: Int? = null,
-        val infiniteScrollEnabled: Boolean = true,
+        val infiniteScrollDisabled: Boolean = false,
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -475,11 +475,11 @@ class SettingsScreen : Screen {
 
                     // infinite scrolling
                     SettingsSwitchRow(
-                        title = stringResource(MR.strings.settings_infinite_scroll_enabled),
-                        value = uiState.infiniteScrollEnabled,
+                        title = stringResource(MR.strings.settings_infinite_scroll_disabled),
+                        value = uiState.infiniteScrollDisabled,
                         onValueChanged = rememberCallbackArgs(model) { value ->
                             model.reduce(
-                                SettingsMviModel.Intent.ChangeInfiniteScrollEnabled(value)
+                                SettingsMviModel.Intent.ChangeInfiniteScrollDisabled(value)
                             )
                         },
                     )

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
@@ -218,7 +218,7 @@ class SettingsViewModel(
                 searchPostTitleOnly = settings.searchPostTitleOnly,
                 edgeToEdge = settings.edgeToEdge,
                 postBodyMaxLines = settings.postBodyMaxLines,
-                infiniteScrollEnabled = settings.infiniteScrollEnabled,
+                infiniteScrollDisabled = !settings.infiniteScrollEnabled,
             )
         }
     }
@@ -361,8 +361,8 @@ class SettingsViewModel(
                 changePostBodyMaxLines(intent.value)
             }
 
-            is SettingsMviModel.Intent.ChangeInfiniteScrollEnabled -> {
-                changeInfiniteScrollEnabled(intent.value)
+            is SettingsMviModel.Intent.ChangeInfiniteScrollDisabled -> {
+                changeInfiniteScrollDisabled(intent.value)
             }
         }
     }
@@ -708,11 +708,11 @@ class SettingsViewModel(
         }
     }
 
-    private fun changeInfiniteScrollEnabled(value: Boolean) {
-        mvi.updateState { it.copy(infiniteScrollEnabled = value) }
+    private fun changeInfiniteScrollDisabled(value: Boolean) {
+        mvi.updateState { it.copy(infiniteScrollDisabled = value) }
         mvi.scope?.launch(Dispatchers.IO) {
             val settings = settingsRepository.currentSettings.value.copy(
-                infiniteScrollEnabled = value
+                infiniteScrollEnabled = !value
             )
             saveSettings(settings)
         }

--- a/resources/src/commonMain/resources/MR/ar/strings.xml
+++ b/resources/src/commonMain/resources/MR/ar/strings.xml
@@ -308,5 +308,5 @@
     <string name="settings_post_body_max_lines_unlimited">غير محدود</string>
     <string name="message_content_removed">(تمت إزالة هذا المحتوى)</string>
     <string name="post_list_load_more_posts">تحميل المزيد من المشاركات</string>
-    <string name="settings_infinite_scroll_enabled">تمكين التمرير اللانهائي</string>
+    <string name="settings_infinite_scroll_disabled">تعطيل التمرير اللانهائي</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/base/strings.xml
+++ b/resources/src/commonMain/resources/MR/base/strings.xml
@@ -339,5 +339,5 @@
     <string name="settings_post_body_max_lines_unlimited">Unlimited</string>
     <string name="message_content_removed">(this content has been removed)</string>
     <string name="post_list_load_more_posts">Load more posts</string>
-    <string name="settings_infinite_scroll_enabled">Enable infinite scrolling</string>
+    <string name="settings_infinite_scroll_disabled">Disable infinite scrolling</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/bg/strings.xml
+++ b/resources/src/commonMain/resources/MR/bg/strings.xml
@@ -318,5 +318,5 @@
     <string name="settings_post_body_max_lines_unlimited">Неограничен</string>
     <string name="message_content_removed">(това съдържание е премахнато)</string>
     <string name="post_list_load_more_posts">Зареди още публикации</string>
-    <string name="settings_infinite_scroll_enabled">Активиране на безкрайно превъртане</string>
+    <string name="settings_infinite_scroll_disabled">Деактивирайте безкрайното превъртане</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/cs/strings.xml
+++ b/resources/src/commonMain/resources/MR/cs/strings.xml
@@ -310,5 +310,5 @@
     <string name="settings_post_body_max_lines_unlimited">Neomezený</string>
     <string name="message_content_removed">(tento obsah byl odstraněn)</string>
     <string name="post_list_load_more_posts">Načíst další příspěvky</string>
-    <string name="settings_infinite_scroll_enabled">Povolit nekonečné posouvání</string>
+    <string name="settings_infinite_scroll_disabled">Zakázat nekonečné posouvání</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/da/strings.xml
+++ b/resources/src/commonMain/resources/MR/da/strings.xml
@@ -310,5 +310,5 @@
     <string name="settings_post_body_max_lines_unlimited">Ubegrænset</string>
     <string name="message_content_removed">(dette indhold er blevet fjernet)</string>
     <string name="post_list_load_more_posts">Indlæs flere indlæg</string>
-    <string name="settings_infinite_scroll_enabled">Aktiver uendelig rulning</string>
+    <string name="settings_infinite_scroll_disabled">Deaktiver uendelig rulning</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/de/strings.xml
+++ b/resources/src/commonMain/resources/MR/de/strings.xml
@@ -318,5 +318,5 @@
     <string name="settings_post_body_max_lines_unlimited">Unbegrenzt</string>
     <string name="message_content_removed">(dieser Inhalt wurde entfernt)</string>
     <string name="post_list_load_more_posts">Mehr Beiträge laden</string>
-    <string name="settings_infinite_scroll_enabled">Aktivieren Sie unendliches Scrollen</string>
+    <string name="settings_infinite_scroll_disabled">Deaktivieren Sie das unendliche Scrollen</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/el/strings.xml
+++ b/resources/src/commonMain/resources/MR/el/strings.xml
@@ -321,5 +321,5 @@
     <string name="settings_post_body_max_lines_unlimited">Απεριόριστος</string>
     <string name="message_content_removed">(αυτό το περιεχόμενο έχει αφαιρεθεί)</string>
     <string name="post_list_load_more_posts">Φόρτωση περισσότερων αναρτήσεων</string>
-    <string name="settings_infinite_scroll_enabled">Ενεργοποίηση άπειρης κύλισης</string>
+    <string name="settings_infinite_scroll_disabled">Απενεργοποιήστε άπειρης κύλισης</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/eo/strings.xml
+++ b/resources/src/commonMain/resources/MR/eo/strings.xml
@@ -309,5 +309,5 @@
     <string name="settings_post_body_max_lines_unlimited">Senlima</string>
     <string name="message_content_removed">(ĉi tiu enhavo estis forigita)</string>
     <string name="post_list_load_more_posts">Ŝarĝi pli da afiŝoj</string>
-    <string name="settings_infinite_scroll_enabled">Ebligi senfinan movadadon</string>
+    <string name="settings_infinite_scroll_disabled">Malebligi senfinan movadadon</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/es/strings.xml
+++ b/resources/src/commonMain/resources/MR/es/strings.xml
@@ -311,5 +311,5 @@
     <string name="settings_post_body_max_lines_unlimited">Ilimitado</string>
     <string name="message_content_removed">(este contenido ha sido eliminado)</string>
     <string name="post_list_load_more_posts">Cargar más publicaciones</string>
-    <string name="settings_infinite_scroll_enabled">Habilitar desplazamiento infinito</string>
+    <string name="settings_infinite_scroll_disabled">Desactivar desplazamiento infinito</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/et/strings.xml
+++ b/resources/src/commonMain/resources/MR/et/strings.xml
@@ -310,5 +310,5 @@
     <string name="settings_post_body_max_lines_unlimited">Piiramatu</string>
     <string name="message_content_removed">(see sisu on eemaldatud)</string>
     <string name="post_list_load_more_posts">Laadige rohkem postitusi</string>
-    <string name="settings_infinite_scroll_enabled">Luba lõpmatu kerimine</string>
+    <string name="settings_infinite_scroll_disabled">Keela lõpmatu kerimine</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fi/strings.xml
+++ b/resources/src/commonMain/resources/MR/fi/strings.xml
@@ -310,5 +310,5 @@
     <string name="settings_post_body_max_lines_unlimited">Rajoittamaton</string>
     <string name="message_content_removed">(tämä sisältö on poistettu)</string>
     <string name="post_list_load_more_posts">Lataa lisää viestejä</string>
-    <string name="settings_infinite_scroll_enabled">Ota käyttöön loputon vieritys</string>
+    <string name="settings_infinite_scroll_disabled">Poista loputon vieritys käytöstä</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/fr/strings.xml
+++ b/resources/src/commonMain/resources/MR/fr/strings.xml
@@ -315,5 +315,5 @@
     <string name="settings_post_body_max_lines_unlimited">Illimité</string>
     <string name="message_content_removed">(ce contenu a été supprimé)</string>
     <string name="post_list_load_more_posts">Charger plus de messages</string>
-    <string name="settings_infinite_scroll_enabled">Activer le défilement infini</string>
+    <string name="settings_infinite_scroll_disabled">Désactiver le défilement infini</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ga/strings.xml
+++ b/resources/src/commonMain/resources/MR/ga/strings.xml
@@ -319,5 +319,5 @@
     <string name="settings_post_body_max_lines_unlimited">Gan teorainn</string>
     <string name="message_content_removed">(tá an t-ábhar seo bainte)</string>
     <string name="post_list_load_more_posts">Luchtaigh tuilleadh post</string>
-    <string name="settings_infinite_scroll_enabled">Cumasaigh scrollaigh gan teorainn</string>
+    <string name="settings_infinite_scroll_disabled">Díchumasaigh scrollaigh gan teorainn</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hr/strings.xml
+++ b/resources/src/commonMain/resources/MR/hr/strings.xml
@@ -315,5 +315,5 @@
     <string name="settings_post_body_max_lines_unlimited">Neograničen</string>
     <string name="message_content_removed">(ovaj sadržaj je uklonjen)</string>
     <string name="post_list_load_more_posts">Učitaj još postova</string>
-    <string name="settings_infinite_scroll_enabled">Omogućite beskonačno pomicanje</string>
+    <string name="settings_infinite_scroll_disabled">Onemogući beskonačno pomicanje</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/hu/strings.xml
+++ b/resources/src/commonMain/resources/MR/hu/strings.xml
@@ -314,5 +314,5 @@
     <string name="settings_post_body_max_lines_unlimited">Korlátlan</string>
     <string name="message_content_removed">(ezt a tartalmat eltávolítottuk)</string>
     <string name="post_list_load_more_posts">További bejegyzések betöltése</string>
-    <string name="settings_infinite_scroll_enabled">Engedélyezze a végtelen görgetést</string>
+    <string name="settings_infinite_scroll_disabled">A végtelen görgetés letiltása</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/it/strings.xml
+++ b/resources/src/commonMain/resources/MR/it/strings.xml
@@ -314,5 +314,5 @@
     <string name="settings_post_body_max_lines_unlimited">Illimitato</string>
     <string name="message_content_removed">(questo contenuto è stato rimosso)</string>
     <string name="post_list_load_more_posts">Carica altri post</string>
-    <string name="settings_infinite_scroll_enabled">Abilita scorrimento infinito</string>
+    <string name="settings_infinite_scroll_disabled">Disabilita scorrimento infinito</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lt/strings.xml
+++ b/resources/src/commonMain/resources/MR/lt/strings.xml
@@ -312,5 +312,5 @@
     <string name="settings_post_body_max_lines_unlimited">Neribota</string>
     <string name="message_content_removed">(šis turinys pašalintas)</string>
     <string name="post_list_load_more_posts">Įkelti daugiau pranešimų</string>
-    <string name="settings_infinite_scroll_enabled">Įgalinti begalinį slinkimą</string>
+    <string name="settings_infinite_scroll_disabled">Išjungti begalinį slinkimą</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/lv/strings.xml
+++ b/resources/src/commonMain/resources/MR/lv/strings.xml
@@ -314,5 +314,5 @@
     <string name="settings_post_body_max_lines_unlimited">Neierobežots</string>
     <string name="message_content_removed">(šis saturs ir noņemts)</string>
     <string name="post_list_load_more_posts">Ielādēt vairāk ziņu</string>
-    <string name="settings_infinite_scroll_enabled">Iespējot bezgalīgu ritināšanu</string>
+    <string name="settings_infinite_scroll_disabled">Atspējot bezgalīgu ritināšanu</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/mt/strings.xml
+++ b/resources/src/commonMain/resources/MR/mt/strings.xml
@@ -315,5 +315,5 @@
     <string name="settings_post_body_max_lines_unlimited">Illimitat</string>
     <string name="message_content_removed">(dan il-kontenut tneħħa)</string>
     <string name="post_list_load_more_posts">Tagħbija aktar postijiet</string>
-    <string name="settings_infinite_scroll_enabled">Ippermetti scrolling infinit</string>
+    <string name="settings_infinite_scroll_disabled">Itfi scrolling infinit</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/nl/strings.xml
+++ b/resources/src/commonMain/resources/MR/nl/strings.xml
@@ -313,5 +313,5 @@
     <string name="settings_post_body_max_lines_unlimited">Onbeperkt</string>
     <string name="message_content_removed">(deze inhoud is verwijderd)</string>
     <string name="post_list_load_more_posts">Laad meer berichten</string>
-    <string name="settings_infinite_scroll_enabled">Schakel oneindig scrollen in</string>
+    <string name="settings_infinite_scroll_disabled">Schakel oneindig scrollen uit</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/no/strings.xml
+++ b/resources/src/commonMain/resources/MR/no/strings.xml
@@ -312,5 +312,5 @@
     <string name="settings_post_body_max_lines_unlimited">Ubegrenset</string>
     <string name="message_content_removed">(dette innholdet er fjernet)</string>
     <string name="post_list_load_more_posts">Last inn flere innlegg</string>
-    <string name="settings_infinite_scroll_enabled">Aktiver uendelig rulling</string>
+    <string name="settings_infinite_scroll_disabled">Deaktiver uendelig rulling</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pl/strings.xml
+++ b/resources/src/commonMain/resources/MR/pl/strings.xml
@@ -313,5 +313,5 @@
     <string name="settings_post_body_max_lines_unlimited">Nieograniczony</string>
     <string name="message_content_removed">(ta treść została usunięta)</string>
     <string name="post_list_load_more_posts">Załaduj więcej postów</string>
-    <string name="settings_infinite_scroll_enabled">Włącz nieskończone przewijanie</string>
+    <string name="settings_infinite_scroll_disabled">Wyłącz nieskończone przewijanie</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/pt/strings.xml
+++ b/resources/src/commonMain/resources/MR/pt/strings.xml
@@ -312,5 +312,5 @@
     <string name="settings_post_body_max_lines_unlimited">Ilimitado</string>
     <string name="message_content_removed">(este conteúdo foi removido)</string>
     <string name="post_list_load_more_posts">Carregar mais postagens</string>
-    <string name="settings_infinite_scroll_enabled">Ativar rolagem infinita</string>
+    <string name="settings_infinite_scroll_disabled">Desativar rolagem infinita</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ro/strings.xml
+++ b/resources/src/commonMain/resources/MR/ro/strings.xml
@@ -311,5 +311,5 @@
     <string name="settings_post_body_max_lines_unlimited">Nelimitat</string>
     <string name="message_content_removed">(acest conținut a fost eliminat)</string>
     <string name="post_list_load_more_posts">Încărcă mai multe postări</string>
-    <string name="settings_infinite_scroll_enabled">Activează derularea infinită</string>
+    <string name="settings_infinite_scroll_disabled">Dezactivează derularea infinită</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/ru/strings.xml
+++ b/resources/src/commonMain/resources/MR/ru/strings.xml
@@ -314,5 +314,5 @@
     <string name="settings_post_body_max_lines_unlimited">Безлимитный</string>
     <string name="message_content_removed">(этот контент был удален)</string>
     <string name="post_list_load_more_posts">Загрузить больше сообщений</string>
-    <string name="settings_infinite_scroll_enabled">Включить бесконечную прокрутку</string>
+    <string name="settings_infinite_scroll_disabled">Отключить бесконечную прокрутку</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/se/strings.xml
+++ b/resources/src/commonMain/resources/MR/se/strings.xml
@@ -311,5 +311,5 @@
     <string name="settings_post_body_max_lines_unlimited">Obegränsat</string>
     <string name="message_content_removed">(detta innehåll har tagits bort)</string>
     <string name="post_list_load_more_posts">Ladda fler inlägg</string>
-    <string name="settings_infinite_scroll_enabled">Aktivera oändlig rullning</string>
+    <string name="settings_infinite_scroll_disabled">Inaktivera oändlig rullning</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sk/strings.xml
+++ b/resources/src/commonMain/resources/MR/sk/strings.xml
@@ -312,5 +312,5 @@
     <string name="settings_post_body_max_lines_unlimited">Neobmedzené</string>
     <string name="message_content_removed">(tento obsah bol odstránený)</string>
     <string name="post_list_load_more_posts">Načítať viac príspevkov</string>
-    <string name="settings_infinite_scroll_enabled">Povoliť nekonečné posúvanie</string>
+    <string name="settings_infinite_scroll_disabled">Zakázať nekonečné posúvanie</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sl/strings.xml
+++ b/resources/src/commonMain/resources/MR/sl/strings.xml
@@ -310,5 +310,5 @@
     <string name="settings_post_body_max_lines_unlimited">Neomejeno</string>
     <string name="message_content_removed">(ta vsebina je bila odstranjena)</string>
     <string name="post_list_load_more_posts">Naloži več objav</string>
-    <string name="settings_infinite_scroll_enabled">Omogoči neskončno drsenje</string>
+    <string name="settings_infinite_scroll_disabled">Onemogoči neskončno drsenje</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/sq/strings.xml
+++ b/resources/src/commonMain/resources/MR/sq/strings.xml
@@ -316,5 +316,5 @@
     <string name="settings_post_body_max_lines_unlimited">E pakufizuar</string>
     <string name="message_content_removed">(kjo përmbajtje është hequr)</string>
     <string name="post_list_load_more_posts">Ngarko më shumë postime</string>
-    <string name="settings_infinite_scroll_enabled">Aktivizo lëvizjen e pafund</string>
+    <string name="settings_infinite_scroll_disabled">Çaktivizo lëvizjen e pafund</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/tr/strings.xml
+++ b/resources/src/commonMain/resources/MR/tr/strings.xml
@@ -313,5 +313,5 @@
     <string name="settings_post_body_max_lines_unlimited">Sınırsız</string>
     <string name="message_content_removed">(bu içerik kaldırıldı)</string>
     <string name="post_list_load_more_posts">Daha fazla gönderi yükle</string>
-    <string name="settings_infinite_scroll_enabled">Sonsuz kaydırmayı etkinleştir</string>
+    <string name="settings_infinite_scroll_disabled">Sonsuz kaydırmayı devre dışı bırak</string>
 </resources>

--- a/resources/src/commonMain/resources/MR/uk/strings.xml
+++ b/resources/src/commonMain/resources/MR/uk/strings.xml
@@ -312,5 +312,5 @@
     <string name="settings_post_body_max_lines_unlimited">Необмежений</string>
     <string name="message_content_removed">(цей вміст було видалено)</string>
     <string name="post_list_load_more_posts">Завантажити більше дописів</string>
-    <string name="settings_infinite_scroll_enabled">Увімкніть нескінченне прокручування</string>
+    <string name="settings_infinite_scroll_disabled">Вимкнути нескінченне прокручування</string>
 </resources>


### PR DESCRIPTION
This PR fixes a bug in the mapping of settings which prevented infinite scrolling from being applied after application restart. Moreover, it flips the semantics of the option in the settings screen. 