### PR TITLE
refactor: remove navigation debounce

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/FabNestedScrollConnection.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/FabNestedScrollConnection.kt
@@ -23,7 +23,6 @@ internal class DefaultFabNestedScrollConnection : FabNestedScrollConnection {
     private val scope = CoroutineScope(SupervisorJob())
     override val isFabVisible: StateFlow<Boolean>
         get() = fabVisible
-            //.debounce(750)
             .stateIn(
                 scope = scope,
                 started = SharingStarted.WhileSubscribed(5_000),

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
@@ -146,9 +146,7 @@ internal object MainScreen : Screen {
                                     // wait for transition to finish
                                     delay(750)
                                     notificationCenter.send(
-                                        NotificationCenterEvent.ChangeFeedType(
-                                            evt.value
-                                        )
+                                        NotificationCenterEvent.ChangeFeedType(evt.value)
                                     )
                                 }
                             }


### PR DESCRIPTION
This PR removes the debounce intervals that were once needed for navigation to avoid transition crashes but are no longer necessary and  degraded the user experience (as observed by some people).