### PR TITLE
fix: markdown render improvements

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardBody.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardBody.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.toTypography
 import com.github.diegoberaldin.raccoonforlemmy.core.markdown.CustomMarkdownWrapper
@@ -56,6 +58,10 @@ fun PostCardBody(
                 h6 = typography.titleSmall,
                 text = typography.bodyMedium,
                 paragraph = typography.bodyMedium,
+                quote = typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
+                bullet = typography.bodyMedium,
+                list = typography.bodyMedium,
+                code = typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
             ),
             colors = markdownColor(
                 text = MaterialTheme.colorScheme.onBackground,

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.toTypography
@@ -65,6 +67,10 @@ fun PostCardTitle(
             h6 = typography.titleSmall,
             text = typography.bodyMedium.copy(fontWeight = weightMediumOrNormal),
             paragraph = typography.bodyMedium.copy(fontWeight = weightMediumOrNormal),
+            quote = typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
+            bullet = typography.bodyMedium,
+            list = typography.bodyMedium,
+            code = typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
         ),
         colors = markdownColor(
             text = MaterialTheme.colorScheme.onBackground,

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
@@ -60,9 +60,14 @@ private fun String.quoteFixup(): String = run {
     val finalLines = mutableListOf<String>()
     lines().forEach { line ->
         // removes list inside quotes
-        val cleanLine = line.replace(Regex("^>\\s*?-"), ">")
-        if (cleanLine.isNotEmpty()) {
-            finalLines += cleanLine
+        val quoteAndList = Regex("^>\\s*?-")
+        if (quoteAndList.matches(line)) {
+            val cleanLine = line.replace(quoteAndList, ">")
+            if (cleanLine.isNotEmpty()) {
+                finalLines += cleanLine
+            }
+        } else {
+            finalLines += line
         }
     }
     finalLines.joinToString("\n")


### PR DESCRIPTION
This PR fixes a couple of other issues with MD, mainly the blank lines being ripped off and some missing styles (where the default font family popped up instead of the custom one).