### PR TITLE
fix: do not collapse comments while clicking on spoilers

### DIFF
--- a/core/md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/plugins/MarkwonSpoilerPlugin.kt
+++ b/core/md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/plugins/MarkwonSpoilerPlugin.kt
@@ -19,11 +19,22 @@ class SpoilerCloseSpan
  * Originally inspired by:
  * https://github.com/dessalines/jerboa/blob/main/app/src/main/java/com/jerboa/util/markwon/MarkwonSpoilerPlugin.kt
  */
-class MarkwonSpoilerPlugin private constructor(private val enableInteraction: Boolean) :
+class MarkwonSpoilerPlugin private constructor(
+    private val enableInteraction: Boolean,
+    private val onInteraction: () -> Unit,
+) :
     AbstractMarkwonPlugin() {
 
     companion object {
-        fun create(enableInteraction: Boolean) = MarkwonSpoilerPlugin(enableInteraction)
+        fun create(
+            enableInteraction: Boolean = true,
+            onInteraction: () -> Unit = {},
+        ): MarkwonSpoilerPlugin {
+            return MarkwonSpoilerPlugin(
+                enableInteraction = enableInteraction,
+                onInteraction = onInteraction,
+            )
+        }
     }
 
     override fun configure(registry: MarkwonPlugin.Registry) {
@@ -72,6 +83,7 @@ class MarkwonSpoilerPlugin private constructor(private val enableInteraction: Bo
                         textView = textView,
                         spoilerTitle = startSpan.title.toString(),
                         spoilerContent = spoilerContent.toString(),
+                        onInteraction = onInteraction,
                     )
 
                     // Set spoiler block type as ClickableSpan
@@ -101,12 +113,14 @@ private class SpoilerClickableSpan(
     private val textView: TextView,
     private val spoilerTitle: String,
     private val spoilerContent: String,
+    private val onInteraction: () -> Unit,
 ) : ClickableSpan() {
 
     private var open = false
 
     override fun onClick(view: View) {
         if (enableInteraction) {
+            onInteraction()
             textView.cancelPendingInputEvents()
             val spanned = SpannableStringBuilder(textView.text)
             val title = getSpoilerTitle(open, spoilerTitle)

--- a/core/md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/DefaultMarkwonProvider.kt
+++ b/core/md/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/provider/DefaultMarkwonProvider.kt
@@ -42,18 +42,28 @@ class DefaultMarkwonProvider(
             .usePlugin(StrikethroughPlugin.create())
             .usePlugin(TablePlugin.create(context))
             .usePlugin(HtmlPlugin.create())
-            .usePlugin(MarkwonSpoilerPlugin.create(true))
+            .usePlugin(
+                MarkwonSpoilerPlugin.create(
+                    onInteraction =  {
+                        blockClickPropagation.value = true
+                        scope.launch {
+                            delay(OPEN_LINK_DELAY)
+                            blockClickPropagation.value = false
+                        }
+                    }
+                )
+            )
             .run {
                 val imageLoader = getCoilImageLoader(context)
                 usePlugin(CoilImagesPlugin.create(context, imageLoader))
             }
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun beforeSetText(textView: TextView, markdown: Spanned) {
-                    AsyncDrawableScheduler.unschedule(textView);
+                    AsyncDrawableScheduler.unschedule(textView)
                 }
 
                 override fun afterSetText(textView: TextView) {
-                    AsyncDrawableScheduler.schedule(textView);
+                    AsyncDrawableScheduler.schedule(textView)
                 }
             })
             .usePlugin(


### PR DESCRIPTION
Thanks rb_c for this report, it was a really tricky behaviour!