### PR TITLE
fix:  md non inline images

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownImage.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownImage.kt
@@ -32,46 +32,61 @@ internal fun CustomMarkdownImage(
     val link = node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)
         ?.getTextInNode(content)
         ?.toString().orEmpty()
-    if (link.isNotEmpty()) {
-        CustomImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .onClick(
-                    onClick = {
-                        onOpenImage?.invoke(link)
-                    },
-                ),
-            url = link,
-            autoload = autoLoadImages,
-            quality = FilterQuality.Low,
-            contentScale = ContentScale.FillWidth,
-            onFailure = {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    text = LocalXmlStrings.current.messageImageLoadingError,
-                    style = LocalMarkdownTypography.current.text,
-                )
-            },
-            onLoading = { progress ->
-                val prog = if (progress != null) {
-                    progress
-                } else {
-                    val transition = rememberInfiniteTransition()
-                    val res by transition.animateFloat(
-                        initialValue = 0f,
-                        targetValue = 1f,
-                        animationSpec = InfiniteRepeatableSpec(
-                            animation = tween(1000)
-                        ),
-                    )
-                    res
-                }
-                CircularProgressIndicator(
-                    progress = prog,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            },
-        )
+    CustomMarkdownImage(
+        url = link,
+        autoLoadImages = autoLoadImages,
+        onOpenImage = onOpenImage,
+    )
+}
+
+@Composable
+internal fun CustomMarkdownImage(
+    url: String,
+    onOpenImage: ((String) -> Unit)?,
+    autoLoadImages: Boolean,
+) {
+    if (url.isBlank()) {
+        return
     }
+
+    CustomImage(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onClick(
+                onClick = {
+                    onOpenImage?.invoke(url)
+                },
+            ),
+        url = url,
+        autoload = autoLoadImages,
+        quality = FilterQuality.Low,
+        contentScale = ContentScale.FillWidth,
+        onFailure = {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = LocalXmlStrings.current.messageImageLoadingError,
+                style = LocalMarkdownTypography.current.text,
+            )
+        },
+        onLoading = { progress ->
+            val prog = if (progress != null) {
+                progress
+            } else {
+                val transition = rememberInfiniteTransition()
+                val res by transition.animateFloat(
+                    initialValue = 0f,
+                    targetValue = 1f,
+                    animationSpec = InfiniteRepeatableSpec(
+                        animation = tween(1000)
+                    ),
+                )
+                res
+            }
+            CircularProgressIndicator(
+                progress = prog,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        },
+    )
 }

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownSpoiler.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownSpoiler.kt
@@ -26,7 +26,7 @@ internal fun CustomMarkdownSpoiler(
         modifier = modifier,
     ) {
         var lastIndex = 0
-        val matches = SpoilerRegex.spoilerOpenRegex.findAll(content)
+        val matches = SpoilerRegex.spoilerOpening.findAll(content)
         for (match in matches) {
             val openingStart = match.range.first
             val openingEnd = match.range.last
@@ -38,7 +38,7 @@ internal fun CustomMarkdownSpoiler(
                 MarkdownText(content = subcontent)
             }
             val spoilerTitle = match.groups["title"]?.value.orEmpty()
-            val closeMatch = SpoilerRegex.spoilerCloseRegex.find(
+            val closeMatch = SpoilerRegex.spoilerClosing.find(
                 input = content,
                 startIndex = openingEnd,
             )

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownWrapper.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownWrapper.kt
@@ -22,7 +22,10 @@ import com.mikepenz.markdown.model.markdownPadding
 import com.mikepenz.markdown.model.markdownTypography
 
 private val String.containsSpoiler: Boolean
-    get() = SpoilerRegex.spoilerOpenRegex.containsMatchIn(this)
+    get() = SpoilerRegex.spoilerOpening.containsMatchIn(this)
+
+private val String.isImage: Boolean
+    get() = ImageRegex.image.matches(this)
 
 @Composable
 fun CustomMarkdownWrapper(
@@ -55,6 +58,16 @@ fun CustomMarkdownWrapper(
             when {
                 substring.containsSpoiler -> {
                     CustomMarkdownSpoiler(content = substring)
+                }
+
+                substring.isImage -> {
+                    val res = ImageRegex.image.find(substring)
+                    val link = res?.groups?.get("url")?.value.orEmpty()
+                    CustomMarkdownImage(
+                        url = link,
+                        autoLoadImages = autoLoadImages,
+                        onOpenImage = onOpenImage,
+                    )
                 }
 
                 else -> {

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Regexes.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Regexes.kt
@@ -1,8 +1,8 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.markdown
 
 internal object SpoilerRegex {
-    val spoilerOpenRegex = Regex("(:::\\s+spoiler\\s+)(?<title>.*)")
-    val spoilerCloseRegex = Regex(":::")
+    val spoilerOpening = Regex("(:::\\s+spoiler\\s+)(?<title>.*)")
+    val spoilerClosing = Regex(":::")
 }
 
 internal object LemmyLinkRegex {
@@ -15,3 +15,6 @@ internal object LemmyLinkRegex {
         Regex("(?<!\\S)!(?<detail>$DETAIL_FRAGMENT)(?:@(?<instance>$INSTANCE_FRAGMENT))?\\b")
 }
 
+internal object ImageRegex {
+    val image = Regex("!\\[[^]]*]\\((?<url>.*?)\\)")
+}

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
@@ -26,6 +26,7 @@ internal fun String.sanitize(): String = this
 private fun String.removeEntities(): String =
     replace("&amp;", "&")
         .replace("&nbsp;", " ")
+        .replace("&hellip;", "…")
 
 
 private fun String.spoilerFixup(): String = run {
@@ -33,7 +34,7 @@ private fun String.spoilerFixup(): String = run {
     var finalLinesSizeAtLastSpoiler = 0
     lines().forEach { line ->
         val isSpoilerOnTopOfStack = finalLinesSizeAtLastSpoiler == finalLines.size
-        if (line.contains(SpoilerRegex.spoilerOpenRegex)) {
+        if (line.contains(SpoilerRegex.spoilerOpening)) {
             if (finalLines.lastOrNull()?.isEmpty() == false) {
                 finalLines += ""
             }


### PR DESCRIPTION
This PR treats "paragraph" blocks containing only images (non-inline images) like regular images.