### PR TITLE
refactor: rationalizes settings screen

### DIFF
--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -203,9 +203,9 @@
     <string name="settings_post_layout_compact">مضغوط</string>
     <string name="settings_post_layout_full">كامل</string>
     <string name="settings_section_appearance">الشكل والمظهر</string>
-    <string name="settings_section_behaviour">السلوك</string>
+    <string name="settings_advanced">إعدادات متقدمة</string>
     <string name="settings_section_debug">تصحيح الأخطاء</string>
-    <string name="settings_section_feed">المنشورات والتعليقات</string>
+    <string name="settings_section_general">عام</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">الظلام (أموليد)</string>
     <string name="settings_theme_dark">داكن</string>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -211,9 +211,9 @@
     <string name="settings_post_layout_compact">Компактни</string>
     <string name="settings_post_layout_full">Пълна</string>
     <string name="settings_section_appearance">Изглед и усещане</string>
-    <string name="settings_section_behaviour">Поведение</string>
+    <string name="settings_advanced">Разширени настройки</string>
     <string name="settings_section_debug">Отстраняване на дефекти</string>
-    <string name="settings_section_feed">Публикации и коментари</string>
+    <string name="settings_section_general">Общ</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Тъмно (AMOLED)</string>
     <string name="settings_theme_dark">Тъмно</string>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -205,9 +205,9 @@
     <string name="settings_post_layout_compact">Kompaktní</string>
     <string name="settings_post_layout_full">Plná</string>
     <string name="settings_section_appearance">Vypadat a cítit se</string>
-    <string name="settings_section_behaviour">Vlastnost</string>
+    <string name="settings_advanced">Pokročilé nastavení</string>
     <string name="settings_section_debug">Ladění</string>
-    <string name="settings_section_feed">Příspěvky a komentáře</string>
+    <string name="settings_section_general">Všeobecné</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tmavý (AMOLED)</string>
     <string name="settings_theme_dark">Tmavý</string>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -206,9 +206,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">Full (Fuld)</string>
     <string name="settings_section_appearance">Se og fornem</string>
-    <string name="settings_section_behaviour">Adfærd</string>
+    <string name="settings_advanced">Avancerede indstillinger</string>
     <string name="settings_section_debug">Debugging</string>
-    <string name="settings_section_feed">Indlæg og kommentarer</string>
+    <string name="settings_section_general">Generel</string>
     <string name="settings_section_nsfw">nsfw</string>
     <string name="settings_theme_black">Mørk (AMOLED)</string>
     <string name="settings_theme_dark">Mørk</string>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -209,9 +209,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">Voll</string>
     <string name="settings_section_appearance">Aussehen und Gefühl</string>
-    <string name="settings_section_behaviour">Verhalten</string>
+    <string name="settings_advanced">Erweiterte Einstellungen</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Beiträge und Kommentare</string>
+    <string name="settings_section_general">Allgemein</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Dunkel (AMOLED)</string>
     <string name="settings_theme_dark">Dunkel</string>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -209,9 +209,9 @@
     <string name="settings_post_layout_compact">Συμπαγής</string>
     <string name="settings_post_layout_full">Πλήρης</string>
     <string name="settings_section_appearance">Εμφάνιση και αίσθηση</string>
-    <string name="settings_section_behaviour">Συμπεριφορά</string>
+    <string name="settings_advanced">Προηγμένες ρυθμίσεις</string>
     <string name="settings_section_debug">Αποσφαλμάτωση</string>
-    <string name="settings_section_feed">Αναρτήσεις και σχόλια</string>
+    <string name="settings_section_general">Γενικές</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Σκοτεινό (AMOLED)</string>
     <string name="settings_theme_dark">Σκοτεινό</string>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -205,9 +205,9 @@
     <string name="settings_post_layout_compact">Kunpremita</string>
     <string name="settings_post_layout_full">Plena</string>
     <string name="settings_section_appearance">Rigardo kaj sento</string>
-    <string name="settings_section_behaviour">Konduto</string>
+    <string name="settings_advanced">Altnivelaj agordoj</string>
     <string name="settings_section_debug">Sencimigi</string>
-    <string name="settings_section_feed">Afiŝoj kaj komentoj</string>
+    <string name="settings_section_general">Generalaj</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Malhela (AMOLED)</string>
     <string name="settings_theme_dark">Malhela</string>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -51,7 +51,7 @@
     <string name="explore_result_type_posts">Publicaciones</string>
     <string name="explore_result_type_users">Usuarios</string>
     <string name="explore_search_placeholder">Búsqueda</string>
-    <string name="home_instance_via">via %1$s</string>
+    <string name="home_instance_via">vía %1$s</string>
     <string name="home_listing_title">Listados</string>
     <string name="home_listing_type_all">Todos</string>
     <string name="home_listing_type_local">Locales</string>
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Compacto</string>
     <string name="settings_post_layout_full">Completo</string>
     <string name="settings_section_appearance">Apariencia</string>
-    <string name="settings_section_behaviour">Comportamiento</string>
+    <string name="settings_advanced">Ajustes avanzados</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Publicaciones y comentarios</string>
+    <string name="settings_section_general">General</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Oscuro (AMOLED)</string>
     <string name="settings_theme_dark">Oscuro</string>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -205,9 +205,9 @@
     <string name="settings_post_layout_compact">Compact</string>
     <string name="settings_post_layout_full">Full</string>
     <string name="settings_section_appearance">Välimus</string>
-    <string name="settings_section_behaviour">käitumist</string>
+    <string name="settings_advanced">Täpsemad seaded</string>
     <string name="settings_section_debug">Silumine</string>
-    <string name="settings_section_feed">Postitused ja kommentaarid</string>
+    <string name="settings_section_general">Kindral</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tume (AMOLED)</string>
     <string name="settings_theme_dark">Tume</string>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -205,9 +205,9 @@
     <string name="settings_post_layout_compact">Tiivistetty</string>
     <string name="settings_post_layout_full">Täysi</string>
     <string name="settings_section_appearance">käyttötuntuma</string>
-    <string name="settings_section_behaviour">Käyttäytyminen</string>
+    <string name="settings_advanced">Lisäasetukset</string>
     <string name="settings_section_debug">Testaa</string>
