### PR TITLE
fix: close drawer after instance change

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultDrawerCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultDrawerCoordinator.kt
@@ -9,7 +9,11 @@ class DefaultDrawerCoordinator : DrawerCoordinator {
     override val gesturesEnabled = MutableStateFlow(true)
 
     override suspend fun toggleDrawer() {
-        events.emit(DrawerEvent.Toggled)
+        events.emit(DrawerEvent.Toggle)
+    }
+
+    override suspend fun closeDrawer() {
+        events.emit(DrawerEvent.Close)
     }
 
     override suspend fun sendEvent(event: DrawerEvent) {

--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DrawerCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DrawerCoordinator.kt
@@ -8,7 +8,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 sealed interface DrawerEvent {
-    data object Toggled : DrawerEvent
+    data object Toggle : DrawerEvent
+    data object Close : DrawerEvent
     data class OpenCommunity(val community: CommunityModel) : DrawerEvent
     data class OpenMultiCommunity(val community: MultiCommunityModel) : DrawerEvent
     data object ManageSubscriptions : DrawerEvent
@@ -20,7 +21,9 @@ sealed interface DrawerEvent {
 interface DrawerCoordinator {
     val events: SharedFlow<DrawerEvent>
     val gesturesEnabled: StateFlow<Boolean>
+
     suspend fun toggleDrawer()
+    suspend fun closeDrawer()
     suspend fun sendEvent(event: DrawerEvent)
     fun setGesturesEnabled(value: Boolean)
 }

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/App.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/App.kt
@@ -185,12 +185,22 @@ fun App(onLoadingFinished: () -> Unit = {}) {
     LaunchedEffect(drawerCoordinator) {
         drawerCoordinator.events.onEach { evt ->
             when (evt) {
-                DrawerEvent.Toggled -> {
+                DrawerEvent.Toggle -> {
                     drawerState.apply {
                         launch {
                             if (isClosed) {
                                 open()
                             } else {
+                                close()
+                            }
+                        }
+                    }
+                }
+
+                DrawerEvent.Close -> {
+                    drawerState.apply {
+                        launch {
+                            if (!isClosed) {
                                 close()
                             }
                         }

--- a/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
+++ b/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
@@ -99,7 +99,7 @@ object ModalDrawerContent : Tab {
         LaunchedEffect(notificationCenter) {
             notificationCenter.subscribe(NotificationCenterEvent.InstanceSelected::class).onEach {
                 // closes the navigation drawer after instance change
-                coordinator.toggleDrawer()
+                coordinator.closeDrawer()
             }.launchIn(this)
         }
 


### PR DESCRIPTION
This PR prevents the drawer from being opened when changing instance from the top bar.