### PR TITLE
chore: share images as text

### DIFF
--- a/unit/zoomableimage/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/zoomableimage/ZoomableImageViewModel.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/zoomableimage/ZoomableImageViewModel.kt
@@ -34,7 +34,7 @@ class ZoomableImageViewModel(
         when (intent) {
             is ZoomableImageMviModel.Intent.Share -> {
                 runCatching {
-                    shareHelper.share(intent.url, "image/*")
+                    shareHelper.share(intent.url)
                 }
             }
 


### PR DESCRIPTION
This is a temporary workaround for Whatsapp sharing broken.