-    <string name="settings_section_feed">Julkaisut ja kommentit</string>
+    <string name="settings_section_general">Kenraali</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tumma (AMOLED)</string>
     <string name="settings_theme_dark">Tumma</string>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Compacte</string>
     <string name="settings_post_layout_full">Pleine</string>
     <string name="settings_section_appearance">Aspect</string>
-    <string name="settings_section_behaviour">Comportement</string>
+    <string name="settings_advanced">Réglages avancés</string>
     <string name="settings_section_debug">Débogage</string>
-    <string name="settings_section_feed">Publications et commentaires</string>
+    <string name="settings_section_general">Généraux</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Sombre (AMOLED)</string>
     <string name="settings_theme_dark">Sombre</string>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -212,9 +212,9 @@
     <string name="settings_post_layout_compact">Dlúth</string>
     <string name="settings_post_layout_full">Iomlán</string>
     <string name="settings_section_appearance">Cuma</string>
-    <string name="settings_section_behaviour">Iompar</string>
+    <string name="settings_advanced">Ardsocruithe</string>
     <string name="settings_section_debug">Dífhabhtú</string>
-    <string name="settings_section_feed">Poist agus tuairimí</string>
+    <string name="settings_section_general">Ginearálta</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Íon - dubh</string>
     <string name="settings_theme_dark">Dorcha</string>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -208,9 +208,9 @@
     <string name="settings_post_layout_compact">Kompaktno</string>
     <string name="settings_post_layout_full">Puna baterija</string>
     <string name="settings_section_appearance">Gledaj i osjeti</string>
-    <string name="settings_section_behaviour">Ponašanje</string>
+    <string name="settings_advanced">Napredne postavke</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Objave i komentari</string>
+    <string name="settings_section_general">Općenito</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tamni (AMOLED)</string>
     <string name="settings_theme_dark">Tamni</string>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">Teljes</string>
     <string name="settings_section_appearance">nézd és érezd</string>
-    <string name="settings_section_behaviour">Viselkedés</string>
+    <string name="settings_advanced">További beállítások</string>
     <string name="settings_section_debug">Hibaelhárítás</string>
-    <string name="settings_section_feed">Bejegyzések és megjegyzések</string>
+    <string name="settings_section_general">Tábornok</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Sötét (AMOLED)</string>
     <string name="settings_theme_dark">Sötét</string>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -208,9 +208,9 @@
     <string name="settings_post_layout_compact">Compatto</string>
     <string name="settings_post_layout_full">Intero</string>
     <string name="settings_section_appearance">Aspetto interfaccia</string>
-    <string name="settings_section_behaviour">Comportamento</string>
+    <string name="settings_advanced">Impostazioni avanzate</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Post e commenti</string>
+    <string name="settings_section_general">Generali</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Scuro (AMOLED)</string>
     <string name="settings_theme_dark">Scuro</string>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -199,16 +199,16 @@
     <string name="settings_language">Kalba</string>
     <string name="settings_navigation_bar_titles_visible">Rodyti naršymo juostos pavadinimus
     </string>
-    <string name="settings_open_url_external">@ info: progress operation</string>
+    <string name="settings_open_url_external">Atidarykite URL išorinėje naršyklėje</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Įrašo maketas</string>
     <string name="settings_post_layout_card">Kortelė</string>
     <string name="settings_post_layout_compact">Kompaktiškas</string>
     <string name="settings_post_layout_full">Visų funkcijų</string>
     <string name="settings_section_appearance">Atrodykite ir jauskitės</string>
-    <string name="settings_section_behaviour">Elgesys</string>
+    <string name="settings_advanced">Pažangūs nustatymai</string>
     <string name="settings_section_debug">Derinti</string>
-    <string name="settings_section_feed">Įrašai ir komentarai</string>
+    <string name="settings_section_general">Generolas</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tamsus (AMOLED)</string>
     <string name="settings_theme_dark">Tamsus</string>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -208,9 +208,9 @@
     <string name="settings_post_layout_compact">Compact</string>
     <string name="settings_post_layout_full">Pilnībā</string>
     <string name="settings_section_appearance">Skaties un jūti</string>
-    <string name="settings_section_behaviour">Uzvedība</string>
+    <string name="settings_advanced">Papildu iestatījumi</string>
     <string name="settings_section_debug">Atkļūdot</string>
-    <string name="settings_section_feed">Ziņas un komentāri</string>
+    <string name="settings_section_general">Ģenerālis</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tumša (AMOLED)</string>
     <string name="settings_theme_dark">Tumša</string>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Kumpatt</string>
     <string name="settings_post_layout_full">Sħiħ</string>
     <string name="settings_section_appearance">Ħares u ħoss</string>
-    <string name="settings_section_behaviour">Imġiba</string>
+    <string name="settings_advanced">Settings avvanzati</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Posts u kummenti</string>
+    <string name="settings_section_general">Ġenerali</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Skur (AMOLED)</string>
     <string name="settings_theme_dark">Skur</string>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Compact</string>
     <string name="settings_post_layout_full">Vol</string>
     <string name="settings_section_appearance">Een verlengstuk van jezelf</string>
-    <string name="settings_section_behaviour">Gedrag</string>
+    <string name="settings_advanced">Geavanceerde instellingen</string>
     <string name="settings_section_debug">Fouten opsporen</string>
-    <string name="settings_section_feed">Berichten en reacties</string>
+    <string name="settings_section_general">Algemeen</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Pure Black</string>
     <string name="settings_theme_dark">Donker</string>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -208,9 +208,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">Fullt</string>
     <string name="settings_section_appearance">Utsjånad</string>
-    <string name="settings_section_behaviour">atferd</string>
+    <string name="settings_advanced">Avanserte innstillinger</string>
     <string name="settings_section_debug">Feilsøk</string>
-    <string name="settings_section_feed">Innlegg og merknader</string>
+    <string name="settings_section_general">Generell</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Mørk (AMOLED)</string>
     <string name="settings_theme_dark">Mørk</string>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -208,9 +208,9 @@
     <string name="settings_post_layout_compact">Kompaktowy</string>
     <string name="settings_post_layout_full">Kompletny</string>
     <string name="settings_section_appearance">Wygląd i styl</string>
