### PR TITLE
fix: blur not working for video elements

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -253,6 +253,7 @@ private fun CompactPost(
                     url = post.videoUrl,
                     blurred = blurNsfw && post.nsfw,
                     autoLoadImages = autoLoadImages,
+                    onOpen = onClick,
                 )
             } else {
                 PostCardImage(
@@ -400,6 +401,7 @@ private fun ExtendedPost(
                 blurred = blurNsfw && post.nsfw,
                 autoLoadImages = autoLoadImages,
                 backgroundColor = backgroundColor,
+                onOpen = onClick,
             )
         } else {
             PostCardImage(

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardVideo.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardVideo.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -32,22 +32,45 @@ fun PostCardVideo(
     blurred: Boolean = false,
     autoLoadImages: Boolean = true,
     backgroundColor: Color = MaterialTheme.colorScheme.background,
+    onOpen: (() -> Unit)? = null,
 ) {
-    if (url.isNotEmpty()) {
-        Box(
-            modifier = modifier
-                .fillMaxWidth()
-                .aspectRatio(1.33f)
-                .onClick(),
-            contentAlignment = Alignment.Center,
-        ) {
+    if (url.isEmpty()) {
+        return
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(1.33f)
+            .onClick(),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (blurred) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = LocalXmlStrings.current.messageVideoNsfw,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Button(
+                    onClick = {
+                        onOpen?.invoke()
+                    },
+                ) {
+                    Text(
+                        text = LocalXmlStrings.current.buttonLoad,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        } else {
             var shouldBeRendered by remember(autoLoadImages) { mutableStateOf(autoLoadImages) }
             var loading by remember { mutableStateOf(true) }
             if (shouldBeRendered) {
                 VideoPlayer(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .blur(radius = if (blurred) 60.dp else 0.dp),
+                    modifier = Modifier.fillMaxSize(),
                     url = url,
                     onPlaybackStarted = {
                         loading = false

--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -330,4 +330,5 @@
     <string name="settings_vote_format_hidden">مختفي</string>
     <string name="settings_comment_bar_thickness">سمك شريط التعليق</string>
     <string name="settings_prefer_user_nicknames">استخدم أسماء العرض للمستخدمين والمجتمعات</string>
+    <string name="message_video_nsfw">تم وضع علامة على هذا الفيديو على أنه NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -340,4 +340,5 @@
     <string name="settings_vote_format_hidden">Скрити</string>
     <string name="settings_comment_bar_thickness">Дебелина на лентата за коментари</string>
     <string name="settings_prefer_user_nicknames">Използвайте показвани имена за потребители и общности</string>
+    <string name="message_video_nsfw">Този видеоклип беше маркиран като NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -332,4 +332,5 @@
     <string name="settings_vote_format_hidden">Skrytý</string>
     <string name="settings_comment_bar_thickness">Komentář tloušťka tyče</string>
     <string name="settings_prefer_user_nicknames">Používejte zobrazovaná jména pro uživatele a komunity</string>
+    <string name="message_video_nsfw">Toto video bylo označeno jako NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -332,4 +332,5 @@
     <string name="settings_vote_format_hidden">Skjult</string>
     <string name="settings_comment_bar_thickness">Kommentarbjælketykkelse</string>
     <string name="settings_prefer_user_nicknames">Brug visningsnavne til brugere og fællesskaber</string>
+    <string name="message_video_nsfw">Denne video blev markeret som NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -340,4 +340,5 @@
     <string name="settings_vote_format_hidden">Versteckt</string>
     <string name="settings_comment_bar_thickness">Dicke der Kommentarleiste</string>
     <string name="settings_prefer_user_nicknames">Verwenden Sie Anzeigenamen für Benutzer und Communities</string>
+    <string name="message_video_nsfw">Dieses Video wurde als NSFW markiert</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -343,4 +343,5 @@
     <string name="settings_vote_format_hidden">Κρυμμένο</string>
     <string name="settings_comment_bar_thickness">Πάχος ράβδου σχολίων</string>
     <string name="settings_prefer_user_nicknames">Χρησιμοποιήστε εμφανιζόμενα ονόματα για χρήστες και κοινότητες</string>
+    <string name="message_video_nsfw">Αυτό το βίντεο επισημάνθηκε ως NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -331,4 +331,5 @@
     <string name="settings_vote_format_hidden">Kaŝita</string>
     <string name="settings_comment_bar_thickness">Komento trinkejo dikeco</string>
     <string name="settings_prefer_user_nicknames">Uzu vidnomojn por uzantoj kaj komunumoj</string>
+    <string name="message_video_nsfw">Ĉi tiu video estis markita kiel NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -333,4 +333,5 @@
     <string name="settings_vote_format_hidden">Escondido</string>
     <string name="settings_comment_bar_thickness">Grosor de la barra de comentarios</string>
     <string name="settings_prefer_user_nicknames">Utilizar nombres para mostrar para usuarios y comunidades</string>
+    <string name="message_video_nsfw">Este vídeo fue marcado como NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -332,4 +332,5 @@
     <string name="settings_vote_format_hidden">Peidetud</string>
     <string name="settings_comment_bar_thickness">Kommentaari riba paksus</string>
     <string name="settings_prefer_user_nicknames">Kasutage kasutajate ja kogukondade jaoks kuvatavaid nimesid</string>
+    <string name="message_video_nsfw">See video märgiti kui NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -332,4 +332,5 @@
     <string name="settings_vote_format_hidden">Piilotettu</string>
     <string name="settings_comment_bar_thickness">Kommenttipalkin paksuus</string>
     <string name="settings_prefer_user_nicknames">Käytä näyttönimiä käyttäjille ja yhteisöille</string>
+    <string name="message_video_nsfw">Tämä video on merkitty NSFW:ksi</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -337,4 +337,5 @@
     <string name="settings_vote_format_hidden">Caché</string>
     <string name="settings_comment_bar_thickness">Épaisseur de la barre de commentaires</string>
     <string name="settings_prefer_user_nicknames">Utiliser des noms d\'affichage pour les utilisateurs et les communautés</string>
+    <string name="message_video_nsfw">Cette vidéo a été marquée comme NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -341,4 +341,5 @@
     <string name="settings_vote_format_hidden">I bhfolach</string>
     <string name="settings_comment_bar_thickness">Tiús barra tráchta</string>
     <string name="settings_prefer_user_nicknames">Úsáid ainmneacha taispeána le haghaidh úsáideoirí agus pobail</string>
+    <string name="message_video_nsfw">Marcáladh an físeán seo mar NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -337,4 +337,5 @@
     <string name="settings_vote_format_hidden">Skriven</string>
     <string name="settings_comment_bar_thickness">Debljina trake komentara</string>
     <string name="settings_prefer_user_nicknames">Koristite imena za prikaz za korisnike i zajednice</string>
+    <string name="message_video_nsfw">Ovaj video je označen kao NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -336,4 +336,5 @@
     <string name="settings_vote_format_hidden">Rejtett</string>
     <string name="settings_comment_bar_thickness">Megjegyzés sáv vastagsága</string>
     <string name="settings_prefer_user_nicknames">Használjon megjelenített neveket a felhasználók és közösségek számára</string>
+    <string name="message_video_nsfw">Ez a videó NSFW-ként lett megjelölve</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -336,4 +336,5 @@
     <string name="settings_vote_format_hidden">Nascosto</string>
     <string name="settings_comment_bar_thickness">Spessore barra dei commenti</string>
     <string name="settings_prefer_user_nicknames">Utilizza nome visualizzato per utenti e comunità</string>
+    <string name="message_video_nsfw">Questo video è stato contrassegnato come NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -334,4 +334,5 @@
     <string name="settings_vote_format_hidden">Paslėpta</string>
     <string name="settings_comment_bar_thickness">Komentarų juostos storis</string>
     <string name="settings_prefer_user_nicknames">Naudokite rodomus vardus naudotojams ir bendruomenėms</string>
+    <string name="message_video_nsfw">Šis vaizdo įrašas buvo pažymėtas kaip NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -336,4 +336,5 @@
     <string name="settings_vote_format_hidden">Slēpts</string>
     <string name="settings_comment_bar_thickness">Komentāru joslas biezums</string>
     <string name="settings_prefer_user_nicknames">Izmantojiet parādāmos vārdus lietotājiem un kopienām</string>
+    <string name="message_video_nsfw">Šis videoklips tika atzīmēts kā NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -337,4 +337,5 @@
     <string name="settings_vote_format_hidden">Moħbija</string>
     <string name="settings_comment_bar_thickness">Ħxuna tal-bar tal-kumment</string>
     <string name="settings_prefer_user_nicknames">Uża ismijiet tal-wiri għall-utenti u l-komunitajiet</string>
+    <string name="message_video_nsfw">Dan il-video kien immarkat bħala NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -335,4 +335,5 @@
     <string name="settings_vote_format_hidden">Verborgen</string>
     <string name="settings_comment_bar_thickness">Opmerking staafdikte</string>
     <string name="settings_prefer_user_nicknames">Gebruik weergavenamen voor gebruikers en community\'s</string>
+    <string name="message_video_nsfw">Deze video is gemarkeerd als NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -334,4 +334,5 @@
     <string name="settings_vote_format_hidden">Skjult</string>
     <string name="settings_comment_bar_thickness">Kommentarstavtykkelse</string>
     <string name="settings_prefer_user_nicknames">Bruk visningsnavn for brukere og fellesskap</string>
+    <string name="message_video_nsfw">Denne videoen ble merket som NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -335,4 +335,5 @@
     <string name="settings_vote_format_hidden">Ukryty</string>
     <string name="settings_comment_bar_thickness">Grubość paska komentarza</string>
     <string name="settings_prefer_user_nicknames">Używaj nazw wyświetlanych dla użytkowników i społeczności</string>
+    <string name="message_video_nsfw">Ten film wideo został oznaczony jako NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -332,4 +332,5 @@
     <string name="settings_vote_format_hidden">Escondido</string>
     <string name="settings_comment_bar_thickness">Espessura da barra de comentários</string>
     <string name="settings_prefer_user_nicknames">Usar nomes de exibição para usuários e comunidades</string>
+    <string name="message_video_nsfw">Este vídeo foi marcado como NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -334,4 +334,5 @@
     <string name="settings_vote_format_hidden">Escondido</string>
     <string name="settings_comment_bar_thickness">Espessura da barra de comentários</string>
     <string name="settings_prefer_user_nicknames">Usar nomes de exibição para usuários e comunidades</string>
+    <string name="message_video_nsfw">Este vídeo foi marcado como NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -333,4 +333,5 @@
     <string name="settings_vote_format_hidden">Ascuns</string>
     <string name="settings_comment_bar_thickness">Grosimea barei comentariilor</string>
     <string name="settings_prefer_user_nicknames">Utilizează nume afișate pentru utilizatori și comunități</string>
+    <string name="message_video_nsfw">Acest videoclip a fost marcat ca NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -336,4 +336,5 @@
     <string name="settings_vote_format_hidden">Скрытый</string>
     <string name="settings_comment_bar_thickness">Толщина панели комментариев</string>
     <string name="settings_prefer_user_nicknames">Используйте отображаемые имена для пользователей и сообществ</string>
+    <string name="message_video_nsfw">Это видео было отмечено как NSFW.</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -333,4 +333,5 @@
     <string name="settings_vote_format_hidden">Dold</string>
     <string name="settings_comment_bar_thickness">Kommentarstapelns tjocklek</string>
     <string name="settings_prefer_user_nicknames">Använd visningsnamn för användare och gemenskaper</string>
+    <string name="message_video_nsfw">Den här videon markerades som NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -334,4 +334,5 @@
     <string name="settings_vote_format_hidden">Skryté</string>
     <string name="settings_comment_bar_thickness">Komentár hrúbka pruhu</string>
     <string name="settings_prefer_user_nicknames">Používať zobrazované mená pre používateľov a komunity</string>
+    <string name="message_video_nsfw">Toto video bolo označené ako NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -332,4 +332,5 @@
     <string name="settings_vote_format_hidden">Skrito</string>
     <string name="settings_comment_bar_thickness">Debelina vrstice za komentarje</string>
     <string name="settings_prefer_user_nicknames">Uporabite prikazna imena za uporabnike in skupnosti</string>
+    <string name="message_video_nsfw">Ta video je bil označen kot NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -338,4 +338,5 @@
     <string name="settings_vote_format_hidden">I fshehur</string>
     <string name="settings_comment_bar_thickness">Trashësia e shiritit të komenteve</string>
     <string name="settings_prefer_user_nicknames">Përdorni emra të shfaqur për përdoruesit dhe komunitetet</string>
+    <string name="message_video_nsfw">Kjo video u shënua si NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -331,4 +331,5 @@
     <string name="settings_vote_format_hidden">ala</string>
     <string name="settings_comment_bar_thickness">suli pi linja pi toki lili</string>
     <string name="settings_prefer_user_nicknames">o lukin e nimi lili tan jan tan kulupu</string>
+    <string name="message_video_nsfw">sitelen tawa ni li NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -335,4 +335,5 @@
     <string name="settings_vote_format_hidden">Gizlenmiş</string>
     <string name="settings_comment_bar_thickness">Yorum çubuğu kalınlığı</string>
     <string name="settings_prefer_user_nicknames">Kullanıcılar ve topluluklar için görünen adları kullanın</string>
+    <string name="message_video_nsfw">Bu video NSFW olarak işaretlendi</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -335,4 +335,5 @@
     <string name="settings_vote_format_hidden">Прихований</string>
     <string name="settings_comment_bar_thickness">Товщина панелі коментарів</string>
     <string name="settings_prefer_user_nicknames">Використовуйте відображувані імена для користувачів і спільнот</string>
+    <string name="message_video_nsfw">Це відео було позначено як NSFW</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -330,4 +330,5 @@
     <string name="settings_vote_format_hidden">Hidden</string>
     <string name="settings_comment_bar_thickness">Comment bar thickness</string>
     <string name="settings_prefer_user_nicknames">Use display names for users and communities</string>
+    <string name="message_video_nsfw">This video was marked as NSFW</string>
 </resources>


### PR DESCRIPTION
The blur modifier does not work on `PlayerView`s so instead of showing them in feeds, they are hidden with a load button that allows to navigate to the detail screen where the video is shown.