### PR TITLE
fix: formatting bar actions

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/TextFormattingBar.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/TextFormattingBar.kt
@@ -60,6 +60,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val selection = textFieldValue.selection
                         val newValue = textFieldValue.let {
@@ -80,7 +81,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -89,13 +90,14 @@ fun TextFormattingBar(
                             } else {
                                 TextRange(
                                     start = it.selection.start + 2,
-                                    end = it.selection.end + 2
+                                    end = it.selection.end + 2,
                                 )
                             }
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.FormatBold,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -106,6 +108,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val selection = textFieldValue.selection
                         val newValue = textFieldValue.let {
@@ -118,7 +121,7 @@ fun TextFormattingBar(
                                     append(
                                         it.text.substring(
                                             selection.start,
-                                            selection.end
+                                            selection.end,
                                         )
                                     )
                                 }
@@ -126,7 +129,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -135,13 +138,14 @@ fun TextFormattingBar(
                             } else {
                                 TextRange(
                                     start = it.selection.start + 1,
-                                    end = it.selection.end + 1
+                                    end = it.selection.end + 1,
                                 )
                             }
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.FormatItalic,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -152,6 +156,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val selection = textFieldValue.selection
                         val newValue = textFieldValue.let {
@@ -164,7 +169,7 @@ fun TextFormattingBar(
                                     append(
                                         it.text.substring(
                                             selection.start,
-                                            selection.end
+                                            selection.end,
                                         )
                                     )
                                 }
@@ -172,7 +177,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -181,13 +186,14 @@ fun TextFormattingBar(
                             } else {
                                 TextRange(
                                     start = it.selection.start + 2,
-                                    end = it.selection.end + 2
+                                    end = it.selection.end + 2,
                                 )
                             }
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.FormatStrikethrough,
                 tint = MaterialTheme.colorScheme.onBackground,
                 contentDescription = null,
@@ -226,7 +232,7 @@ fun TextFormattingBar(
                                     append(
                                         it.text.substring(
                                             selection.start,
-                                            selection.end
+                                            selection.end,
                                         )
                                     )
                                 }
@@ -236,7 +242,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -245,13 +251,14 @@ fun TextFormattingBar(
                             } else {
                                 TextRange(
                                     start = it.selection.start + 1,
-                                    end = it.selection.end + 1
+                                    end = it.selection.end + 1,
                                 )
                             }
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.InsertLink,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -262,6 +269,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val newValue = textFieldValue.let {
                             val selection = it.selection
@@ -274,7 +282,7 @@ fun TextFormattingBar(
                                     append(
                                         it.text.substring(
                                             selection.start,
-                                            selection.end
+                                            selection.end,
                                         )
                                     )
                                 }
@@ -282,7 +290,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -291,13 +299,14 @@ fun TextFormattingBar(
                             } else {
                                 TextRange(
                                     start = it.selection.start + 1,
-                                    end = it.selection.end + 1
+                                    end = it.selection.end + 1,
                                 )
                             }
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.Code,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -308,6 +317,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val newValue = textFieldValue.let {
                             val selection = it.selection
@@ -317,7 +327,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -325,7 +335,8 @@ fun TextFormattingBar(
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.FormatQuote,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -336,6 +347,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val newValue = textFieldValue.let {
                             val selection = it.selection
@@ -345,7 +357,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -353,7 +365,8 @@ fun TextFormattingBar(
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.FormatListBulleted,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -364,6 +377,7 @@ fun TextFormattingBar(
         item {
             Icon(
                 modifier = Modifier.onClick(
+                    key = textFieldValue,
                     onClick = {
                         val newValue = textFieldValue.let {
                             val selection = it.selection
@@ -373,7 +387,7 @@ fun TextFormattingBar(
                                 append(
                                     it.text.substring(
                                         selection.end,
-                                        it.text.length
+                                        it.text.length,
                                     )
                                 )
                             }
@@ -381,7 +395,8 @@ fun TextFormattingBar(
                             it.copy(text = newText, selection = newSelection)
                         }
                         onTextFieldValueChanged(newValue)
-                    }),
+                    },
+                ),
                 imageVector = Icons.Default.FormatListNumbered,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
@@ -397,7 +412,7 @@ fun TextFormattingBar(
                         .border(
                             color = MaterialTheme.colorScheme.onBackground,
                             width = Dp.Hairline,
-                            shape = RoundedCornerShape(CornerSize.m)
+                            shape = RoundedCornerShape(CornerSize.m),
                         )
                         .clickable(onClick = onSelectLanguage)
                         .padding(Spacing.xxxs),
@@ -406,7 +421,7 @@ fun TextFormattingBar(
                     val languageCode = availableLanguages.firstOrNull { l ->
                         l.id == currentLanguageId
                     }?.takeIf { l ->
-                        l.id > 0 // undetermied language
+                        l.id > 0 // undetermined language
                     }?.code ?: "λ"
                     Text(
                         text = languageCode,
@@ -425,7 +440,8 @@ fun TextFormattingBar(
                     modifier = Modifier.onClick(
                         onClick = {
                             onLastAction()
-                        }),
+                        },
+                    ),
                     imageVector = lastActionIcon,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onBackground,

--- a/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/compose/OnClick.kt
+++ b/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/compose/OnClick.kt
@@ -10,19 +10,20 @@ import androidx.compose.ui.Modifier
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun Modifier.onClick(
+    key: Any = Unit,
     onClick: () -> Unit = {},
     onDoubleClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
 ): Modifier = combinedClickable(
     indication = null,
     interactionSource = remember { MutableInteractionSource() },
-    onClick = rememberCallback {
+    onClick = rememberCallback(key) {
         onClick()
     },
-    onDoubleClick = rememberCallback {
+    onDoubleClick = rememberCallback(key) {
         onDoubleClick()
     },
-    onLongClick = rememberCallback {
+    onLongClick = rememberCallback(key) {
         onLongClick()
     }
 )

--- a/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -109,7 +109,7 @@ class CreateCommentScreen(
         var textFieldValue by remember {
             mutableStateOf(
                 TextFieldValue(
-                    text = (initialText ?: uiState.editedComment?.text).orEmpty()
+                    text = (initialText ?: uiState.editedComment?.text).orEmpty(),
                 )
             )
         }


### PR DESCRIPTION
This PR solves a bug that led to the content of text fields with a formatting bar to be overridden instead of appending the formatted part. The bug was due to the new onClick modifier introduced in #414.