-    <string name="settings_section_behaviour">Zachowanie</string>
+    <string name="settings_advanced">Zaawansowane ustawienia</string>
     <string name="settings_section_debug">Debugowanie</string>
-    <string name="settings_section_feed">Posty i komentarze</string>
+    <string name="settings_section_general">Ogólny</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Ciemny (AMOLED)</string>
     <string name="settings_theme_dark">Ciemny</string>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -206,9 +206,9 @@
     <string name="settings_post_layout_compact">Compacto</string>
     <string name="settings_post_layout_full">Completo</string>
     <string name="settings_section_appearance">Aparência</string>
-    <string name="settings_section_behaviour">Desempenho</string>
+    <string name="settings_advanced">Configurações avançadas</string>
     <string name="settings_section_debug">Depuração</string>
-    <string name="settings_section_feed">Posts e comentários</string>
+    <string name="settings_section_general">Gerais</string>
     <string name="settings_section_nsfw">NSFW (conteúdo explícito)</string>
     <string name="settings_theme_black">Escuro (AMOLED)</string>
     <string name="settings_theme_dark">Escuro</string>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -205,10 +205,10 @@
     <string name="settings_post_layout_card">Ficha</string>
     <string name="settings_post_layout_compact">Compacto</string>
     <string name="settings_post_layout_full">Completo</string>
-    <string name="settings_section_appearance">Aparencia</string>
-    <string name="settings_section_behaviour">Comportamento</string>
+    <string name="settings_section_appearance">Aparência</string>
+    <string name="settings_advanced">Configurações avançadas</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Publicaçoes e comentários</string>
+    <string name="settings_section_general">Gerais</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Escuro (AMOLED)</string>
     <string name="settings_theme_dark">Escuro</string>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Compact</string>
     <string name="settings_post_layout_full">Complet</string>
     <string name="settings_section_appearance">Aspect interfeței</string>
-    <string name="settings_section_behaviour">Comportament</string>
+    <string name="settings_advanced">Setari avansate</string>
     <string name="settings_section_debug">Depanare</string>
-    <string name="settings_section_feed">Postări și comentării</string>
+    <string name="settings_section_general">Generale</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Întunecată (AMOLED)</string>
     <string name="settings_theme_dark">Întunecată</string>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Компактные</string>
     <string name="settings_post_layout_full">Буферный бак полон</string>
     <string name="settings_section_appearance">Вид и поведение</string>
-    <string name="settings_section_behaviour">Поведение</string>
+    <string name="settings_advanced">Расширенные настройки</string>
     <string name="settings_section_debug">Отладить</string>
-    <string name="settings_section_feed">Редактирование публикаций и комментариев</string>
+    <string name="settings_section_general">Общий</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Тёмная (AMOLED)</string>
     <string name="settings_theme_dark">Тёмная</string>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">Fullständigt</string>
     <string name="settings_section_appearance">Utseende och känsla</string>
-    <string name="settings_section_behaviour">Beteende</string>
+    <string name="settings_advanced">Avancerade inställningar</string>
     <string name="settings_section_debug">Felsökning</string>
-    <string name="settings_section_feed">Inlägg och kommentarer</string>
+    <string name="settings_section_general">Allmän</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Mörk (AMOLED)</string>
     <string name="settings_theme_dark">Mörk</string>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Kompaktný</string>
     <string name="settings_post_layout_full">Plné</string>
     <string name="settings_section_appearance">Pozrieť sa a feel</string>
-    <string name="settings_section_behaviour">Správanie</string>
+    <string name="settings_advanced">Pokročilé nastavenia</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Príspevky a komentáre</string>
+    <string name="settings_section_general">Generál</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tmavá (AMOLED)</string>
     <string name="settings_theme_dark">Tmavá</string>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -206,9 +206,9 @@
     <string name="settings_post_layout_compact">Kompaktno</string>
     <string name="settings_post_layout_full">Popolno</string>
     <string name="settings_section_appearance">Videz in občutek</string>
-    <string name="settings_section_behaviour">Vedenje</string>
+    <string name="settings_advanced">Napredne nastavitve</string>
     <string name="settings_section_debug">Debugiranje</string>
-    <string name="settings_section_feed">Objave in komentarji</string>
+    <string name="settings_section_general">Splošno</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Tema (AMOLED)</string>
     <string name="settings_theme_dark">Tema</string>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -63,7 +63,7 @@
     <string name="home_sort_type_most_comments">Shumica e komenteve</string>
     <string name="home_sort_type_new">I ri</string>
     <string name="home_sort_type_new_comments">Komente të reja</string>
-    <string name="home_sort_type_old">E moshuar...</string>
+    <string name="home_sort_type_old">E moshuar…</string>
     <string name="home_sort_type_scaled">E shkallëzuar</string>
     <string name="home_sort_type_top">Kryesoret</string>
     <string name="home_sort_type_top_12_hours">12 orët më të mira</string>
@@ -209,9 +209,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">I plotë</string>
     <string name="settings_section_appearance">SHIKONI DHE NDJENI.</string>
-    <string name="settings_section_behaviour">Sjellja</string>
+    <string name="settings_advanced">Cilësimet e avancuara</string>
     <string name="settings_section_debug">Korrigjo</string>
-    <string name="settings_section_feed">Postime dhe komente</string>
+    <string name="settings_section_general">Gjeneral</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">E errët (AMOLED)</string>
     <string name="settings_theme_dark">E errët</string>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -205,9 +205,9 @@
     <string name="settings_post_layout_compact">lili</string>
     <string name="settings_post_layout_full">suli</string>
     <string name="settings_section_appearance">nasin lukin</string>
-    <string name="settings_section_behaviour">nasin pali</string>
+    <string name="settings_advanced">ante mute</string>
     <string name="settings_section_debug">moli e pipi</string>
