### PR TITLE
chore: add tests for :core:notifications

### DIFF
--- a/core/notifications/build.gradle.kts
+++ b/core/notifications/build.gradle.kts
@@ -38,9 +38,13 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
             }
         }
-        val commonTest by getting {
+        val androidUnitTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(kotlin("test-junit"))
+                implementation(libs.mockk)
+                implementation(libs.turbine)
+                implementation(projects.core.testutils)
             }
         }
     }

--- a/core/notifications/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultContentResetCoordinatorTest.kt
+++ b/core/notifications/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultContentResetCoordinatorTest.kt
@@ -1,0 +1,52 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.notifications
+
+import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultContentResetCoordinatorTest {
+
+    @get:Rule
+    val dispatcherRule = DispatcherTestRule()
+
+    private val sut = DefaultContentResetCoordinator()
+
+    @Test
+    fun whenResetExplore_thenValueIsUpdatedAccordingly() = runTest {
+        val initial = sut.resetExplore
+        assertFalse(initial)
+
+        with(sut) {
+            resetExplore = true
+        }
+
+        assertTrue(sut.resetExplore)
+    }
+
+    @Test
+    fun whenResetHome_thenValueIsUpdatedAccordingly() = runTest {
+        val initial = sut.resetHome
+        assertFalse(initial)
+
+        with(sut) {
+            resetHome = true
+        }
+
+        assertTrue(sut.resetHome)
+    }
+
+    @Test
+    fun whenResetInbox_thenValueIsUpdatedAccordingly() = runTest {
+        val initial = sut.resetInbox
+        assertFalse(initial)
+
+        with(sut) {
+            resetInbox = true
+        }
+
+        assertTrue(sut.resetInbox)
+    }
+}

--- a/core/notifications/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultNotificationCenterTest.kt
+++ b/core/notifications/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultNotificationCenterTest.kt
@@ -1,0 +1,70 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.notifications
+
+import app.cash.turbine.test
+import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultNotificationCenterTest {
+
+    @get:Rule
+    val dispatcherRule = DispatcherTestRule()
+
+    private val sut = DefaultNotificationCenter
+
+    @Test
+    fun givenSubscription_whenSendEvent_thenEventIsReceivedJustOnce() = runTest {
+        launch {
+            sut.send(NotificationCenterEvent.Logout)
+        }
+
+
+        sut.subscribe(NotificationCenterEvent.Logout::class).test {
+            val evt = awaitItem()
+            assertEquals(NotificationCenterEvent.Logout, evt)
+        }
+
+        sut.subscribe(NotificationCenterEvent.Logout::class).test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun givenMultipleSubscriptions_whenSendReplayableEvent_thenEventIsReceivedAndReplayed() =
+        runTest {
+            launch {
+                sut.send(NotificationCenterEvent.PostCreated)
+            }
+
+            sut.subscribe(NotificationCenterEvent.PostCreated::class).test {
+                val evt = awaitItem()
+                assertEquals(NotificationCenterEvent.PostCreated, evt)
+            }
+
+            sut.subscribe(NotificationCenterEvent.PostCreated::class).test {
+                val evt = awaitItem()
+                assertEquals(NotificationCenterEvent.PostCreated, evt)
+            }
+        }
+
+    @Test
+    fun givenMultipleSubscriptions_whenResetCache_thenEventIsNotReplayed() =
+        runTest {
+            launch {
+                sut.send(NotificationCenterEvent.PostCreated)
+            }
+            sut.subscribe(NotificationCenterEvent.PostCreated::class).test {
+                val evt = awaitItem()
+                assertEquals(NotificationCenterEvent.PostCreated, evt)
+            }
+
+            sut.resetCache()
+
+            sut.subscribe(NotificationCenterEvent.PostCreated::class).test {
+                expectNoEvents()
+            }
+        }
+}


### PR DESCRIPTION
Adds tests for the `:core:notifications` module.