### PR TITLE
chore: remove unread indicator for private messages

### DIFF
--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesMviModel.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesMviModel.kt
@@ -12,7 +12,6 @@ interface InboxMessagesMviModel :
     sealed interface Intent {
         data object Refresh : Intent
         data object LoadNextPage : Intent
-        data class MarkAsRead(val read: Boolean, val id: Int) : Intent
     }
 
     data class UiState(

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesScreen.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesScreen.kt
@@ -40,6 +40,8 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallb
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.otherUser
 import com.github.diegoberaldin.raccoonforlemmy.unit.chat.InboxChatScreen
+import com.github.diegoberaldin.raccoonforlemmy.unit.messages.components.ChatCard
+import com.github.diegoberaldin.raccoonforlemmy.unit.messages.components.ChatCardPlaceholder
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -123,21 +125,11 @@ class InboxMessagesScreen : Tab {
                         user = chat.otherUser(uiState.currentUserId),
                         autoLoadImages = uiState.autoLoadImages,
                         lastMessage = chat.content.orEmpty(),
-                        read = chat.read,
                         lastMessageDate = chat.publishDate,
                         onOpenUser = rememberCallbackArgs { user ->
                             detailOpener.openUserDetail(user, "")
                         },
                         onOpen = rememberCallback {
-                            if (!chat.read) {
-                                model.reduce(
-                                    InboxMessagesMviModel.Intent.MarkAsRead(
-                                        read = true,
-                                        id = chat.id,
-                                    ),
-                                )
-                            }
-
                             val userId = chat.otherUser(uiState.currentUserId)?.id
                             if (userId != null) {
                                 navigationCoordinator.pushScreen(

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCard.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCard.kt
@@ -1,4 +1,4 @@
-package com.github.diegoberaldin.raccoonforlemmy.unit.messages
+package com.github.diegoberaldin.raccoonforlemmy.unit.messages.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FiberManualRecord
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
@@ -51,7 +50,6 @@ internal fun ChatCard(
     user: UserModel?,
     autoLoadImages: Boolean = true,
     preferNicknames: Boolean = true,
-    read: Boolean = true,
     lastMessage: String,
     lastMessageDate: String? = null,
     modifier: Modifier = Modifier,
@@ -125,13 +123,6 @@ internal fun ChatCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = ancillaryColor,
                 )
-                if (!read) {
-                    Icon(
-                        modifier = Modifier.size(IconSize.xs),
-                        imageVector = Icons.Filled.FiberManualRecord,
-                        contentDescription = null,
-                    )
-                }
             }
             CustomizedContent {
                 // last message text

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCardPlaceholder.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCardPlaceholder.kt
@@ -1,4 +1,4 @@
-package com.github.diegoberaldin.raccoonforlemmy.unit.messages
+package com.github.diegoberaldin.raccoonforlemmy.unit.messages.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box


### PR DESCRIPTION
This PR removes the unread indicator for chats and the ability to mark private messages as read because it does not seem to work.