-    <string name="settings_section_feed">lipu en toki lili</string>
+    <string name="settings_section_general">ijo suli</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">pimeja mute</string>
     <string name="settings_theme_dark">pimeja</string>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -206,9 +206,9 @@
     <string name="settings_post_layout_compact">Kompakt</string>
     <string name="settings_post_layout_full">Dolu</string>
     <string name="settings_section_appearance">Bak ve hisset</string>
-    <string name="settings_section_behaviour">Davranış</string>
+    <string name="settings_advanced">Gelişmiş ayarlar</string>
     <string name="settings_section_debug">Hata ayıklama</string>
-    <string name="settings_section_feed">Gönderiler ve yorumlar</string>
+    <string name="settings_section_general">Genel</string>
     <string name="settings_section_nsfw">Sakıncalı İçerik</string>
     <string name="settings_theme_black">Saf siyah</string>
     <string name="settings_theme_dark">Karanlık</string>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -207,9 +207,9 @@
     <string name="settings_post_layout_compact">Компактний</string>
     <string name="settings_post_layout_full">Повна бойова готовність</string>
     <string name="settings_section_appearance">Вигляд і поведінка</string>
-    <string name="settings_section_behaviour">Поведінка</string>
+    <string name="settings_advanced">Розширені налаштування</string>
     <string name="settings_section_debug">Відлагодити</string>
-    <string name="settings_section_feed">Дописи та коментарі</string>
+    <string name="settings_section_general">Загальний</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Темрява (AMOLED)</string>
     <string name="settings_theme_dark">Темрява</string>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -205,9 +205,9 @@
     <string name="settings_post_layout_compact">Compact</string>
     <string name="settings_post_layout_full">Full</string>
     <string name="settings_section_appearance">Look and feel</string>
-    <string name="settings_section_behaviour">Behaviour</string>
+    <string name="settings_advanced">Advanced settings</string>
     <string name="settings_section_debug">Debug</string>
