### PR TITLE
feat: add share option to community and user detail

### DIFF
--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -109,6 +109,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.containsId
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.unit.ban.BanUserScreen
@@ -293,6 +294,9 @@ class CommunityDetailScreen(
                                     OptionId.InfoInstance,
                                     LocalXmlStrings.current.communityDetailInstanceInfo
                                 )
+                                this += Option(
+                                    OptionId.Share, LocalXmlStrings.current.postActionShare
+                                )
                                 if (uiState.isLogged) {
                                     this += Option(
                                         OptionId.Block,
@@ -399,6 +403,25 @@ class CommunityDetailScreen(
                                                             communityId = uiState.community.id,
                                                         )
                                                         navigationCoordinator.pushScreen(screen)
+                                                    }
+
+                                                    OptionId.Share -> {
+                                                        val urls = buildList {
+                                                            if (uiState.community.host != uiState.instance) {
+                                                                this += "https://${uiState.instance}/c/${uiState.community.readableHandle}"
+                                                            }
+                                                            this += "https://${uiState.community.host}/c/${uiState.community.name}"
+                                                        }
+                                                        if (urls.size == 1) {
+                                                            model.reduce(
+                                                                CommunityDetailMviModel.Intent.Share(
+                                                                    urls.first()
+                                                                )
+                                                            )
+                                                        } else {
+                                                            val screen = ShareBottomSheet(urls = urls)
+                                                            navigationCoordinator.showBottomSheet(screen)
+                                                        }
                                                     }
 
                                                     else -> Unit

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -105,6 +105,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallb
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableName
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
@@ -240,6 +241,9 @@ class UserDetailScreen(
                                 this += Option(
                                     OptionId.Info, LocalXmlStrings.current.userDetailInfo
                                 )
+                                this += Option(
+                                    OptionId.Share, LocalXmlStrings.current.postActionShare
+                                )
                                 if (uiState.isLogged) {
                                     this += Option(
                                         OptionId.Block,
@@ -296,6 +300,25 @@ class UserDetailScreen(
                                                         navigationCoordinator.showBottomSheet(
                                                             UserInfoScreen(uiState.user.id),
                                                         )
+                                                    }
+
+                                                    OptionId.Share -> {
+                                                        val urls = buildList {
+                                                            if (uiState.user.host != uiState.instance) {
+                                                                this += "https://${uiState.instance}/u/${uiState.user.readableHandle}"
+                                                            }
+                                                            this += "https://${uiState.user.host}/u/${uiState.user.name}"
+                                                        }
+                                                        if (urls.size == 1) {
+                                                            model.reduce(
+                                                                UserDetailMviModel.Intent.Share(
+                                                                    urls.first()
+                                                                )
+                                                            )
+                                                        } else {
+                                                            val screen = ShareBottomSheet(urls = urls)
+                                                            navigationCoordinator.showBottomSheet(screen)
+                                                        }
                                                     }
 
                                                     else -> Unit


### PR DESCRIPTION
This PR adds the "share" option in community and user detail screens. As usual, if you are on a different instance, you can choose among multiple URL formats, one pointing to your local instance and the other to the original instance.