-    <string name="settings_section_feed">Posts and comments</string>
+    <string name="settings_section_general">General</string>
     <string name="settings_section_nsfw">NSFW</string>
     <string name="settings_theme_black">Pure black</string>
     <string name="settings_theme_dark">Dark</string>

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -1,0 +1,42 @@
+package com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+interface AdvancedSettingsMviModel :
+    MviModel<AdvancedSettingsMviModel.Intent, AdvancedSettingsMviModel.UiState, AdvancedSettingsMviModel.Effect>,
+    ScreenModel {
+
+    sealed interface Intent {
+        data class ChangeEnableDoubleTapAction(val value: Boolean) : Intent
+        data class ChangeAutoLoadImages(val value: Boolean) : Intent
+        data class ChangeAutoExpandComments(val value: Boolean) : Intent
+        data class ChangeHideNavigationBarWhileScrolling(val value: Boolean) : Intent
+        data class ChangeMarkAsReadWhileScrolling(val value: Boolean) : Intent
+        data class ChangeNavBarTitlesVisible(val value: Boolean) : Intent
+        data class ChangeSearchPostTitleOnly(val value: Boolean) : Intent
+        data class ChangeEdgeToEdge(val value: Boolean) : Intent
+        data class ChangeInfiniteScrollDisabled(val value: Boolean) : Intent
+    }
+
+    data class UiState(
+        val isLogged: Boolean = false,
+        val autoLoadImages: Boolean = false,
+        val defaultInboxUnreadOnly: Boolean = true,
+        val navBarTitlesVisible: Boolean = false,
+        val enableDoubleTapAction: Boolean = true,
+        val autoExpandComments: Boolean = false,
+        val hideNavigationBarWhileScrolling: Boolean = true,
+        val zombieModeInterval: Duration = 2.5.seconds,
+        val zombieModeScrollAmount: Float = 100f,
+        val markAsReadWhileScrolling: Boolean = true,
+        val searchPostTitleOnly: Boolean = false,
+        val edgeToEdge: Boolean = true,
+        val infiniteScrollDisabled: Boolean = false,
+        val opaqueSystemBars: Boolean = false,
+    )
+
+    sealed interface Effect
+}

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -1,0 +1,285 @@
+package com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.toSize
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.koin.getScreenModel
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiBarTheme
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toReadableName
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+import com.github.diegoberaldin.raccoonforlemmy.core.architecture.bindToLifecycle
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.BarThemeBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.DurationBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.InboxTypeSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SliderBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
+import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.datetime.getPrettyDuration
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
+import kotlin.math.roundToInt
+
+class AdvancedSettingsScreen : Screen {
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<AdvancedSettingsMviModel>()
+        model.bindToLifecycle(key)
+        val uiState by model.uiState.collectAsState()
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+        val scrollState = rememberScrollState()
+        var screenWidth by remember { mutableStateOf(0f) }
+
+        Scaffold(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .onGloballyPositioned {
+                    screenWidth = it.size.toSize().width
+                }.padding(Spacing.xs),
+            topBar = {
+                TopAppBar(
+                    scrollBehavior = scrollBehavior,
+                    title = {
+                        Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
+                            text = LocalXmlStrings.current.settingsAdvanced,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            Image(
+                                modifier = Modifier.onClick(
+                                    onClick = rememberCallback {
+                                        navigationCoordinator.popScreen()
+                                    },
+                                ),
+                                imageVector = Icons.Filled.ArrowBack,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
+                    },
+                )
+            },
+        ) { paddingValues ->
+            Box(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .nestedScroll(scrollBehavior.nestedScrollConnection),
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize().verticalScroll(scrollState),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                ) {
+                    if (uiState.isLogged) {
+                        // default inbox type
+                        SettingsRow(
+                            title = LocalXmlStrings.current.settingsDefaultInboxType,
+                            value = if (uiState.defaultInboxUnreadOnly) {
+                                LocalXmlStrings.current.inboxListingTypeUnread
+                            } else {
+                                LocalXmlStrings.current.inboxListingTypeAll
+                            },
+                            onTap = rememberCallback {
+                                val sheet = InboxTypeSheet()
+                                navigationCoordinator.showBottomSheet(sheet)
+                            },
+                        )
+                    }
+
+                    // navigation bar titles
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsNavigationBarTitlesVisible,
+                        value = uiState.navBarTitlesVisible,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeNavBarTitlesVisible(value)
+                            )
+                        },
+                    )
+
+                    // edge to edge
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsEdgeToEdge,
+                        value = uiState.edgeToEdge,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeEdgeToEdge(value)
+                            )
+                        },
+                    )
+
+                    // system bar theme
+                    if (uiState.edgeToEdge) {
+                        val barThemeName = if (uiState.opaqueSystemBars) {
+                            UiBarTheme.Opaque.toReadableName()
+                        } else {
+                            UiBarTheme.Transparent.toReadableName()
+                        }
+                        SettingsRow(
+                            title = LocalXmlStrings.current.settingsBarTheme,
+                            value = barThemeName,
+                            onTap = rememberCallback {
+                                val sheet = BarThemeBottomSheet()
+                                navigationCoordinator.showBottomSheet(sheet)
+                            },
+                        )
+                    }
+
+                    // bottom navigation hiding
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsHideNavigationBar,
+                        value = uiState.hideNavigationBarWhileScrolling,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeHideNavigationBarWhileScrolling(
+                                    value
+                                )
+                            )
+                        },
+                    )
+
+                    // auto-expand comments
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsAutoExpandComments,
+                        value = uiState.autoExpandComments,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeAutoExpandComments(value)
+                            )
+                        },
+                    )
+
+                    // infinite scrolling
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsInfiniteScrollDisabled,
+                        value = uiState.infiniteScrollDisabled,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeInfiniteScrollDisabled(value)
+                            )
+                        },
+                    )
+
+                    if (uiState.isLogged) {
+                        // mark as read while scrolling
+                        SettingsSwitchRow(
+                            title = LocalXmlStrings.current.settingsMarkAsReadWhileScrolling,
+                            value = uiState.markAsReadWhileScrolling,
+                            onValueChanged = rememberCallbackArgs(model) { value ->
+                                model.reduce(
+                                    AdvancedSettingsMviModel.Intent.ChangeMarkAsReadWhileScrolling(
+                                        value
+                                    )
+                                )
+                            },
+                        )
+                    }
+
+                    // zombie mode interval
+                    SettingsRow(
+                        title = LocalXmlStrings.current.settingsZombieModeInterval,
+                        value = uiState.zombieModeInterval.getPrettyDuration(
+                            secondsLabel = LocalXmlStrings.current.postSecondShort,
+                            minutesLabel = LocalXmlStrings.current.postMinuteShort,
+                            hoursLabel = LocalXmlStrings.current.homeSortTypeTop6Hours,
+                        ),
+                        onTap = rememberCallback {
+                            val sheet = DurationBottomSheet()
+                            navigationCoordinator.showBottomSheet(sheet)
+                        },
+                    )
+
+                    // zombie scroll amount
+                    SettingsRow(
+                        title = LocalXmlStrings.current.settingsZombieModeScrollAmount,
+                        value = buildString {
+                            val pt = uiState.zombieModeScrollAmount.toLocalDp().value.roundToInt()
+                            append(pt)
+                            append(LocalXmlStrings.current.settingsPointsShort)
+                        },
+                        onTap = rememberCallback {
+                            val sheet = SliderBottomSheet(
+                                min = 0f,
+                                max = screenWidth,
+                                initial = uiState.zombieModeScrollAmount,
+                            )
+                            navigationCoordinator.showBottomSheet(sheet)
+                        },
+                    )
+
+                    if (uiState.isLogged) {
+                        // double tap
+                        SettingsSwitchRow(
+                            title = LocalXmlStrings.current.settingsEnableDoubleTap,
+                            value = uiState.enableDoubleTapAction,
+                            onValueChanged = rememberCallbackArgs(model) { value ->
+                                model.reduce(
+                                    AdvancedSettingsMviModel.Intent.ChangeEnableDoubleTapAction(
+                                        value
+                                    )
+                                )
+                            },
+                        )
+                    }
+
+                    // image loading
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsAutoLoadImages,
+                        value = uiState.autoLoadImages,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeAutoLoadImages(value)
+                            )
+                        },
+                    )
+
+                    // search posts only in title
+                    SettingsSwitchRow(
+                        title = LocalXmlStrings.current.settingsSearchPostsTitleOnly,
+                        value = uiState.searchPostTitleOnly,
+                        onValueChanged = rememberCallbackArgs(model) { value ->
+                            model.reduce(
+                                AdvancedSettingsMviModel.Intent.ChangeSearchPostTitleOnly(value)
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -1,0 +1,253 @@
+package com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced
+
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiBarTheme
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.architecture.DefaultMviModel
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.ContentResetCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenter
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.SettingsModel
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.toInboxDefaultType
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.toInboxUnreadOnly
+import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+
+class AdvancedSettingsViewModel(
+    private val themeRepository: ThemeRepository,
+    private val identityRepository: IdentityRepository,
+    private val settingsRepository: SettingsRepository,
+    private val accountRepository: AccountRepository,
+    private val notificationCenter: NotificationCenter,
+    private val contentResetCoordinator: ContentResetCoordinator,
+) : AdvancedSettingsMviModel,
+    DefaultMviModel<AdvancedSettingsMviModel.Intent, AdvancedSettingsMviModel.UiState, AdvancedSettingsMviModel.Effect>(
+        initialState = AdvancedSettingsMviModel.UiState(),
+    ) {
+
+    override fun onStarted() {
+        super.onStarted()
+        scope?.launch {
+            themeRepository.navItemTitles.onEach { value ->
+                updateState { it.copy(navBarTitlesVisible = value) }
+            }.launchIn(this)
+
+            identityRepository.isLogged.onEach { logged ->
+                updateState { it.copy(isLogged = logged ?: false) }
+            }.launchIn(this)
+
+            notificationCenter.subscribe(NotificationCenterEvent.ChangeZombieInterval::class)
+                .onEach { evt ->
+                    changeZombieModeInterval(evt.value)
+                }.launchIn(this)
+            notificationCenter.subscribe(NotificationCenterEvent.ChangeZombieScrollAmount::class)
+                .onEach { evt ->
+                    changeZombieModeScrollAmount(evt.value)
+                }.launchIn(this)
+            notificationCenter.subscribe(NotificationCenterEvent.ChangeInboxType::class)
+                .onEach { evt ->
+                    changeDefaultInboxUnreadOnly(evt.unreadOnly)
+                }.launchIn(this)
+            notificationCenter.subscribe(NotificationCenterEvent.ChangeSystemBarTheme::class)
+                .onEach { evt ->
+                    changeSystemBarTheme(evt.value)
+                }.launchIn(this)
+        }
+
+        val settings = settingsRepository.currentSettings.value
+        updateState {
+            it.copy(
+                defaultInboxUnreadOnly = settings.defaultInboxType.toInboxUnreadOnly(),
+                enableDoubleTapAction = settings.enableDoubleTapAction,
+                autoLoadImages = settings.autoLoadImages,
+                autoExpandComments = settings.autoExpandComments,
+                hideNavigationBarWhileScrolling = settings.hideNavigationBarWhileScrolling,
+                zombieModeInterval = settings.zombieModeInterval,
+                zombieModeScrollAmount = settings.zombieModeScrollAmount,
+                markAsReadWhileScrolling = settings.markAsReadWhileScrolling,
+                searchPostTitleOnly = settings.searchPostTitleOnly,
+                edgeToEdge = settings.edgeToEdge,
+                infiniteScrollDisabled = !settings.infiniteScrollEnabled,
+                opaqueSystemBars = settings.opaqueSystemBars,
+
+                )
+        }
+    }
+
+    override fun reduce(intent: AdvancedSettingsMviModel.Intent) {
+        when (intent) {
+            is AdvancedSettingsMviModel.Intent.ChangeNavBarTitlesVisible -> changeNavBarTitlesVisible(
+                intent.value
+            )
+
+            is AdvancedSettingsMviModel.Intent.ChangeEnableDoubleTapAction ->
+                changeEnableDoubleTapAction(intent.value)
+
+            is AdvancedSettingsMviModel.Intent.ChangeAutoLoadImages -> changeAutoLoadImages(intent.value)
+            is AdvancedSettingsMviModel.Intent.ChangeAutoExpandComments -> changeAutoExpandComments(
+                intent.value
+            )
+
+            is AdvancedSettingsMviModel.Intent.ChangeHideNavigationBarWhileScrolling ->
+                changeHideNavigationBarWhileScrolling(intent.value)
+
+            is AdvancedSettingsMviModel.Intent.ChangeMarkAsReadWhileScrolling ->
+                changeMarkAsReadWhileScrolling(intent.value)
+
+            is AdvancedSettingsMviModel.Intent.ChangeSearchPostTitleOnly -> changeSearchPostTitleOnly(
+                intent.value
+            )
+
+            is AdvancedSettingsMviModel.Intent.ChangeEdgeToEdge -> changeEdgeToEdge(intent.value)
+            is AdvancedSettingsMviModel.Intent.ChangeInfiniteScrollDisabled ->
+                changeInfiniteScrollDisabled(intent.value)
+        }
+    }
+
+    private fun changeNavBarTitlesVisible(value: Boolean) {
+        themeRepository.changeNavItemTitles(value)
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                navigationTitlesVisible = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeEnableDoubleTapAction(value: Boolean) {
+        updateState { it.copy(enableDoubleTapAction = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                enableDoubleTapAction = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeAutoLoadImages(value: Boolean) {
+        updateState { it.copy(autoLoadImages = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                autoLoadImages = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeAutoExpandComments(value: Boolean) {
+        updateState { it.copy(autoExpandComments = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                autoExpandComments = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeHideNavigationBarWhileScrolling(value: Boolean) {
+        updateState { it.copy(hideNavigationBarWhileScrolling = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                hideNavigationBarWhileScrolling = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeMarkAsReadWhileScrolling(value: Boolean) {
+        updateState { it.copy(markAsReadWhileScrolling = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                markAsReadWhileScrolling = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeZombieModeInterval(value: Duration) {
+        updateState { it.copy(zombieModeInterval = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                zombieModeInterval = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeZombieModeScrollAmount(value: Float) {
+        updateState { it.copy(zombieModeScrollAmount = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                zombieModeScrollAmount = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeDefaultInboxUnreadOnly(value: Boolean) {
+        updateState { it.copy(defaultInboxUnreadOnly = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                defaultInboxType = value.toInboxDefaultType(),
+            )
+            saveSettings(settings)
+            contentResetCoordinator.resetInbox = true
+        }
+    }
+
+    private fun changeSearchPostTitleOnly(value: Boolean) {
+        updateState { it.copy(searchPostTitleOnly = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                searchPostTitleOnly = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeEdgeToEdge(value: Boolean) {
+        updateState { it.copy(edgeToEdge = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                edgeToEdge = value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeInfiniteScrollDisabled(value: Boolean) {
+        updateState { it.copy(infiniteScrollDisabled = value) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                infiniteScrollEnabled = !value
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeSystemBarTheme(value: UiBarTheme) {
+        val opaque = when (value) {
+            UiBarTheme.Opaque -> true
+            else -> false
+        }
+        updateState { it.copy(opaqueSystemBars = opaque) }
+        scope?.launch(Dispatchers.IO) {
+            val settings = settingsRepository.currentSettings.value.copy(
+                opaqueSystemBars = opaque
+            )
+            saveSettings(settings)
+        }
+    }
+
+    private suspend fun saveSettings(settings: SettingsModel) {
+        val accountId = accountRepository.getActive()?.id
+        settingsRepository.updateSettings(settings, accountId)
+        settingsRepository.changeCurrentSettings(settings)
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/di/SettingsModule.kt
@@ -1,5 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.feature.settings.di
 
+import com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced.AdvancedSettingsMviModel
+import com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced.AdvancedSettingsViewModel
 import com.github.diegoberaldin.raccoonforlemmy.feature.settings.colors.SettingsColorAndFontMviModel
 import com.github.diegoberaldin.raccoonforlemmy.feature.settings.colors.SettingsColorAndFontViewModel
 import com.github.diegoberaldin.raccoonforlemmy.feature.settings.main.SettingsMviModel
@@ -30,6 +32,16 @@ val settingsTabModule = module {
             identityRepository = get(),
             colorSchemeProvider = get(),
             notificationCenter = get(),
+        )
+    }
+    factory<AdvancedSettingsMviModel> {
+        AdvancedSettingsViewModel(
+            settingsRepository = get(),
+            accountRepository = get(),
+            themeRepository = get(),
+            identityRepository = get(),
+            notificationCenter = get(),
+            contentResetCoordinator = get(),
         )
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsMviModel.kt
@@ -5,8 +5,6 @@ import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiTheme
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 interface SettingsMviModel :
     MviModel<SettingsMviModel.Intent, SettingsMviModel.UiState, SettingsMviModel.Effect>,
@@ -15,21 +13,11 @@ interface SettingsMviModel :
     sealed interface Intent {
         data class ChangeUiTheme(val value: UiTheme?) : Intent
         data class ChangeLanguage(val value: String) : Intent
-        data class ChangeNavBarTitlesVisible(val value: Boolean) : Intent
         data class ChangeIncludeNsfw(val value: Boolean) : Intent
         data class ChangeBlurNsfw(val value: Boolean) : Intent
-        data class ChangeOpenUrlsInExternalBrowser(val value: Boolean) : Intent
         data class ChangeEnableSwipeActions(val value: Boolean) : Intent
-        data class ChangeEnableDoubleTapAction(val value: Boolean) : Intent
+        data class ChangeOpenUrlsInExternalBrowser(val value: Boolean) : Intent
         data class ChangeCrashReportEnabled(val value: Boolean) : Intent
-        data class ChangeAutoLoadImages(val value: Boolean) : Intent
-        data class ChangeAutoExpandComments(val value: Boolean) : Intent
-        data class ChangeHideNavigationBarWhileScrolling(val value: Boolean) : Intent
-        data class ChangeMarkAsReadWhileScrolling(val value: Boolean) : Intent
-        data class ChangeDefaultInboxUnreadOnly(val value: Boolean) : Intent
-        data class ChangeSearchPostTitleOnly(val value: Boolean) : Intent
-        data class ChangeEdgeToEdge(val value: Boolean) : Intent
-        data class ChangeInfiniteScrollDisabled(val value: Boolean) : Intent
     }
 
     data class UiState(
@@ -39,26 +27,13 @@ interface SettingsMviModel :
         val defaultListingType: ListingType = ListingType.Local,
         val defaultPostSortType: SortType = SortType.Active,
         val defaultCommentSortType: SortType = SortType.New,
-        val defaultInboxUnreadOnly: Boolean = true,
-        val navBarTitlesVisible: Boolean = false,
+        val enableSwipeActions: Boolean = true,
         val includeNsfw: Boolean = true,
         val blurNsfw: Boolean = true,
         val openUrlsInExternalBrowser: Boolean = false,
-        val enableSwipeActions: Boolean = true,
-        val enableDoubleTapAction: Boolean = true,
         val crashReportEnabled: Boolean = false,
-        val autoLoadImages: Boolean = false,
-        val autoExpandComments: Boolean = false,
-        val hideNavigationBarWhileScrolling: Boolean = true,
-        val zombieModeInterval: Duration = 2.5.seconds,
-        val zombieModeScrollAmount: Float = 100f,
-        val markAsReadWhileScrolling: Boolean = true,
         val availableSortTypesForPosts: List<SortType> = emptyList(),
         val availableSortTypesForComments: List<SortType> = emptyList(),
-        val searchPostTitleOnly: Boolean = false,
-        val edgeToEdge: Boolean = true,
-        val infiniteScrollDisabled: Boolean = false,
-        val opaqueSystemBars: Boolean = false,
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material.icons.filled.BugReport
-import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Explicit
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.SettingsApplications
@@ -36,13 +35,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.unit.toSize
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
-import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiBarTheme
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toReadableName
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.bindToLifecycle
@@ -50,12 +46,8 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsHe
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.handleUrl
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.BarThemeBottomSheet
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.DurationBottomSheet
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.InboxTypeSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.LanguageBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.ListingTypeBottomSheet
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SliderBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SortBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.ThemeBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
@@ -67,12 +59,11 @@ import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotific
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.datetime.getPrettyDuration
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLanguageFlag
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLanguageName
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toReadableName
+import com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced.AdvancedSettingsScreen
 import com.github.diegoberaldin.raccoonforlemmy.feature.settings.colors.SettingsColorAndFontScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.about.AboutDialog
 import com.github.diegoberaldin.raccoonforlemmy.unit.accountsettings.AccountSettingsScreen
@@ -83,7 +74,6 @@ import com.github.diegoberaldin.raccoonforlemmy.unit.web.WebViewScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 class SettingsScreen : Screen {
 
@@ -118,11 +108,8 @@ class SettingsScreen : Screen {
             }.launchIn(this)
         }
 
-        var screenWidth by remember { mutableStateOf(0f) }
         Scaffold(
-            modifier = Modifier.onGloballyPositioned {
-                screenWidth = it.size.toSize().width
-            }.padding(Spacing.xxs),
+            modifier = Modifier.padding(Spacing.xs),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -190,56 +177,6 @@ class SettingsScreen : Screen {
                         },
                     )
 
-                    // navigation bar titles
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsNavigationBarTitlesVisible,
-                        value = uiState.navBarTitlesVisible,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeNavBarTitlesVisible(value)
-                            )
-                        },
-                    )
-
-                    // edge to edge
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsEdgeToEdge,
-                        value = uiState.edgeToEdge,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeEdgeToEdge(value)
-                            )
-                        },
-                    )
-
-                    // system bar theme
-                    if (uiState.edgeToEdge) {
-                        val barThemeName = if (uiState.opaqueSystemBars) {
-                            UiBarTheme.Opaque.toReadableName()
-                        } else {
-                            UiBarTheme.Transparent.toReadableName()
-                        }
-                        SettingsRow(
-                            title = LocalXmlStrings.current.settingsBarTheme,
-                            value = barThemeName,
-                            onTap = rememberCallback {
-                                val sheet = BarThemeBottomSheet()
-                                navigationCoordinator.showBottomSheet(sheet)
-                            },
-                        )
-                    }
-
-                    // bottom navigation hiding
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsHideNavigationBar,
-                        value = uiState.hideNavigationBarWhileScrolling,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeHideNavigationBarWhileScrolling(value)
-                            )
-                        },
-                    )
-
                     // colors and fonts
                     SettingsRow(
                         title = LocalXmlStrings.current.settingsColorsAndFonts,
@@ -249,19 +186,18 @@ class SettingsScreen : Screen {
                         }
                     )
 
-                    SettingsHeader(
-                        icon = Icons.Default.Dashboard,
-                        title = LocalXmlStrings.current.settingsSectionFeed,
-                    )
-
-
-                    // colors and fonts
+                    // content view configuration
                     SettingsRow(
                         title = LocalXmlStrings.current.settingsConfigureContent,
                         disclosureIndicator = true,
                         onTap = rememberCallback {
                             navigationCoordinator.pushScreen(ConfigureContentViewScreen())
                         }
+                    )
+
+                    SettingsHeader(
+                        icon = Icons.Default.SettingsApplications,
+                        title = LocalXmlStrings.current.settingsSectionGeneral,
                     )
 
                     // default listing type
@@ -307,94 +243,6 @@ class SettingsScreen : Screen {
                     )
 
                     if (uiState.isLogged) {
-                        // default inbox type
-                        SettingsRow(
-                            title = LocalXmlStrings.current.settingsDefaultInboxType,
-                            value = if (uiState.defaultInboxUnreadOnly) {
-                                LocalXmlStrings.current.inboxListingTypeUnread
-                            } else {
-                                LocalXmlStrings.current.inboxListingTypeAll
-                            },
-                            onTap = rememberCallback {
-                                val sheet = InboxTypeSheet()
-                                navigationCoordinator.showBottomSheet(sheet)
-                            },
-                        )
-                    }
-
-                    SettingsHeader(
-                        icon = Icons.Default.SettingsApplications,
-                        title = LocalXmlStrings.current.settingsSectionBehaviour,
-                    )
-
-                    // auto-expand comments
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsAutoExpandComments,
-                        value = uiState.autoExpandComments,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeAutoExpandComments(value)
-                            )
-                        },
-                    )
-
-                    // infinite scrolling
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsInfiniteScrollDisabled,
-                        value = uiState.infiniteScrollDisabled,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeInfiniteScrollDisabled(value)
-                            )
-                        },
-                    )
-
-                    if (uiState.isLogged) {
-                        // mark as read while scrolling
-                        SettingsSwitchRow(
-                            title = LocalXmlStrings.current.settingsMarkAsReadWhileScrolling,
-                            value = uiState.markAsReadWhileScrolling,
-                            onValueChanged = rememberCallbackArgs(model) { value ->
-                                model.reduce(
-                                    SettingsMviModel.Intent.ChangeMarkAsReadWhileScrolling(value)
-                                )
-                            },
-                        )
-                    }
-
-                    // zombie mode interval
-                    SettingsRow(
-                        title = LocalXmlStrings.current.settingsZombieModeInterval,
-                        value = uiState.zombieModeInterval.getPrettyDuration(
-                            secondsLabel = LocalXmlStrings.current.postSecondShort,
-                            minutesLabel = LocalXmlStrings.current.postMinuteShort,
-                            hoursLabel = LocalXmlStrings.current.homeSortTypeTop6Hours,
-                        ),
-                        onTap = rememberCallback {
-                            val sheet = DurationBottomSheet()
-                            navigationCoordinator.showBottomSheet(sheet)
-                        },
-                    )
-
-                    // zombie scroll amount
-                    SettingsRow(
-                        title = LocalXmlStrings.current.settingsZombieModeScrollAmount,
-                        value = buildString {
-                            val pt = uiState.zombieModeScrollAmount.toLocalDp().value.roundToInt()
-                            append(pt)
-                            append(LocalXmlStrings.current.settingsPointsShort)
-                        },
-                        onTap = rememberCallback {
-                            val sheet = SliderBottomSheet(
-                                min = 0f,
-                                max = screenWidth,
-                                initial = uiState.zombieModeScrollAmount,
-                            )
-                            navigationCoordinator.showBottomSheet(sheet)
-                        },
-                    )
-
-                    if (uiState.isLogged) {
                         // swipe actions
                         SettingsSwitchRow(
                             title = LocalXmlStrings.current.settingsEnableSwipeActions,
@@ -413,17 +261,6 @@ class SettingsScreen : Screen {
                                 navigationCoordinator.pushScreen(screen)
                             },
                         )
-
-                        // double tap
-                        SettingsSwitchRow(
-                            title = LocalXmlStrings.current.settingsEnableDoubleTap,
-                            value = uiState.enableDoubleTapAction,
-                            onValueChanged = rememberCallbackArgs(model) { value ->
-                                model.reduce(
-                                    SettingsMviModel.Intent.ChangeEnableDoubleTapAction(value)
-                                )
-                            },
-                        )
                     }
 
                     // URL open
@@ -437,25 +274,13 @@ class SettingsScreen : Screen {
                         },
                     )
 
-                    // image loading
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsAutoLoadImages,
-                        value = uiState.autoLoadImages,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeAutoLoadImages(value)
-                            )
-                        },
-                    )
-
-                    // search posts only in title
-                    SettingsSwitchRow(
-                        title = LocalXmlStrings.current.settingsSearchPostsTitleOnly,
-                        value = uiState.searchPostTitleOnly,
-                        onValueChanged = rememberCallbackArgs(model) { value ->
-                            model.reduce(
-                                SettingsMviModel.Intent.ChangeSearchPostTitleOnly(value)
-                            )
+                    // advanced settings
+                    SettingsRow(
+                        title = LocalXmlStrings.current.settingsAdvanced,
+                        disclosureIndicator = true,
+                        onTap = rememberCallback {
+                            val screen = AdvancedSettingsScreen()
+                            navigationCoordinator.pushScreen(screen)
                         },
                     )
 


### PR DESCRIPTION
The settings screen was too cluttered with many things, most of which were added over time and were not probably used by anyone.

This PR moves all the settings that are intended for pro users in a separate sub-screen "Advanced settings", leaving only the basic ones in the main screen.