### PR TITLE
fix: login at startup if not connectivity

### DIFF
--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -89,7 +89,7 @@
     <string name="inbox_listing_type_all">الجميع</string>
     <string name="inbox_listing_type_title">نوع البريد الوارد</string>
     <string name="inbox_listing_type_unread">غير مقروءة</string>
-    <string name="inbox_not_logged_message">\n</string>
+    <string name="inbox_not_logged_message">لم تقم بتسجيل الدخول حاليًا.\nيرجى إضافة حساب من شاشة الملف الشخصي لرؤية صندوق الوارد الخاص بكn</string>
     <string name="inbox_section_mentions">عدد المرات التي ذكر فيها</string>
     <string name="inbox_section_messages">رسائل</string>
     <string name="inbox_section_replies">Replies</string>
@@ -105,9 +105,7 @@
     <string name="manage_accounts_title">إدارة الحسابات</string>
     <string name="manage_subscriptions_header_multicommunities">تعدد المجتمعات</string>
     <string name="manage_subscriptions_header_subscriptions">الاشتراكات</string>
-    <string name="message_empty_comments">المكان صامت للغاية هناك.\nهل ترغب في أن تكون الشخص الذي
-        يكتب التعليق الأول؟
-    </string>
+    <string name="message_empty_comments">المكان صامت للغاية هناك.\nهل ترغب في أن تكون الشخص الذييكتب التعليق الأول؟</string>
     <string name="message_empty_list">لا توجد عناصر للعرض</string>
     <string name="message_error_loading_comments">حدث خطأ أثناء تحميل التعليقات.</string>
     <string name="message_generic_error">عام خطأ.</string>
@@ -142,9 +140,7 @@
     <string name="profile_day_short">أيام</string>
     <string name="profile_million_short">ملايين</string>
     <string name="profile_month_short">شهور</string>
-    <string name="profile_not_logged_message">لم تقم بتسجيل الدخول حاليًا\n .يرجى إضافة
-        حساب للمتابعة.
-    </string>
+    <string name="profile_not_logged_message">لم تقم بتسجيل الدخول حاليًا\n .يرجى إضافةحساب للمتابعة.</string>
     <string name="profile_section_comments">التعليقات</string>
     <string name="profile_section_posts">المنشورات</string>
     <string name="profile_thousand_short">k</string>
@@ -217,9 +213,7 @@
     <string name="settings_hide_navigation_bar">إخفاء شريط التنقل أثناء التمرير</string>
     <string name="settings_zombie_mode_interval">مدة الفاصل الزمني لوضع الزومبي</string>
     <string name="settings_zombie_mode_scroll_amount">كمية التمرير في وضع الزومبي</string>
-    <string name="settings_mark_as_read_while_scrolling">وضع علامة على المنشورات كمقروءة أثناء
-        التمرير
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">وضع علامة على المنشورات كمقروءة أثناءالتمرير</string>
     <string name="action_quote">اقتباس</string>
     <string name="mod_action_allow">السماح للمستخدم مرة أخرى</string>
     <string name="mod_action_ban">حظر العضو</string>
@@ -237,10 +231,7 @@
     <string name="report_list_type_unresolved">غير محلول</string>
     <string name="report_action_resolve">تحلل</string>
     <string name="report_action_unresolve">إلغاء الحل</string>
-    <string name="sidebar_not_logged_message">مرحبًا بك في الراكون من أجل ليمي!\n\nفي الوضع المجهول،
-        استخدم زر القائمة المنسدلة (▼) أعلاه لتغيير المثيل.\n\nيمكنك تسجيل الدخول إلى حسابك في أي
-        وقت من شاشة ملف التعريف.\n\nاستمتع بليمي!
-    </string>
+    <string name="sidebar_not_logged_message">مرحبًا بك في الراكون من أجل ليمي!\n\nفي الوضع المجهول، استخدم زر القائمة المنسدلة (▼) أعلاه لتغيير المثيل.\n\nيمكنك تسجيل الدخول إلى حسابك في أي وقت من شاشة ملف التعريف.\n\nاستمتع بليمي!</string>
     <string name="settings_default_inbox_type">نوع البريد الوارد الافتراضي</string>
     <string name="mod_action_add_mod">إضافة مشرف</string>
     <string name="mod_action_remove_mod">إزالة المشرف</string>
@@ -341,4 +332,5 @@
     <string name="moderator_zone_title">أدوات للمشرفين</string>
     <string name="moderator_zone_action_comments">تعليقات خاضعة للإشراف</string>
     <string name="moderator_zone_action_posts">المشاركات الخاضعة للإشراف</string>
+    <string name="message_auth_issue">حدث خطأ أثناء جلب بيانات المستخدم، حاول تحديث الشاشة</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Всички</string>
     <string name="inbox_listing_type_title">Тип входяща поща</string>
     <string name="inbox_listing_type_unread">Отбелязване като непрочетено</string>
-    <string name="inbox_not_logged_message">В момента не сте влезли.Моля, добавете\n акаунт
-        от екрана на профила, за да видите входящата си поща.
-    </string>
+    <string name="inbox_not_logged_message">В момента не сте влезли.Моля, добавете\n акаунт от екрана на профила, за да видите входящата си поща.</string>
     <string name="inbox_section_mentions">Споменавания</string>
     <string name="inbox_section_messages">Съобщения</string>
     <string name="inbox_section_replies">Отговори</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Акаунти</string>
     <string name="manage_subscriptions_header_multicommunities">Мулти - общности</string>
     <string name="manage_subscriptions_header_subscriptions">Абонаменти</string>
-    <string name="message_empty_comments">Таме твърде тихо.Бихте\n ли искали да сте този, който
-        пише първия коментар?
-    </string>
+    <string name="message_empty_comments">Таме твърде тихо.Бихте\n ли искали да сте този, който пише първия коментар?</string>
     <string name="message_empty_list">Няма данни за показване</string>
-    <string name="message_error_loading_comments">Възникна грешка при зареждането на коментарите.
-    </string>
+    <string name="message_error_loading_comments">Възникна грешка при зареждането на коментарите.</string>
     <string name="message_generic_error">Обща грешка</string>
     <string name="message_image_loading_error">Грешка при зареждане на изображението</string>
     <string name="message_invalid_field">Невалиден ID на полето.</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">В момента не сте влезли.Моля, добавете\n акаунт, за да
-        продължите.
-    </string>
+    <string name="profile_not_logged_message">В момента не сте влезли.Моля, добавете\n акаунт, за да продължите.</string>
     <string name="profile_section_comments">Коментари</string>
     <string name="profile_section_posts">Публикации</string>
     <string name="profile_thousand_short">k</string>
@@ -155,8 +148,7 @@
     <string name="settings_about">Относно това приложение</string>
     <string name="settings_about_app_version">Версия на приложението</string>
     <string name="settings_about_changelog">Преглед на пълния дневник на промените</string>
-    <string name="settings_about_report_github">Подаване на сигнал за програмна грешка (GitHub)
-    </string>
+    <string name="settings_about_report_github">Подаване на сигнал за програмна грешка (GitHub)</string>
     <string name="settings_about_report_email">Подаване на сигнал за грешка (имейл)</string>
     <string name="settings_about_view_github">Преглед в GitHub</string>
     <string name="settings_about_view_lemmy">Общност на Lemmy</string>
@@ -188,11 +180,9 @@
     <string name="settings_content_font_smaller">Много Малък</string>
     <string name="settings_content_font_smallest">Двойно по - малко</string>
     <string name="settings_custom_seed_color">Персонализиран цвят на темата</string>
-    <string name="settings_default_comment_sort_type">Тип сортиране на коментарите по подразбиране
-    </string>
+    <string name="settings_default_comment_sort_type">Тип сортиране на коментарите по подразбиране</string>
     <string name="settings_default_listing_type">Тип емисия по подразбиране</string>
-    <string name="settings_default_post_sort_type">Тип сортиране на публикация по подразбиране
-    </string>
+    <string name="settings_default_post_sort_type">Тип сортиране на публикация по подразбиране</string>
     <string name="settings_downvote_color">Цвят на отрицателното гласуване</string>
     <string name="settings_dynamic_colors">Използване на динамични цветове</string>
     <string name="settings_enable_crash_report">Активиране на докладването на сриво</string>
@@ -201,9 +191,7 @@
     <string name="settings_full_height_images">Изображения с пълна височина</string>
     <string name="settings_include_nsfw">Включване на съдържание на NSFW</string>
     <string name="settings_language">Език</string>
-    <string name="settings_navigation_bar_titles_visible">Показване на заглавията на лентата за
-        навига
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Показване на заглавията на лентата за навига</string>
     <string name="settings_open_url_external">Отваряне във външен браузър</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Оформление на статията</string>
@@ -222,13 +210,10 @@
     <string name="settings_ui_font_scale">Размер на текста на потребителския интерфейс</string>
     <string name="settings_ui_theme">Тема на потребителския интерфейс</string>
     <string name="settings_upvote_color">Цвят на предварителното гласуване</string>
-    <string name="settings_hide_navigation_bar">Скриване на навигационната лента при превъртане
-    </string>
+    <string name="settings_hide_navigation_bar">Скриване на навигационната лента при превъртане</string>
     <string name="settings_zombie_mode_interval">Продължителност на интервала в режим Зомби</string>
     <string name="settings_zombie_mode_scroll_amount">Сума за превъртане в режим на зомби</string>
-    <string name="settings_mark_as_read_while_scrolling">Маркирайте публикациите като прочетени при
-        превъртате
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Маркирайте публикациите като прочетени при превъртате</string>
     <string name="action_quote">цитат</string>
     <string name="mod_action_allow">Позволи на потребителя отново</string>
     <string name="mod_action_ban">Бан потребител</string>
@@ -239,18 +224,14 @@
     <string name="mod_action_unlock">Отключване</string>
     <string name="mod_action_remove">Премахване</string>
     <string name="mod_action_mark_as_distinguished">Маркиране като отличен</string>
-    <string name="mod_action_unmark_as_distinguished">Премахване на отметката като разграничен
-    </string>
+    <string name="mod_action_unmark_as_distinguished">Премахване на отметката като разграничен</string>
     <string name="report_list_title">Списък с отчети</string>
     <string name="report_list_type_title">Тип списък на отчет</string>
     <string name="report_list_type_all">Всички</string>
     <string name="report_list_type_unresolved">Неразрешено</string>
     <string name="report_action_resolve">Разрешаване</string>
     <string name="report_action_unresolve">Отмяна на разрешаването</string>
-    <string name="sidebar_not_logged_message">Добре дошли в Raccoon for Lemmy!\n\nВ анонимен режим,
-        използвайте падащия бутон (▼) по-горе, за да промените инстанцията.\n\nМожете да влезете във
-        вашата инстанция на по всяко време от екрана на профила.\n\nНасладете се на Леми!
-    </string>
+    <string name="sidebar_not_logged_message">Добре дошли в Raccoon for Lemmy!\n\nВ анонимен режим, използвайте падащия бутон (▼) по-горе, за да промените инстанцията.\n\nМожете да влезете във вашата инстанция на по всяко време от екрана на профила.\n\nНасладете се на Леми!</string>
     <string name="settings_default_inbox_type">Тип входяща кутия по подразбиране</string>
     <string name="mod_action_add_mod">Добавете модератор</string>
     <string name="mod_action_remove_mod">Премахване на модератора</string>
@@ -351,4 +332,5 @@
     <string name="moderator_zone_title">Инструменти за модератори</string>
     <string name="moderator_zone_action_comments">Модерирани коментари</string>
     <string name="moderator_zone_action_posts">Модерирани публикации</string>
+    <string name="message_auth_issue">Възникна грешка при извличането на потребителски данни, опитайте да обновите екрана</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Vše</string>
     <string name="inbox_listing_type_title">Typ doručené pošty</string>
     <string name="inbox_listing_type_unread">Nepřečteno</string>
-    <string name="inbox_not_logged_message">Momentálně nejste přihlášeni. Přidejte\nprosím účet
-        z obrazovky profilu pro zobrazení doručených zpráv.
-    </string>
+    <string name="inbox_not_logged_message">Momentálně nejste přihlášeni. Přidejte\nprosím účet z obrazovky profilu pro zobrazení doručených zpráv.</string>
     <string name="inbox_section_mentions">Zmínky</string>
     <string name="inbox_section_messages">Zprávy</string>
     <string name="inbox_section_replies">Odpovědi</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Správce účtů</string>
     <string name="manage_subscriptions_header_multicommunities">Multikomunity</string>
     <string name="manage_subscriptions_header_subscriptions">Předplatné</string>
-    <string name="message_empty_comments">Je tam příliš ticho.\nChtěl bys být tím, kdo
-        napíše první komentář?
-    </string>
+    <string name="message_empty_comments">Je tam příliš ticho.\nChtěl bys být tím, kdo napíše první komentář?</string>
     <string name="message_empty_list">Žádné položky k zobrazení</string>
     <string name="message_error_loading_comments">Při načítání komentářů došlo k chybě.</string>
     <string name="message_generic_error">Obecná chyba</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Momentálně nejste přihlášeni\n. Přidejteprosím
-        účet pro pokračování.
-    </string>
+    <string name="profile_not_logged_message">Momentálně nejste přihlášeni\n. Přidejteprosím účet pro pokračování.</string>
     <string name="profile_section_comments">Komentáře</string>
     <string name="profile_section_posts">Příspěvky</string>
     <string name="profile_thousand_short">k</string>
@@ -219,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Skrýt navigační panel při rolování</string>
     <string name="settings_zombie_mode_interval">Trvání intervalu režimu Zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Množství posouvání v zombie režimu</string>
-    <string name="settings_mark_as_read_while_scrolling">Označte příspěvky jako přečtené při
-        rolování
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Označte příspěvky jako přečtené při rolování</string>
     <string name="mod_action_allow">Znovu uživateli povolit</string>
     <string name="action_quote">Citát</string>
     <string name="mod_action_ban">Zakázat uživatele</string>
@@ -239,10 +231,7 @@
     <string name="report_list_type_unresolved">Nevyřešeno</string>
     <string name="report_action_resolve">Vyřešit</string>
     <string name="report_action_unresolve">Nevyřešit</string>
-    <string name="sidebar_not_logged_message">Vítejte v Raccoon for Lemmy!\n\nV anonymním režimu
-        použijte rozbalovací tlačítko (▼) výše pro změnu instance.\n\nDo své intance se můžete
-        přihlásit na kdykoli z obrazovky profilu.\n\nUžijte si Lemmyho!
-    </string>
+    <string name="sidebar_not_logged_message">Vítejte v Raccoon for Lemmy!\n\nV anonymním režimu použijte rozbalovací tlačítko (▼) výše pro změnu instance.\n\nDo své intance se můžete přihlásit na kdykoli z obrazovky profilu.\n\nUžijte si Lemmyho! </string>
     <string name="settings_default_inbox_type">Výchozí typ doručené pošty</string>
     <string name="mod_action_add_mod">Přidat moderátora</string>
     <string name="mod_action_remove_mod">Odstranit moderátora</string>
@@ -343,4 +332,5 @@
     <string name="moderator_zone_title">Nástroje pro moderátory</string>
     <string name="moderator_zone_action_comments">Moderované komentáře</string>
     <string name="moderator_zone_action_posts">Moderované příspěvky</string>
+    <string name="message_auth_issue">Při načítání uživatelských dat došlo k chybě, zkuste obnovit obrazovku</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Alle</string>
     <string name="inbox_listing_type_title">Indbakke type</string>
     <string name="inbox_listing_type_unread">Ikke læst</string>
-    <string name="inbox_not_logged_message">Du er i øjeblikket\n ikke loggetind.Tilføj en konto
-        fra profilskærmen for at se din indbakke.
-    </string>
+    <string name="inbox_not_logged_message">Du er i øjeblikket\n ikke loggetind.Tilføj en konto fra profilskærmen for at se din indbakke.</string>
     <string name="inbox_section_mentions">Omtale</string>
     <string name="inbox_section_messages">Beskeder</string>
     <string name="inbox_section_replies">Svar</string>
@@ -107,11 +105,9 @@
     <string name="manage_accounts_title">Administration af kontoer</string>
     <string name="manage_subscriptions_header_multicommunities">Multifællesskaber</string>
     <string name="manage_subscriptions_header_subscriptions">Abonnementer</string>
-    <string name="message_empty_comments">\n</string>
+    <string name="message_empty_comments">Der er for stille.\nVil du være den, der skriver den første kommentar?</string>
     <string name="message_empty_list">Menupunkter, der skal vises</string>
-    <string name="message_error_loading_comments">Der opstod en fejl under indlæsning af
-        kommentarer.
-    </string>
+    <string name="message_error_loading_comments">Der opstod en fejl under indlæsning af kommentarer.</string>
     <string name="message_generic_error">Generisk fejl</string>
     <string name="message_image_loading_error">Billedindlæsningsfejl</string>
     <string name="message_invalid_field">Ugyldigt felt!</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Du er i øjeblikket\n ikke loggetind.Tilføj en
-        konto for at fortsætte.
-    </string>
+    <string name="profile_not_logged_message">Du er i øjeblikket\n ikke loggetind.Tilføj en konto for at fortsætte.</string>
     <string name="profile_section_comments">Kommentarer</string>
     <string name="profile_section_posts">Indlæg</string>
     <string name="profile_thousand_short">k</string>
@@ -186,8 +180,7 @@
     <string name="settings_content_font_smaller">Ekstra lille</string>
     <string name="settings_content_font_smallest">Dobbelt ekstra lille</string>
     <string name="settings_custom_seed_color">Brugerdefineret temafarve</string>
-    <string name="settings_default_comment_sort_type">Standard sorteringstype for kommentarer
-    </string>
+    <string name="settings_default_comment_sort_type">Standard sorteringstype for kommentarer</string>
     <string name="settings_default_listing_type">Standard feed type</string>
     <string name="settings_default_post_sort_type">Standard: Sorterings Type</string>
     <string name="settings_downvote_color">Downvote farve</string>
@@ -220,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Skjul navigationslinjen, mens du ruller</string>
     <string name="settings_zombie_mode_interval">Varighed af Zombie-tilstandsinterval</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie-tilstand scroll beløb</string>
-    <string name="settings_mark_as_read_while_scrolling">Marker indlæg som læst, mens du ruller
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marker indlæg som læst, mens du ruller</string>
     <string name="action_quote">Citere</string>
     <string name="mod_action_allow">Tillade brugeren igen</string>
     <string name="mod_action_ban">Udelukke bruger</string>
@@ -239,10 +231,7 @@
     <string name="report_list_type_unresolved">Ikke løst</string>
     <string name="report_action_resolve">Løs</string>
     <string name="report_action_unresolve">Løs op</string>
-    <string name="sidebar_not_logged_message">Velkommen til Raccoon for Lemmy!\n\nI anonym tilstand,
-        brug rullemenuen (▼) ovenfor for at ændre forekomst.\n\nDu kan logge ind på din forekomst på
-        når som helst fra profilskærmen.\n\nNyd Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Velkommen til Raccoon for Lemmy!\n\nI anonym tilstand, brug rullemenuen (▼) ovenfor for at ændre forekomst.\n\nDu kan logge ind på din forekomst på når som helst fra profilskærmen.\n\nNyd Lemmy!</string>
     <string name="settings_default_inbox_type">Standard indbakketype</string>
     <string name="mod_action_add_mod">Tilføje moderator</string>
     <string name="mod_action_remove_mod">Fjern moderator</string>
@@ -343,4 +332,5 @@
     <string name="moderator_zone_title">Værktøjer til moderatorer</string>
     <string name="moderator_zone_action_comments">Modererede kommentarer</string>
     <string name="moderator_zone_action_posts">Modererede indlæg</string>
+    <string name="message_auth_issue">Der opstod en fejl under hentning af brugerdata. Prøv at opdatere skærmen</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Ungelesen</string>
     <string name="inbox_action_mark_read">Als gelesen markieren</string>
     <string name="inbox_action_mark_unread">Als ungelesen markieren</string>
-    <string name="inbox_not_logged_message">Sie sind derzeit nicht angemeldet.\nBitte fügen Sie über
-        den Profilbildschirm ein Konto hinzu, um Ihren Posteingang anzuzeigen.
-    </string>
+    <string name="inbox_not_logged_message">Sie sind derzeit nicht angemeldet.\nBitte fügen Sie über den Profilbildschirm ein Konto hinzu, um Ihren Posteingang anzuzeigen.</string>
     <string name="inbox_section_mentions">Erwähnungen</string>
     <string name="inbox_section_messages">Mitteilungen</string>
     <string name="inbox_section_replies">Antworten</string>
@@ -107,13 +105,9 @@
     <string name="manage_accounts_title">Konten verwalten</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-Communitys</string>
     <string name="manage_subscriptions_header_subscriptions">Abonnements</string>
-    <string name="message_empty_comments">Dort ist es zu still.\nMöchtest du derjenige sein, der den
-        ersten Kommentar schreibt?
-    </string>
+    <string name="message_empty_comments">Dort ist es zu still.\nMöchtest du derjenige sein, der den ersten Kommentar schreibt?</string>
     <string name="message_empty_list">Keine Elemente zum Anzeigen</string>
-    <string name="message_error_loading_comments">Beim Laden der Kommentare ist ein Fehler
-        aufgetreten.
-    </string>
+    <string name="message_error_loading_comments">Beim Laden der Kommentare ist ein Fehler aufgetreten.</string>
     <string name="message_generic_error">Allgemeiner Fehler</string>
     <string name="message_image_loading_error">Fehler beim Laden des Bildes</string>
     <string name="message_invalid_field">Ungültige Felder</string>
@@ -146,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Sie sind derzeit nicht angemeldet.\nFügen Sie bitte
-        ein Konto hinzu, um fortzufahren.
-    </string>
+    <string name="profile_not_logged_message">Sie sind derzeit nicht angemeldet.\nFügen Sie bitte ein Konto hinzu, um fortzufahren.</string>
     <string name="profile_section_comments">Kommentare</string>
     <string name="profile_section_posts">Beiträge</string>
     <string name="profile_thousand_short">k</string>
@@ -188,8 +180,7 @@
     <string name="settings_content_font_smaller">Extra klein</string>
     <string name="settings_content_font_smallest">Doppelt extra klein</string>
     <string name="settings_custom_seed_color">Benutzerdefinierte Designfarbe</string>
-    <string name="settings_default_comment_sort_type">Standardtyp für die Kommentarsortierung
-    </string>
+    <string name="settings_default_comment_sort_type">Standardtyp für die Kommentarsortierung</string>
     <string name="settings_default_listing_type">Standardtyp für den Feed</string>
     <string name="settings_default_post_sort_type">Standardtyp für die Beitragssortierung</string>
     <string name="settings_downvote_color">Farbe für Downvotes</string>
@@ -200,8 +191,7 @@
     <string name="settings_full_height_images">Bilder in voller Höhe</string>
     <string name="settings_include_nsfw">NSFW-Inhalte anzeigen</string>
     <string name="settings_language">Sprache</string>
-    <string name="settings_navigation_bar_titles_visible">Titel der Navigationsleiste anzeigen
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Titel der Navigationsleiste anzeigen</string>
     <string name="settings_open_url_external">URLs in einem externen Browser öffnen</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Beitragsformat</string>
@@ -223,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Navigationsleiste beim Scrollen ausblenden</string>
     <string name="settings_zombie_mode_interval">Intervalldauer des Zombie-Modus</string>
     <string name="settings_zombie_mode_scroll_amount">Bildlaufweite im Zombie-Modus</string>
-    <string name="settings_mark_as_read_while_scrolling">Beiträge beim Scrollen als
-        gelesen markieren
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Beiträge beim Scrollen als gelesen markieren</string>
     <string name="action_quote">Zitat</string>
     <string name="mod_action_allow">Erlauben Sie dem Benutzer erneut</string>
     <string name="mod_action_ban">Benutzer blocken</string>
@@ -243,12 +231,7 @@
     <string name="report_list_type_unresolved">Ungelöst</string>
     <string name="report_action_resolve">Auflösen</string>
     <string name="report_action_unresolve">Auflösung</string>
-    <string name="sidebar_not_logged_message">Willkommen bei Raccoon for Lemmy!\n\nIm anonymen
-        Modus,
-        Verwenden Sie die Dropdown-Schaltfläche (▼) oben, um die Instanz zu ändern.\n\nSie können
-        sich unter bei Ihrer Instanz anmelden
-        jederzeit über den Profilbildschirm.\n\nViel Spaß mit Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Willkommen bei Raccoon for Lemmy!\n\nIm anonymen Modus, Verwenden Sie die Dropdown-Schaltfläche (▼) oben, um die Instanz zu ändern.\n\nSie können sich unter bei Ihrer Instanz anmelden jederzeit über den Profilbildschirm.\n\nViel Spaß mit Lemmy!</string>
     <string name="settings_default_inbox_type">Standard-Posteingangstyp</string>
     <string name="mod_action_add_mod">Moderator hinzufügen</string>
     <string name="mod_action_remove_mod">Moderator entfernen</string>
@@ -277,15 +260,13 @@
     <string name="modlog_item_user_banned">wurde verbannt</string>
     <string name="modlog_item_user_unbanned">wurde aufgehoben</string>
     <string name="modlog_item_post_featured">wurde als hervorgehobener Beitrag markiert</string>
-    <string name="modlog_item_post_unfeatured">wurde als nicht vorgestellter Beitrag markiert
-    </string>
+    <string name="modlog_item_post_unfeatured">wurde als nicht vorgestellter Beitrag markiert</string>
     <string name="modlog_item_post_locked">wurde gesperrt</string>
     <string name="modlog_item_post_unlocked">wurde entsperrt</string>
     <string name="modlog_item_post_removed">wurde entfernt</string>
     <string name="modlog_item_post_restored">wurde wiederhergestellt</string>
     <string name="modlog_item_comment_removed">wurde aus den Kommentaren von entfernt</string>
-    <string name="modlog_item_comment_restored">wurde in den Kommentaren von wiederhergestellt
-    </string>
+    <string name="modlog_item_comment_restored">wurde in den Kommentaren von wiederhergestellt</string>
     <string name="modlog_item_community_transfer">die Community wurde übertragen</string>
     <string name="block_action_user">Benutzer blockieren</string>
     <string name="block_action_community">Community blockieren</string>
@@ -351,4 +332,5 @@
     <string name="moderator_zone_title">Tools für Moderatoren</string>
     <string name="moderator_zone_action_comments">Moderierte Kommentare</string>
     <string name="moderator_zone_action_posts">Moderierte Beiträge</string>
+    <string name="message_auth_issue">Beim Abrufen der Benutzerdaten ist ein Fehler aufgetreten. Versuchen Sie, den Bildschirm zu aktualisieren</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Μη αναγνωσμένα</string>
     <string name="inbox_action_mark_read">Σημειώσε ως αναγνωσμένο</string>
     <string name="inbox_action_mark_unread">Σημειώστε ως αδιάβαστο</string>
-    <string name="inbox_not_logged_message">Προς το παρόν, δεν έχετε συνδεθεί.\nΠαρακαλούμε
-        προσθέστε έναν λογαριασμό από την οθόνη προφίλ για να δείτε τα εισερχόμενά σας.
-    </string>
+    <string name="inbox_not_logged_message">Προς το παρόν, δεν έχετε συνδεθεί.\nΠαρακαλούμε προσθέστε έναν λογαριασμό από την οθόνη προφίλ για να δείτε τα εισερχόμενά σας.</string>
     <string name="inbox_section_mentions">Αναφορές</string>
     <string name="inbox_section_messages">Μηνύματα</string>
     <string name="inbox_section_replies">Απαντήσεις</string>
@@ -107,17 +105,13 @@
     <string name="manage_accounts_title">Διαχείριση λογαριασμών</string>
     <string name="manage_subscriptions_header_multicommunities">Πολυκοινότητες</string>
     <string name="manage_subscriptions_header_subscriptions">Συνδρομές</string>
-    <string name="message_empty_comments">Είναι πολύ σιωπηλά εκεί.\nΘα θέλατε να είστε εσείς αυτός
-        που θα γράψει το πρώτο σχόλιο;
-    </string>
+    <string name="message_empty_comments">Είναι πολύ σιωπηλά εκεί.\nΘα θέλατε να είστε εσείς αυτός που θα γράψει το πρώτο σχόλιο;</string>
     <string name="message_empty_list">Δεν υπάρχουν αντικείμενα προς εμφάνιση</string>
     <string name="message_generic_error">Γενικό σφάλμα</string>
     <string name="message_image_loading_error">Σφάλμα φόρτωσης εικόνας</string>
     <string name="message_invalid_field">Μη έγκυρο πεδίο</string>
     <string name="message_missing_field">Λείπον πεδίο</string>
-    <string name="message_error_loading_comments">Παρουσιάστηκε σφάλμα κατά τη φόρτωση των
-        σχολίων.
-    </string>
+    <string name="message_error_loading_comments">Παρουσιάστηκε σφάλμα κατά τη φόρτωση των σχολίων.</string>
     <string name="message_operation_successful">Η λειτουργία ολοκληρώθηκε με επιτυχία</string>
     <string name="multi_community_editor_communities">Κοινότητες</string>
     <string name="multi_community_editor_icon">Εικονίδιο</string>
@@ -146,9 +140,7 @@
     <string name="profile_day_short">ημ</string>
     <string name="profile_million_short">εκ</string>
     <string name="profile_month_short">μήν</string>
-    <string name="profile_not_logged_message">Προς το παρόν, δεν έχετε συνδεθεί.\nΠαρακαλώ προσθέστε
-        έναν λογαριασμό για να συνεχίσετε.
-    </string>
+    <string name="profile_not_logged_message">Προς το παρόν, δεν έχετε συνδεθεί.\nΠαρακαλώ προσθέστε έναν λογαριασμό για να συνεχίσετε.</string>
     <string name="profile_section_comments">Σχόλια</string>
     <string name="profile_section_posts">Αναρτήσεις</string>
     <string name="profile_thousand_short">χιλ</string>
@@ -188,11 +180,9 @@
     <string name="settings_content_font_smaller">Πολύ μικρό</string>
     <string name="settings_content_font_smallest">Διπλά πολύ μικρό</string>
     <string name="settings_custom_seed_color">Προσαρμοσμένο χρώμα θέματος</string>
-    <string name="settings_default_comment_sort_type">Προεπιλεγμένος τρόπος ταξινόμησης σχολίου
-    </string>
+    <string name="settings_default_comment_sort_type">Προεπιλεγμένος τρόπος ταξινόμησης σχολίου</string>
     <string name="settings_default_listing_type">Προεπιλεγμένος τύπος τροφοδοσίας</string>
-    <string name="settings_default_post_sort_type">Προεπιλεγμένος τρόπος ταξινόμησης ανάρτησης
-    </string>
+    <string name="settings_default_post_sort_type">Προεπιλεγμένος τρόπος ταξινόμησης ανάρτησης</string>
     <string name="settings_downvote_color">Χρώμα ψήφου κατώτερου</string>
     <string name="settings_dynamic_colors">Χρήση δυναμικών χρωμάτων</string>
     <string name="settings_enable_crash_report">Ενεργοποίηση αναφοράς καταρρεύσεων</string>
@@ -220,15 +210,10 @@
     <string name="settings_ui_font_scale">Μέγεθος κειμένου διεπαφής</string>
     <string name="settings_ui_theme">Θέμα διεπαφής</string>
     <string name="settings_upvote_color">Χρώμα ψήφου ανώτερου</string>
-    <string name="settings_hide_navigation_bar">Απόκρυψη της γραμμής πλοήγησης κατά την κύλιση
-    </string>
-    <string name="settings_zombie_mode_interval">Διάρκεια του διαστήματος της λειτουργίας ζόμπι
-    </string>
-    <string name="settings_zombie_mode_scroll_amount">Ποσότητα της κύλισης της λειτουργίας ζόμπι
-    </string>
-    <string name="settings_mark_as_read_while_scrolling">Επισήμανση αναρτήσεων ως αναγνωσμένων κατά
-        την κύλιση
-    </string>
+    <string name="settings_hide_navigation_bar">Απόκρυψη της γραμμής πλοήγησης κατά την κύλιση</string>
+    <string name="settings_zombie_mode_interval">Διάρκεια του διαστήματος της λειτουργίας ζόμπι</string>
+    <string name="settings_zombie_mode_scroll_amount">Ποσότητα της κύλισης της λειτουργίας ζόμπι</string>
+    <string name="settings_mark_as_read_while_scrolling">Επισήμανση αναρτήσεων ως αναγνωσμένων κατά την κύλιση</string>
     <string name="action_quote">Αναφορά</string>
     <string name="mod_action_allow">Επιτρέψτε ξανά στον χρήστη</string>
     <string name="mod_action_ban">Αποκλεισμός χρήστη</string>
@@ -239,19 +224,14 @@
     <string name="mod_action_unlock">Ξεκλείδωμα</string>
     <string name="mod_action_remove">Κατάργηση</string>
     <string name="mod_action_mark_as_distinguished">Επισήμανση ως διακεκριμένου</string>
-    <string name="mod_action_unmark_as_distinguished">Κατάργηση επισήμανσης ως διακεκριμένου
-    </string>
+    <string name="mod_action_unmark_as_distinguished">Κατάργηση επισήμανσης ως διακεκριμένου</string>
     <string name="report_list_title">Λίστα αναφορών</string>
     <string name="report_list_type_title">Τύπος λίστας αναφοράς</string>
     <string name="report_list_type_all">Όλα</string>
     <string name="report_list_type_unresolved">Μη επιλύθηκε</string>
     <string name="report_action_resolve">Επίλυση</string>
     <string name="report_action_unresolve">Κατάργηση επίλυσης</string>
-    <string name="sidebar_not_logged_message">Καλώς ήρθατε στο Raccoon for Lemmy!\n\nΣε ανώνυμη
-        λειτουργία, χρησιμοποιήστε το αναπτυσσόμενο κουμπί (▼) παραπάνω για να αλλάξετε την
-        εμφάνιση.\n\nΜπορείτε να συνδεθείτε στην παρουσία σας στο οποιαδήποτε στιγμή από την οθόνη
-        Προφίλ.\n\nΑπολαύστε το Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Καλώς ήρθατε στο Raccoon for Lemmy!\n\nΣε ανώνυμη λειτουργία, χρησιμοποιήστε το αναπτυσσόμενο κουμπί (▼) παραπάνω για να αλλάξετε την εμφάνιση.\n\nΜπορείτε να συνδεθείτε στην παρουσία σας στο οποιαδήποτε στιγμή από την οθόνη Προφίλ.\n\nΑπολαύστε το Lemmy!</string>
     <string name="settings_default_inbox_type">Προεπιλεγμένος τύπος εισερχομένων</string>
     <string name="mod_action_add_mod">Προσθήκη συντονιστή</string>
     <string name="mod_action_remove_mod">Κατάργηση συντονιστή</string>
@@ -310,9 +290,7 @@
     <string name="settings_web_show_bot">Εμφάνιση λογαριασμών bot</string>
     <string name="settings_web_show_nsfw">Εμφάνιση NSFW</string>
     <string name="settings_web_show_read">Εμφάνιση αναγνωσμένων αναρτήσεων</string>
-    <string name="settings_web_email_notifications">Αποστολή ειδοποιήσεων μέσω ηλεκτρονικό
-        ταχυδρομείο
-    </string>
+    <string name="settings_web_email_notifications">Αποστολή ειδοποιήσεων μέσω ηλεκτρονικό ταχυδρομείο</string>
     <string name="settings_manage_ban">Απαγορεύσεις και φίλτρα</string>
     <string name="settings_manage_ban_action_unban">Κατάργηση απαγόρευσης</string>
     <string name="settings_manage_ban_section_instances">Περιπτώσεις</string>
@@ -354,4 +332,5 @@
     <string name="moderator_zone_title">Εργαλεία για συντονιστές</string>
     <string name="moderator_zone_action_comments">Εποπτευμένα σχόλια</string>
     <string name="moderator_zone_action_posts">Εποπτευόμενες αναρτήσεις</string>
+    <string name="message_auth_issue">Παρουσιάστηκε σφάλμα κατά την ανάκτηση δεδομένων χρήστη, δοκιμάστε να ανανεώσετε την οθόνη</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Ĉiuj</string>
     <string name="inbox_listing_type_title">Tipo de leterkesto</string>
     <string name="inbox_listing_type_unread">Nelegitai</string>
-    <string name="inbox_not_logged_message">Vi nun ne estas ensalutinta.\nBonvolu aldoni konton en
-        la profila ekrano por vidi vian enirkeston.
-    </string>
+    <string name="inbox_not_logged_message">Vi nun ne estas ensalutinta.\nBonvolu aldoni konton en la profila ekrano por vidi vian enirkeston.</string>
     <string name="inbox_section_mentions">Mencioj</string>
     <string name="inbox_section_messages">Mesaĝoj</string>
     <string name="inbox_section_replies">Respondoj</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Administri kontojn</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-komunumoj</string>
     <string name="manage_subscriptions_header_subscriptions">Subskriboj</string>
-    <string name="message_empty_comments">Tie estas tro silente.\nĈu vi ŝatus esti tiu, kiu skribu
-        la unuan komenton.
-    </string>
+    <string name="message_empty_comments">Tie estas tro silente.\nĈu vi ŝatus esti tiu, kiu skribu la unuan komenton.</string>
     <string name="message_empty_list">Neniuj eroj por montri</string>
     <string name="message_error_loading_comments">Eraro okazis dum ŝarĝo de komentoj.</string>
     <string name="message_generic_error">Ĝenerala eraro</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Vi nun ne estas ensalutinta.\nBonvolu aldoni konton
-        por daŭrigi.
-    </string>
+    <string name="profile_not_logged_message">Vi nun ne estas ensalutinta.\nBonvolu aldoni konton por daŭrigi.</string>
     <string name="profile_section_comments">Komentoj</string>
     <string name="profile_section_posts">Afiŝoj</string>
     <string name="profile_thousand_short">k</string>
@@ -219,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Kaŝi navigobreton dum rulumado</string>
     <string name="settings_zombie_mode_interval">Tempodaŭro de la zombia reĝimo</string>
     <string name="settings_zombie_mode_scroll_amount">Rula kvanto de la zombia reĝimo</string>
-    <string name="settings_mark_as_read_while_scrolling">Marki afiŝojn kiel legitaj dum rulumado
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marki afiŝojn kiel legitaj dum rulumado</string>
     <string name="action_quote">Citi</string>
     <string name="mod_action_allow">Permesi al la uzanto denove</string>
     <string name="mod_action_ban">Malpermesi uzanton</string>
@@ -238,10 +231,7 @@
     <string name="report_list_type_unresolved">Nesolvitaj</string>
     <string name="report_action_resolve">Solvi</string>
     <string name="report_action_unresolve">Nesolvi</string>
-    <string name="sidebar_not_logged_message">Bonvenon al Raccoon for Lemmy!\n\nEn anonima reĝimo,
-        uzu la falbutonon (▼) supre por ŝanĝi nodon.\n\nVi povas ensaluti al via instanco ĉe
-        iam ajn de la Profila ekrano.\n\nĜuu Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Bonvenon al Raccoon for Lemmy!\n\nEn anonima reĝimo, uzu la falbutonon (▼) supre por ŝanĝi nodon.\n\nVi povas ensaluti al via instanco ĉe iam ajn de la Profila ekrano.\n\nĜuu Lemmy!</string>
     <string name="settings_default_inbox_type">Defaŭlta enirkesto tipo</string>
     <string name="mod_action_add_mod">Aldoni moderigilon</string>
     <string name="mod_action_remove_mod">Forigi moderigilon</string>
@@ -342,4 +332,5 @@
     <string name="moderator_zone_title">Iloj por moderigaĵoj</string>
     <string name="moderator_zone_action_comments">Moderigitaj komentoj</string>
     <string name="moderator_zone_action_posts">Moderigitaj afiŝoj</string>
+    <string name="message_auth_issue">Okazis eraro dum venigado de uzantdatenoj, provu refreŝigi la ekranon</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Todos</string>
     <string name="inbox_listing_type_title">Tipo de mensaje</string>
     <string name="inbox_listing_type_unread">No leídos</string>
-    <string name="inbox_not_logged_message">Ha ocurrido un error.\nAñade una cuenta en la pestaña
-        Perfil para acceder a los mensajes.
-    </string>
+    <string name="inbox_not_logged_message">Ha ocurrido un error.\nAñade una cuenta en la pestaña Perfil para acceder a los mensajes.</string>
     <string name="inbox_section_mentions">Menciones</string>
     <string name="inbox_section_messages">Mensajes</string>
     <string name="inbox_section_replies">Respuestas</string>
@@ -107,11 +105,9 @@
     <string name="manage_accounts_title">Gestionar cuentas</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-comunidades</string>
     <string name="manage_subscriptions_header_subscriptions">Suscripciones</string>
-    <string name="message_empty_comments">Nada que ver por aquí.\n¡Sé el primero en comentar!
-    </string>
+    <string name="message_empty_comments">Nada que ver por aquí.\n¡Sé el primero en comentar!</string>
     <string name="message_empty_list">Ningún elemento para mostrar</string>
-    <string name="message_error_loading_comments">Error al cargar los comentarios
-    </string>
+    <string name="message_error_loading_comments">Error al cargar los comentarios</string>
     <string name="message_generic_error">Error</string>
     <string name="message_image_loading_error">No ha sido posible descargar la imagen</string>
     <string name="message_invalid_field">Campo no válido</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">No ha sido posible entrar.\nAñade una cuenta para
-        continuar.
-    </string>
+    <string name="profile_not_logged_message">No ha sido posible entrar.\nAñade una cuenta para continuar.</string>
     <string name="profile_section_comments">Comentarios</string>
     <string name="profile_section_posts">Publicaciones</string>
     <string name="profile_thousand_short">k</string>
@@ -197,9 +191,7 @@
     <string name="settings_full_height_images">Imágenes a tamaño completo</string>
     <string name="settings_include_nsfw">Incluir contenidos NSFW</string>
     <string name="settings_language">Idioma</string>
-    <string name="settings_navigation_bar_titles_visible">Etiquetas en la barra de
-        navegación
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Etiquetas en la barra de navegación</string>
     <string name="settings_open_url_external">Abrir URL en navegador externo</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Diseño de las publicaciones</string>
@@ -239,10 +231,7 @@
     <string name="report_list_type_unresolved">Sin resolver</string>
     <string name="report_action_resolve">Resueltos</string>
     <string name="report_action_unresolve">Pendientes</string>
-    <string name="sidebar_not_logged_message">¡Bienvenido a Raccoon for Lemmy!\n\nEn modo anónimo,
-        usa el botón desplegable (▼) de arriba para cambiar de instancia.\n\nPuedes iniciar sesión
-        en tu instancia en cualquier momento desde la pestaña \'Perfil\'.\n\n¡Disfruta de Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">¡Bienvenido a Raccoon for Lemmy!\n\nEn modo anónimo, usa el botón desplegable (▼) de arriba para cambiar de instancia.\n\nPuedes iniciar sesión en tu instancia en cualquier momento desde la pestaña \'Perfil\'.\n\n¡Disfruta de Lemmy!</string>
     <string name="settings_default_inbox_type">Mostrar por defecto</string>
     <string name="mod_action_add_mod">Añadir moderador</string>
     <string name="mod_action_remove_mod">Eliminar moderador</string>
@@ -301,8 +290,7 @@
     <string name="settings_web_show_bot">Mostrar cuentas de bots</string>
     <string name="settings_web_show_nsfw">Mostrar NSFW</string>
     <string name="settings_web_show_read">Mostrar publicaciones leídas</string>
-    <string name="settings_web_email_notifications">Enviar notificaciones por correo electrónico
-    </string>
+    <string name="settings_web_email_notifications">Enviar notificaciones por correo electrónico</string>
     <string name="settings_manage_ban">Filtros y baneos</string>
     <string name="settings_manage_ban_action_unban">Eliminar ban</string>
     <string name="settings_manage_ban_section_instances">Instancias</string>
@@ -344,4 +332,5 @@
     <string name="moderator_zone_title">Herramientas para moderadores</string>
     <string name="moderator_zone_action_comments">Comentarios por moderar</string>
     <string name="moderator_zone_action_posts">Publicaciones por moderar</string>
+    <string name="message_auth_issue">Se produjo un error al obtener los datos del usuario, intente actualizar la pantalla</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Kõik</string>
     <string name="inbox_listing_type_title">Postkasti tüüp</string>
     <string name="inbox_listing_type_unread">Lugemata</string>
-    <string name="inbox_not_logged_message">Sa pole praegu sisse logitud.Palun lisa konto
-        profiiliekraanilt, et näha oma postkasti. \n
-    </string>
+    <string name="inbox_not_logged_message">Sa pole praegu sisse logitud.Palun lisa konto profiiliekraanilt, et näha oma postkasti.</string>
     <string name="inbox_section_mentions">Mainimised</string>
     <string name="inbox_section_messages">Sõnumid</string>
     <string name="inbox_section_replies">Vastused</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Halda kontosid</string>
     <string name="manage_subscriptions_header_multicommunities">Mitme kogukonna ühendus</string>
     <string name="manage_subscriptions_header_subscriptions">Tellimused</string>
-    <string name="message_empty_comments">Seal on liiga\n vaikne.Kas sooviksid olla see, kes
-        kirjutab esimese kommentaari?
-    </string>
+    <string name="message_empty_comments">Seal on liiga\n vaikne.Kas sooviksid olla see, kes kirjutab esimese kommentaari?</string>
     <string name="message_empty_list">Elemendid näitamiseks</string>
     <string name="message_error_loading_comments">Kommentaaride laadimisel ilmnes tõrge.</string>
     <string name="message_generic_error">Üldine viga</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">p</string>
     <string name="profile_million_short">k</string>
     <string name="profile_month_short">k</string>
-    <string name="profile_not_logged_message">Sa pole praegu sisse logitud.Palun lisa\n jätkamiseks
-        kontot.
-    </string>
+    <string name="profile_not_logged_message">Sa pole praegu sisse logitud.Palun lisa\n jätkamiseks kontot.</string>
     <string name="profile_section_comments">Kommentaarid</string>
     <string name="profile_section_posts">Postid</string>
     <string name="profile_thousand_short">k</string>
@@ -219,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Peida kerimisel navigeerimisriba</string>
     <string name="settings_zombie_mode_interval">Zombirežiimi intervalli kestus</string>
     <string name="settings_zombie_mode_scroll_amount">Zombirežiimi kerimise kogus</string>
-    <string name="settings_mark_as_read_while_scrolling">Märkige postitused kerimise ajal loetuks
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Märkige postitused kerimise ajal loetuks</string>
     <string name="action_quote">Tsiteeri</string>
     <string name="mod_action_allow">Luba kasutaja uuesti</string>
     <string name="mod_action_ban">Keelata kasutaja</string>
@@ -238,11 +231,7 @@
     <string name="report_list_type_unresolved">Lahendamata</string>
     <string name="report_action_resolve">Lahenda</string>
     <string name="report_action_unresolve">Tühista lahendamine</string>
-    <string name="sidebar_not_logged_message">Tere tulemast rakendusse Raccoon for
-        Lemmy!\n\nAnonüümses režiimis kasutage eksemplari muutmiseks ülalolevat rippmenüü nuppu
-        (▼).\n\nSaate oma instantsi sisse logida aadressil igal ajal profiiliekraanilt.\n\nNaudi
-        Lemmyt!
-    </string>
+    <string name="sidebar_not_logged_message">Tere tulemast rakendusse Raccoon for Lemmy!\n\nAnonüümses režiimis kasutage eksemplari muutmiseks ülalolevat rippmenüü nuppu (▼).\n\nSaate oma instantsi sisse logida aadressil igal ajal profiiliekraanilt.\n\nNaudi Lemmyt!</string>
     <string name="settings_default_inbox_type">Vaikepostkasti tüüp</string>
     <string name="mod_action_add_mod">Lisa moderaator</string>
     <string name="mod_action_remove_mod">Eemalda moderaator</string>
@@ -343,4 +332,5 @@
     <string name="moderator_zone_title">Tööriistad moderaatoritele</string>
     <string name="moderator_zone_action_comments">Modereeritud kommentaarid</string>
     <string name="moderator_zone_action_posts">Modereeritud postitused</string>
+    <string name="message_auth_issue">Kasutajaandmete toomisel ilmnes viga. Proovige ekraani värskendada</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Kaikki</string>
     <string name="inbox_listing_type_title">Postilaatikon tyyppi</string>
     <string name="inbox_listing_type_unread">Lukematon</string>
-    <string name="inbox_not_logged_message">Et ole tällä hetkellä kirjautunut sisään.\nLisää tili
-        profiilinäytöstä nähdäksesi postilaatikkosi.
-    </string>
+    <string name="inbox_not_logged_message">Et ole tällä hetkellä kirjautunut sisään.\nLisää tili profiilinäytöstä nähdäksesi postilaatikkosi.</string>
     <string name="inbox_section_mentions">Viittaukset</string>
     <string name="inbox_section_messages">Viestit</string>
     <string name="inbox_section_replies">Vastausta</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Muokkaa tilejä</string>
     <string name="manage_subscriptions_header_multicommunities">Useita yhteisöjä</string>
     <string name="manage_subscriptions_header_subscriptions">Vuokrasopimukset</string>
-    <string name="message_empty_comments">Siellä on liian hiljaista.\nHaluaisitko olla se, joka
-        kirjoittaa ensimmäisen kommentin?
-    </string>
+    <string name="message_empty_comments">Siellä on liian hiljaista.\nHaluaisitko olla se, joka kirjoittaa ensimmäisen kommentin?</string>
     <string name="message_empty_list">Ei enää näytettäviä kohteita</string>
     <string name="message_error_loading_comments">Kommenttien lataamisessa tapahtui virhe.</string>
     <string name="message_generic_error">Yleinen virhe.</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Et ole tällä hetkellä kirjautunut sisään.\nLisää
-        tili jatkaaksesi.
-    </string>
+    <string name="profile_not_logged_message">Et ole tällä hetkellä kirjautunut sisään.\nLisää tili jatkaaksesi.</string>
     <string name="profile_section_comments">Kommentit</string>
     <string name="profile_section_posts">Viestit</string>
     <string name="profile_thousand_short">k</string>
@@ -219,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Piilota navigointipalkki vieritettäessä</string>
     <string name="settings_zombie_mode_interval">Zombitilan aikavälin kesto</string>
     <string name="settings_zombie_mode_scroll_amount">Zombitilan vieritysmäärä</string>
-    <string name="settings_mark_as_read_while_scrolling">Merkitse viestit luetuiksi vieritettäessä
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Merkitse viestit luetuiksi vieritettäessä</string>
     <string name="action_quote">Lainata</string>
     <string name="mod_action_allow">Salli käyttäjän uudelleen</string>
     <string name="mod_action_ban">Kieltää käyttäjä</string>
@@ -238,11 +231,7 @@
     <string name="report_list_type_unresolved">Ratkaisematon</string>
     <string name="report_action_resolve">Ratkaise</string>
     <string name="report_action_unresolve">Ei ratkaise</string>
-    <string name="sidebar_not_logged_message">Tervetuloa Raccoon for Lemmylle!\n\nNimetttömässä
-        tilassa, käytä yllä olevaa pudotusvalikkopainiketta (▼) vaihtaaksesi ilmentymää.\n\nVoit
-        kirjautua sisään tapahtumaasi osoitteessa milloin tahansa profiilinäytöstä.\n\nNauti
-        Lemmystä!
-    </string>
+    <string name="sidebar_not_logged_message">Tervetuloa Raccoon for Lemmylle!\n\nNimetttömässä tilassa, käytä yllä olevaa pudotusvalikkopainiketta (▼) vaihtaaksesi ilmentymää.\n\nVoit kirjautua sisään tapahtumaasi osoitteessa milloin tahansa profiilinäytöstä.\n\nNauti Lemmystä!</string>
     <string name="settings_default_inbox_type">Oletuspostilaatikon tyyppi</string>
     <string name="mod_action_add_mod">Lisää moderaattori</string>
     <string name="mod_action_remove_mod">Poista moderaattori</string>
@@ -343,4 +332,5 @@
     <string name="moderator_zone_title">Työkaluja moderaattoreille</string>
     <string name="moderator_zone_action_comments">Moderoidut kommentit</string>
     <string name="moderator_zone_action_posts">Valvotut viestit</string>
+    <string name="message_auth_issue">Käyttäjätietoja haettaessa tapahtui virhe. Yritä päivittää näyttö</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Non lus</string>
     <string name="inbox_action_mark_read">Marquer comme lu</string>
     <string name="inbox_action_mark_unread">Marquer comme non lu</string>
-    <string name="inbox_not_logged_message">Vous n\'êtes pas connecté.\nVeuillez ajouter un compte à
-        partir de l\'écran de profil pour voir votre boîte de réception.
-    </string>
+    <string name="inbox_not_logged_message">Vous n\'êtes pas connecté.\nVeuillez ajouter un compte à partir de l\'écran de profil pour voir votre boîte de réception.</string>
     <string name="inbox_section_mentions">Mentions</string>
     <string name="inbox_section_messages">Messages</string>
     <string name="inbox_section_replies">Réponses</string>
@@ -107,13 +105,9 @@
     <string name="manage_accounts_title">Gérer les comptes</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-communautés</string>
     <string name="manage_subscriptions_header_subscriptions">Abonnements</string>
-    <string name="message_empty_comments">C\'est trop silencieux ici.\nVoulez-vous être celui qui
-        écrit le premier commentaire ?
-    </string>
+    <string name="message_empty_comments">C\'est trop silencieux ici.\nVoulez-vous être celui qui écrit le premier commentaire ?</string>
     <string name="message_empty_list">Pas d\'éléments à afficher</string>
-    <string name="message_error_loading_comments">Une erreur s\'est produite lors du chargement des
-        commentaires.
-    </string>
+    <string name="message_error_loading_comments">Une erreur s\'est produite lors du chargement des commentaires.</string>
     <string name="message_generic_error">Erreur générique</string>
     <string name="message_image_loading_error">Erreur de chargement de l\'image</string>
     <string name="message_invalid_field">Champ invalide</string>
@@ -146,9 +140,7 @@
     <string name="profile_day_short">j</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Vous n\'êtes pas connecté.\nVeuillez ajouter un compte
-        pour continuer.
-    </string>
+    <string name="profile_not_logged_message">Vous n\'êtes pas connecté.\nVeuillez ajouter un compte pour continuer.</string>
     <string name="profile_section_comments">Commentaires</string>
     <string name="profile_section_posts">Publications</string>
     <string name="profile_thousand_short">k</string>
@@ -218,13 +210,10 @@
     <string name="settings_ui_font_scale">Taille de texte de l\'interface</string>
     <string name="settings_ui_theme">Thème de l\'interface</string>
     <string name="settings_upvote_color">Couleur votes positifs</string>
-    <string name="settings_hide_navigation_bar">Masquer la barre de navigation lors du défilement
-    </string>
+    <string name="settings_hide_navigation_bar">Masquer la barre de navigation lors du défilement</string>
     <string name="settings_zombie_mode_interval">Durée de l\'intervalle du mode zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie mode scroll amount</string>
-    <string name="settings_mark_as_read_while_scrolling">Marquer les messages comme lus lors du
-        défilement
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marquer les messages comme lus lors du défilement</string>
     <string name="action_quote">Citer</string>
     <string name="mod_action_allow">Réautoriser l\'utilisateur</string>
     <string name="mod_action_ban">Bannir l\'utilisateur</string>
@@ -242,10 +231,7 @@
     <string name="report_list_type_unresolved">Non résolu</string>
     <string name="report_action_resolve">Résoudre</string>
     <string name="report_action_unresolve">Ne pas résoudre</string>
-    <string name="sidebar_not_logged_message">Bienvenus sur Raccoon pour Lemmy !\n\nEn mode anonyme,
-        utilisez le bouton déroulant (▼) ci-dessus pour changer d\'instance.\n\nVous pouvez vous
-        connecter à votre instance à tout moment depuis l\'écran Profil.\n\nProfitez de Lemmy !
-    </string>
+    <string name="sidebar_not_logged_message">Bienvenus sur Raccoon pour Lemmy !\n\nEn mode anonyme, utilisez le bouton déroulant (▼) ci-dessus pour changer d\'instance.\n\nVous pouvez vous connecter à votre instance à tout moment depuis l\'écran Profil.\n\nProfitez de Lemmy !</string>
     <string name="settings_default_inbox_type">Type de boîte par défaut</string>
     <string name="mod_action_add_mod">Ajouter modérateur</string>
     <string name="mod_action_remove_mod">Supprimer modérateur</string>
@@ -262,9 +248,7 @@
     <string name="settings_comment_bar_theme_multi">🌈 Arc-en-ciel</string>
     <string name="message_confirm_exit">Appuyez à nouveau sur 🔙 pour quitter</string>
     <string name="community_action_unsubscribe">Se désabonner</string>
-    <string name="settings_search_posts_title_only">Rechercher les publications uniquement dans le
-        titre
-    </string>
+    <string name="settings_search_posts_title_only">Rechercher les publications uniquement dans le titre</string>
     <string name="settings_content_font_family">Police des contenus</string>
     <string name="community_info_moderators">Modérateurs</string>
     <string name="community_action_add_favorite">Ajouter aux favoris</string>
@@ -348,4 +332,5 @@
     <string name="moderator_zone_title">Outils pour les modérateurs</string>
     <string name="moderator_zone_action_comments">Commentaires à modérer</string>
     <string name="moderator_zone_action_posts">Publications à modérer</string>
+    <string name="message_auth_issue">Une erreur s\'est produite lors de la récupération des données utilisateur, essayez d\'actualiser l\'écran</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -13,8 +13,7 @@
     <string name="button_reset">Athshocraigh</string>
     <string name="button_retry">Atriail</string>
     <string name="comment_action_delete">Scrios</string>
-    <string name="community_detail_block">BlocThe shape of the cursor, similar to a capital I
-    </string>
+    <string name="community_detail_block">Bloc</string>
     <string name="community_detail_block_instance">Blocshampla</string>
     <string name="community_detail_info">Eolas pobail</string>
     <string name="community_detail_instance_info">Sonraí an cháis</string>
@@ -89,13 +88,8 @@
     <string name="inbox_item_reply_post">d\'fhreagair sé do phostáil i</string>
     <string name="inbox_listing_type_all">Gach</string>
     <string name="inbox_listing_type_title">Cineál an bhosca isteach</string>
-    <string name="inbox_listing_type_unread">Gan Léamh@ title: column Column showing the total
-        number of messages
-    </string>
-    <string name="inbox_not_logged_message">Níl tú logáilte isteach faoi láthair.\nCuir cuntas leis,
-        le
-        do thoil ón scáileán próifíle chun do bhosca isteach a fheiceáil.
-    </string>
+    <string name="inbox_listing_type_unread">Gan Léamh</string>
+    <string name="inbox_not_logged_message">Níl tú logáilte isteach faoi láthair.\nCuir cuntas leis, le do thoil ón scáileán próifíle chun do bhosca isteach a fheiceáil.</string>
     <string name="inbox_section_mentions">Luaigh</string>
     <string name="inbox_section_messages">Teachtaireachtaí</string>
     <string name="inbox_section_replies">Freagraí</string>
@@ -111,9 +105,7 @@
     <string name="manage_accounts_title">Cuntais a bhainistiú</string>
     <string name="manage_subscriptions_header_multicommunities">Ilphobail</string>
     <string name="manage_subscriptions_header_subscriptions">Suibscríobh</string>
-    <string name="message_empty_comments">Tásé ró - thost ann.\nAr mhaith leat a bheith ar an duine
-        a scríobhann an chéad trácht?
-    </string>
+    <string name="message_empty_comments">Tásé ró - thost ann.\nAr mhaith leat a bheith ar an duine a scríobhann an chéad trácht?</string>
     <string name="message_empty_list">Níl aon earraí le taispeáint</string>
     <string name="message_error_loading_comments">Tharla earráid agus tuairimí á luchtú.</string>
     <string name="message_generic_error">Earráid ghinearálta</string>
@@ -148,10 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Níl tú logáilte isteach faoi láthair.\nCuir cuntas
-        leis,
-        le do thoil, chun leanúint ar aghaidh.
-    </string>
+    <string name="profile_not_logged_message">Níl tú logáilte isteach faoi láthair.\nCuir cuntas leis, le do thoil, chun leanúint ar aghaidh.</string>
     <string name="profile_section_comments">Nótaí</string>
     <string name="profile_section_posts">Postálacha</string>
     <string name="profile_thousand_short">k</string>
@@ -191,8 +180,7 @@
     <string name="settings_content_font_smaller">An - bheag</string>
     <string name="settings_content_font_smallest">Dhá oiread beag breise</string>
     <string name="settings_custom_seed_color">Dath saincheaptha an téama</string>
-    <string name="settings_default_comment_sort_type">Cineál sórtála réamhshocraithe tráchta
-    </string>
+    <string name="settings_default_comment_sort_type">Cineál sórtála réamhshocraithe tráchta</string>
     <string name="settings_default_listing_type">Cineál fotha réamhshocraithe</string>
     <string name="settings_default_post_sort_type">Cineál sórtála réamhshocraithe poist</string>
     <string name="settings_downvote_color">Dath Downvote</string>
@@ -203,8 +191,7 @@
     <string name="settings_full_height_images">Íomhánna lánairde</string>
     <string name="settings_include_nsfw">Cuir ábhar NSFW san áireamh</string>
     <string name="settings_language">Teangacha</string>
-    <string name="settings_navigation_bar_titles_visible">Taispeáin teidil an bharra nascleanúna
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Taispeáin teidil an bharra nascleanúna</string>
     <string name="settings_open_url_external">Oscail i mBrabhsálaí Seachtrach</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Leagan amach an phoist</string>
@@ -223,13 +210,10 @@
     <string name="settings_ui_font_scale">Méid théacs an chomhéadain</string>
     <string name="settings_ui_theme">Téama an Chomhéadain</string>
     <string name="settings_upvote_color">Dath uasvótála</string>
-    <string name="settings_hide_navigation_bar">Folaigh an barra nascleanúna agus tú ag scrollú
-    </string>
+    <string name="settings_hide_navigation_bar">Folaigh an barra nascleanúna agus tú ag scrollú</string>
     <string name="settings_zombie_mode_interval">Fad eatramh an mhóid Zombaí</string>
     <string name="settings_zombie_mode_scroll_amount">Méid scrollaithe an mhóid Zombie</string>
-    <string name="settings_mark_as_read_while_scrolling">Marcáil postálacha mar léite agus tú ag
-        scrollú
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marcáil postálacha mar léite agus tú ag scrollú</string>
     <string name="action_quote">Athfhriotail</string>
     <string name="mod_action_allow">Cead a thabhairt don úsáideoir arís</string>
     <string name="mod_action_ban">Toirmeasc ar úsáideoir</string>
@@ -247,12 +231,8 @@
     <string name="report_list_type_unresolved">Gan réiteach</string>
     <string name="report_action_resolve">Réitigh</string>
     <string name="report_action_unresolve">Díréitigh</string>
-    <string name="sidebar_not_logged_message">Fáilte go Raccoon for Lemmy!\n\nMód gan ainm,
-        úsáid an cnaipe anuas (▼) thuas chun cás a athrú.\n\nIs féidir leat logáil isteach ag
-        am ar bith ón scáileán Próifíl.\n\nBain sult as Lemmy!
-    </string>
-    <string name="settings_default_inbox_type">Cineál an bhosca isteach réamhshocraithe
-    </string>
+    <string name="sidebar_not_logged_message">Fáilte go Raccoon for Lemmy!\n\nMód gan ainm, úsáid an cnaipe anuas (▼) thuas chun cás a athrú.\n\nIs féidir leat logáil isteach ag am ar bith ón scáileán Próifíl.\n\nBain sult as Lemmy!</string>
+    <string name="settings_default_inbox_type">Cineál an bhosca isteach réamhshocraithe</string>
     <string name="mod_action_add_mod">Modhnóir a chur leis</string>
     <string name="mod_action_remove_mod">Bain modhnóir</string>
     <string name="settings_vote_format">Formáid vóta</string>
@@ -352,4 +332,5 @@
     <string name="moderator_zone_title">Uirlisí le haghaidh modhnóirí</string>
     <string name="moderator_zone_action_comments">Tráchtanna modhnaithe</string>
     <string name="moderator_zone_action_posts">Poist mhodhnaithe</string>
+    <string name="message_auth_issue">Tharla earráid agus sonraí úsáideora á bhfáil agat, bain triail as an scáileán a athnuachan</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Sve</string>
     <string name="inbox_listing_type_title">Vrsta ulazne pošte</string>
     <string name="inbox_listing_type_unread">Nepročitano</string>
-    <string name="inbox_not_logged_message">Trenutačno niste prijavljeni.Dodajte\n korisnički račun
-        na zaslonu profila za prikaz dolazne pošte.
-    </string>
+    <string name="inbox_not_logged_message">Trenutačno niste prijavljeni.Dodajte\n korisnički račun na zaslonu profila za prikaz dolazne pošte.</string>
     <string name="inbox_section_mentions">spominjanja</string>
     <string name="inbox_section_messages">Poruke</string>
     <string name="inbox_section_replies">Odgovori</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Upravljajte računima</string>
     <string name="manage_subscriptions_header_multicommunities">Više zajednica</string>
     <string name="manage_subscriptions_header_subscriptions">Pretplate</string>
-    <string name="message_empty_comments">Tamo je previše tiho.\nŽelite li biti onaj koji
-        piše prvi komentar?
-    </string>
+    <string name="message_empty_comments">Tamo je previše tiho.\nŽelite li biti onaj koji piše prvi komentar?</string>
     <string name="message_empty_list">Nema stavki za prikaz</string>
-    <string name="message_error_loading_comments">Došlo je do pogreške pri učitavanju komentara.
-    </string>
+    <string name="message_error_loading_comments">Došlo je do pogreške pri učitavanju komentara.</string>
     <string name="message_generic_error">Generička pogreška</string>
     <string name="message_image_loading_error">Pogreška pri učitavanju slike</string>
     <string name="message_invalid_field">Nevažeće polje</string>
@@ -145,10 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Trenutačno niste prijavljeni.\nZa nastavakunesite
-        korisnički
-        račun.
-    </string>
+    <string name="profile_not_logged_message">Trenutačno niste prijavljeni.\nZa nastavakunesite korisnički račun.</string>
     <string name="profile_section_comments">Komentari</string>
     <string name="profile_section_posts">Objave</string>
     <string name="profile_thousand_short">k</string>
@@ -199,8 +191,7 @@
     <string name="settings_full_height_images">Slike pune visine</string>
     <string name="settings_include_nsfw">Uključi sadržaj NSFW-a</string>
     <string name="settings_language">Jezik</string>
-    <string name="settings_navigation_bar_titles_visible">Prikaži naslove navigacijske trake
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Prikaži naslove navigacijske trake</string>
     <string name="settings_open_url_external">Otvori URL-ove u vanjskom pregledniku</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Izgled objave</string>
@@ -219,14 +210,10 @@
     <string name="settings_ui_font_scale">Veličina teksta korisničkog sučelja</string>
     <string name="settings_ui_theme">Tema korisničkog sučelja</string>
     <string name="settings_upvote_color">Boja za glasanje</string>
-    <string name="settings_hide_navigation_bar">Sakrij navigacijsku traku tijekom pomicanja
-    </string>
+    <string name="settings_hide_navigation_bar">Sakrij navigacijsku traku tijekom pomicanja</string>
     <string name="settings_zombie_mode_interval">Trajanje intervala zombi načina rada</string>
-    <string name="settings_zombie_mode_scroll_amount">Količina pomicanja u zombi načinu rada
-    </string>
-    <string name="settings_mark_as_read_while_scrolling">Označite postove kao pročitane tijekom
-        pomicanja
-    </string>
+    <string name="settings_zombie_mode_scroll_amount">Količina pomicanja u zombi načinu rada</string>
+    <string name="settings_mark_as_read_while_scrolling">Označite postove kao pročitane tijekom pomicanja</string>
     <string name="action_quote">Citat</string>
     <string name="mod_action_allow">Ponovo dopustiti korisniku</string>
     <string name="mod_action_ban">Ban korisnika</string>
@@ -244,10 +231,7 @@
     <string name="report_list_type_unresolved">Neriješeno</string>
     <string name="report_action_resolve">Riješi</string>
     <string name="report_action_unresolve">Poništi rješavanje</string>
-    <string name="sidebar_not_logged_message">Dobro došli u Raccoon za Lemmyja!\n\nU anonimnom
-        načinu rada, koristite padajući gumb (▼) iznad za promjenu instance.\n\nMožete se prijaviti
-        na svoju instancu na bilo kada sa zaslona profila.\n\nUživajte u Lemmyju!
-    </string>
+    <string name="sidebar_not_logged_message">Dobro došli u Raccoon za Lemmyja!\n\nU anonimnom načinu rada, koristite padajući gumb (▼) iznad za promjenu instance.\n\nMožete se prijaviti na svoju instancu na bilo kada sa zaslona profila.\n\nUživajte u Lemmyju!</string>
     <string name="settings_default_inbox_type">Zadana vrsta pristigle pošte</string>
     <string name="mod_action_add_mod">Dodaj moderatora</string>
     <string name="mod_action_remove_mod">Ukloniti moderatora</string>
@@ -348,4 +332,5 @@
     <string name="moderator_zone_title">Alati za moderatore</string>
     <string name="moderator_zone_action_comments">Moderirani komentari</string>
     <string name="moderator_zone_action_posts">Moderirani postovi</string>
+    <string name="message_auth_issue">Došlo je do pogreške prilikom dohvaćanja korisničkih podataka, pokušajte osvježiti zaslon</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Összes</string>
     <string name="inbox_listing_type_title">Postafiók típusa</string>
     <string name="inbox_listing_type_unread">Olvasatlan</string>
-    <string name="inbox_not_logged_message">Jelenleg nem vagy\n bejelentkezve.Adj hozzá egy fiókot
-        a profilképernyőn a postafiókod megtekintéséhez.
-    </string>
+    <string name="inbox_not_logged_message">Jelenleg nem vagy\n bejelentkezve.Adj hozzá egy fiókot a profilképernyőn a postafiókod megtekintéséhez.</string>
     <string name="inbox_section_mentions">Említések</string>
     <string name="inbox_section_messages">Üzenetek</string>
     <string name="inbox_section_replies">Válaszok</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Fiókok kezelése</string>
     <string name="manage_subscriptions_header_multicommunities">Többközösségek</string>
     <string name="manage_subscriptions_header_subscriptions">Feliratkozások</string>
-    <string name="message_empty_comments">Túl nagy ott a\n csend.Szeretnél te lenni az, aki
-        megírja az első hozzászólást?
-    </string>
+    <string name="message_empty_comments">Túl nagy ott a\n csend.Szeretnél te lenni az, aki megírja az első hozzászólást?</string>
     <string name="message_empty_list">Nincs megjeleníthető elem</string>
     <string name="message_error_loading_comments">Hiba történt a megjegyzések betöltésekor.</string>
     <string name="message_generic_error">Általános hiba</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">nap</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Jelenleg nem vagy\n bejelentkezve.Adj meg egy
-        fiókot a folytatáshoz.
-    </string>
+    <string name="profile_not_logged_message">Jelenleg nem vagy\n bejelentkezve.Adj meg egy fiókot a folytatáshoz.</string>
     <string name="profile_section_comments">Hozzászólások</string>
     <string name="profile_section_posts">Bejegyzések</string>
     <string name="profile_thousand_short">k</string>
@@ -186,8 +180,7 @@
     <string name="settings_content_font_smaller">Extra kicsi</string>
     <string name="settings_content_font_smallest">Dupla extra kicsi</string>
     <string name="settings_custom_seed_color">Egyéni téma színe</string>
-    <string name="settings_default_comment_sort_type">Alapértelmezett megjegyzésrendezési típus
-    </string>
+    <string name="settings_default_comment_sort_type">Alapértelmezett megjegyzésrendezési típus</string>
     <string name="settings_default_listing_type">Alapértelmezett feed típus</string>
     <string name="settings_default_post_sort_type">Érvénytelen bejegyzés típus:</string>
     <string name="settings_downvote_color">Negatív szavazatok színe</string>
@@ -198,8 +191,7 @@
     <string name="settings_full_height_images">Teljes magasságú képek</string>
     <string name="settings_include_nsfw">NSFW-tartalom belefoglalása</string>
     <string name="settings_language">Nyelv</string>
-    <string name="settings_navigation_bar_titles_visible">Navigációs sáv címeinek megjelenítése
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Navigációs sáv címeinek megjelenítése</string>
     <string name="settings_open_url_external">Megnyitás külső böngészőben</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Bejegyzés elrendezés</string>
@@ -221,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Navigációs sáv elrejtése görgetés közben</string>
     <string name="settings_zombie_mode_interval">Zombi üzemmód intervallum időtartama</string>
     <string name="settings_zombie_mode_scroll_amount">Zombi mód görgetés mennyisége</string>
-    <string name="settings_mark_as_read_while_scrolling">Bejegyzések megjelölése olvasottként
-        görgetés közben
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Bejegyzések megjelölése olvasottként görgetés közben</string>
     <string name="action_quote">Idézet</string>
     <string name="mod_action_allow">Engedélyezze újra a felhasználót</string>
     <string name="mod_action_ban">Felhasználó kitiltása</string>
@@ -234,19 +224,14 @@
     <string name="mod_action_unlock">Feloldás</string>
     <string name="mod_action_remove">Eltávolítás</string>
     <string name="mod_action_mark_as_distinguished">Megjelölés megkülönböztetettként</string>
-    <string name="mod_action_unmark_as_distinguished">Megkülönböztetettként való megjelölés
-        eltávolítása
-    </string>
+    <string name="mod_action_unmark_as_distinguished">Megkülönböztetettként való megjelölés eltávolítása</string>
     <string name="report_list_title">Jelentéslista</string>
     <string name="report_list_type_title">Jelentéslista típusa</string>
     <string name="report_list_type_all">Mind</string>
     <string name="report_list_type_unresolved">Feloldatlan</string>
     <string name="report_action_resolve">Megoldás</string>
     <string name="report_action_unresolve">Feloldás megszüntetése</string>
-    <string name="sidebar_not_logged_message">Üdvözöljük a Raccoon for Lemmy oldalán!\n\nNévtelen
-        módban, használja a fenti legördülő gombot (▼) a példány megváltoztatásához.\n\nA következő
-        címen jelentkezhet be a példányába bármikor a Profil képernyőről.\n\nÉlvezze Lemmyt!
-    </string>
+    <string name="sidebar_not_logged_message">Üdvözöljük a Raccoon for Lemmy oldalán!\n\nNévtelen módban, használja a fenti legördülő gombot (▼) a példány megváltoztatásához.\n\nA következő címen jelentkezhet be a példányába bármikor a Profil képernyőről.\n\nÉlvezze Lemmyt!</string>
     <string name="settings_default_inbox_type">Alapértelmezett beérkező levelek típusa</string>
     <string name="mod_action_add_mod">Moderátor hozzáadása</string>
     <string name="mod_action_remove_mod">Moderátor eltávolítása</string>
@@ -347,4 +332,5 @@
     <string name="moderator_zone_title">Eszközök moderátorok számára</string>
     <string name="moderator_zone_action_comments">Moderált megjegyzések</string>
     <string name="moderator_zone_action_posts">Moderált bejegyzések</string>
+    <string name="message_auth_issue">Hiba történt a felhasználói adatok lekérése közben, próbálja meg frissíteni a képernyőt</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Non letti</string>
     <string name="inbox_action_mark_read">Segna come letto</string>
     <string name="inbox_action_mark_unread">Segna come non letto</string>
-    <string name="inbox_not_logged_message">Login non effettuato.\nAggiungi un account dalla
-        schermata Profilo per accedere alla inbox.
-    </string>
+    <string name="inbox_not_logged_message">Login non effettuato.\nAggiungi un account dalla schermata Profilo per accedere alla inbox.</string>
     <string name="inbox_section_mentions">Menzioni</string>
     <string name="inbox_section_messages">Messaggi</string>
     <string name="inbox_section_replies">Risposte</string>
@@ -107,13 +105,9 @@
     <string name="manage_accounts_title">Gestisci account</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-comunità</string>
     <string name="manage_subscriptions_header_subscriptions">Iscrizioni</string>
-    <string name="message_empty_comments">È tutto troppo calmo da queste parti.\nVorresti essere tu
-        a scrivere il primo commento?
-    </string>
+    <string name="message_empty_comments">È tutto troppo calmo da queste parti.\nVorresti essere tu a scrivere il primo commento?</string>
     <string name="message_empty_list">Nessun elemento da visualizzare</string>
-    <string name="message_error_loading_comments">Si è verificato un errore nel caricamento dei
-        commenti.
-    </string>
+    <string name="message_error_loading_comments">Si è verificato un errore nel caricamento dei commenti.</string>
     <string name="message_generic_error">Errore generico</string>
     <string name="message_image_loading_error">Errore caricamento immagine</string>
     <string name="message_invalid_field">Campo non valido</string>
@@ -146,9 +140,7 @@
     <string name="profile_day_short">g</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Login non effettuato.\nAggiungi un account per
-        continuare.
-    </string>
+    <string name="profile_not_logged_message">Login non effettuato.\nAggiungi un account per continuare.</string>
     <string name="profile_section_comments">Commenti</string>
     <string name="profile_section_posts">Post</string>
     <string name="profile_thousand_short">k</string>
@@ -199,8 +191,7 @@
     <string name="settings_full_height_images">Altezza completa immagini</string>
     <string name="settings_include_nsfw">Includi contenuti NSFW</string>
     <string name="settings_language">Lingua</string>
-    <string name="settings_navigation_bar_titles_visible">Mostra titoli barra di navigazione
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Mostra titoli barra di navigazione</string>
     <string name="settings_open_url_external">Apri URL su browser esterno</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Layout post</string>
@@ -219,12 +210,10 @@
     <string name="settings_ui_font_scale">Dimensione testo UI</string>
     <string name="settings_ui_theme">Tema interfaccia</string>
     <string name="settings_upvote_color">Colore voti positivi</string>
-    <string name="settings_hide_navigation_bar">Nascondi barra di navigazione durante lo scroll
-    </string>
+    <string name="settings_hide_navigation_bar">Nascondi barra di navigazione durante lo scroll</string>
     <string name="settings_zombie_mode_interval">Durata intevallo modalità zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Ampiezza scroll modalità zombie</string>
-    <string name="settings_mark_as_read_while_scrolling">Segna post come letti durante lo scroll
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Segna post come letti durante lo scroll</string>
     <string name="action_quote">Cita</string>
     <string name="mod_action_allow">Riammetti utente</string>
     <string name="mod_action_ban">Banna utente</string>
@@ -242,11 +231,7 @@
     <string name="report_list_type_unresolved">Non risolte</string>
     <string name="report_action_resolve">Segna come risolto</string>
     <string name="report_action_unresolve">Segna come non risolto</string>
-    <string name="sidebar_not_logged_message">Benvenuto su Raccoon for Lemmy!\n\nIn modalità
-        anonima, utilizza il pulsante di selezione (▼) qui sopra per cambiare istanza.\n\nPuoi
-        effettuare il login sulla tua istanza in qualsiasi momento dalla schermata
-        Profilo.\n\nDivertiti su Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Benvenuto su Raccoon for Lemmy!\n\nIn modalità anonima, utilizza il pulsante di selezione (▼) qui sopra per cambiare istanza.\n\nPuoi effettuare il login sulla tua istanza in qualsiasi momento dalla schermata Profilo.\n\nDivertiti su Lemmy!</string>
     <string name="settings_default_inbox_type">Tipo inbox predefinito</string>
     <string name="mod_action_add_mod">Aggiungi moderatore</string>
     <string name="mod_action_remove_mod">Rimuovi moderatore</string>
@@ -347,4 +332,5 @@
     <string name="moderator_zone_title">Strumenti per moderatori</string>
     <string name="moderator_zone_action_comments">Commenti da moderare</string>
     <string name="moderator_zone_action_posts">Post da moderare</string>
+    <string name="message_auth_issue">Si è verificato un errore nel recupero dei dati utente, fare refresh della schermata</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Viskas</string>
     <string name="inbox_listing_type_title">Pašto dėžutės tipas</string>
     <string name="inbox_listing_type_unread">Neperskaityta</string>
-    <string name="inbox_not_logged_message">Šiuo metu nesate prisijungę.Pridėkite\n paskyrą
-        profilio ekrane, kad pamatytumėte savo pašto dėžutę.
-    </string>
+    <string name="inbox_not_logged_message">Šiuo metu nesate prisijungę.Pridėkite\n paskyrą profilio ekrane, kad pamatytumėte savo pašto dėžutę.</string>
     <string name="inbox_section_mentions">Paminėjimai</string>
     <string name="inbox_section_messages">Žinutės</string>
     <string name="inbox_section_replies">Atsakymai</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Valdyti paskyras</string>
     <string name="manage_subscriptions_header_multicommunities">Kelių bendruomenių</string>
     <string name="manage_subscriptions_header_subscriptions">Prenumeratos</string>
-    <string name="message_empty_comments">Ten per daug\n tylu.Ar norėtum būti tas, kuris
-        parašo pirmąjį komentarą?
-    </string>
+    <string name="message_empty_comments">Ten per daug\n tylu.Ar norėtum būti tas, kuris parašo pirmąjį komentarą?</string>
     <string name="message_empty_list">Nėra rodytinų elementų</string>
     <string name="message_error_loading_comments">Įkeliant komentarus įvyko klaida.</string>
     <string name="message_generic_error">Bendroji klaida</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Šiuo metu nesate prisijungę\n .Pridėkite
-        paskyrą, kad galėtumėte tęsti.
-    </string>
+    <string name="profile_not_logged_message">Šiuo metu nesate prisijungę.\nPridėkite paskyrą, kad galėtumėte tęsti.</string>
     <string name="profile_section_comments">komentarai</string>
     <string name="profile_section_posts">Postai</string>
     <string name="profile_thousand_short">.</string>
@@ -197,8 +191,7 @@
     <string name="settings_full_height_images">Viso aukščio vaizdai</string>
     <string name="settings_include_nsfw">Įtraukti NSFW turinį</string>
     <string name="settings_language">Kalba</string>
-    <string name="settings_navigation_bar_titles_visible">Rodyti naršymo juostos pavadinimus
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Rodyti naršymo juostos pavadinimus</string>
     <string name="settings_open_url_external">Atidarykite URL išorinėje naršyklėje</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Įrašo maketas</string>
@@ -220,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Slinkdami slėpti naršymo juostą</string>
     <string name="settings_zombie_mode_interval">Zombių režimo intervalo trukmė</string>
     <string name="settings_zombie_mode_scroll_amount">Zombių režimo slinkties kiekis</string>
-    <string name="settings_mark_as_read_while_scrolling">Slinkdami pažymėkite įrašus kaip
-        skaitytus
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Slinkdami pažymėkite įrašus kaip skaitytus</string>
     <string name="action_quote">Citata</string>
     <string name="mod_action_allow">Leisti vartotojui dar kartą</string>
     <string name="mod_action_ban">Uždrausti vartotoją</string>
@@ -240,11 +231,7 @@
     <string name="report_list_type_unresolved">Neišspręsta</string>
     <string name="report_action_resolve">Išspręsti</string>
     <string name="report_action_unresolve">Neišspręsti</string>
-    <string name="sidebar_not_logged_message">Sveiki atvykę į Raccoon for Lemmy!\n\nAnoniminiu
-        režimu, naudokite aukščiau esantį išskleidžiamąjį mygtuką (▼), kad pakeistumėte
-        egzempliorių.\n\nPrisijungti galite adresu bet kuriuo metu iš profilio ekrano.\n\nMėgaukitės
-        Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Sveiki atvykę į Raccoon for Lemmy!\n\nAnoniminiu režimu, naudokite aukščiau esantį išskleidžiamąjį mygtuką (▼), kad pakeistumėte egzempliorių.\n\nPrisijungti galite adresu bet kuriuo metu iš profilio ekrano.\n\nMėgaukitės Lemmy!</string>
     <string name="settings_default_inbox_type">Numatytasis gautųjų tipas</string>
     <string name="mod_action_add_mod">Pridėti moderatorių</string>
     <string name="mod_action_remove_mod">Pašalinti moderatorių</string>
@@ -345,4 +332,5 @@
     <string name="moderator_zone_title">Priemonės moderatoriams</string>
     <string name="moderator_zone_action_comments">Moderuojami komentarai</string>
     <string name="moderator_zone_action_posts">Moderuojami įrašai</string>
+    <string name="message_auth_issue">Gaunant vartotojo duomenis įvyko klaida. Pabandykite atnaujinti ekraną</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -89,10 +89,7 @@
     <string name="inbox_listing_type_all">Viss</string>
     <string name="inbox_listing_type_title">Iesūtnes veids</string>
     <string name="inbox_listing_type_unread">Nelasīts</string>
-    <string name="inbox_not_logged_message">Jūs pašlaik neesat pieteicies.Lūdzu,\n pievienojiet
-        kontu
-        profila ekrānā, lai redzētu iesūtni.
-    </string>
+    <string name="inbox_not_logged_message">Jūs pašlaik neesat pieteicies.Lūdzu,\n pievienojiet kontu profila ekrānā, lai redzētu iesūtni.</string>
     <string name="inbox_section_mentions">Pieminējumi</string>
     <string name="inbox_section_messages">Ziņojumi</string>
     <string name="inbox_section_replies">Atbildes</string>
@@ -108,9 +105,7 @@
     <string name="manage_accounts_title">Kontu vadība</string>
     <string name="manage_subscriptions_header_multicommunities">Vairākas kopienas</string>
     <string name="manage_subscriptions_header_subscriptions">Abonementi</string>
-    <string name="message_empty_comments">Tur ir pārāk\n kluss.Vai jūsvēlētos būt tas, kurš
-        raksta pirmo komentāru?
-    </string>
+    <string name="message_empty_comments">Tur ir pārāk\n kluss.Vai jūsvēlētos būt tas, kurš raksta pirmo komentāru?</string>
     <string name="message_empty_list">Nav parādāmu vienumu</string>
     <string name="message_error_loading_comments">Ielādējot komentārus, radās kļūda.</string>
     <string name="message_generic_error">Vispārēja kļūda</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d.</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Jūs pašlaik neesat pieteicies.\nLūdzu, pievienojiet
-        kontā, lai turpinātu.
-    </string>
+    <string name="profile_not_logged_message">Jūs pašlaik neesat pieteicies.\nLūdzu, pievienojiet kontā, lai turpinātu.</string>
     <string name="profile_section_comments">Komentāri</string>
     <string name="profile_section_posts">Ieraksti</string>
     <string name="profile_thousand_short">k</string>
@@ -187,8 +180,7 @@
     <string name="settings_content_font_smaller">Ekstra mazs</string>
     <string name="settings_content_font_smallest">Divvietīgs, īpaši mazs</string>
     <string name="settings_custom_seed_color">Pielāgota dizaina krāsa</string>
-    <string name="settings_default_comment_sort_type">Noklusējuma komentāru kārtošanas veids
-    </string>
+    <string name="settings_default_comment_sort_type">Noklusējuma komentāru kārtošanas veids</string>
     <string name="settings_default_listing_type">Noklusējuma plūsmas veids</string>
     <string name="settings_default_post_sort_type">Noklusējuma ziņu kārtošanas veids</string>
     <string name="settings_downvote_color">Lejupvērstās balss krāsa</string>
@@ -199,8 +191,7 @@
     <string name="settings_full_height_images">Attēli pilnā augumā</string>
     <string name="settings_include_nsfw">Iekļaut NSFW saturu</string>
     <string name="settings_language">Valoda</string>
-    <string name="settings_navigation_bar_titles_visible">Rādīt navigācijas joslu virsrakstus
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Rādīt navigācijas joslu virsrakstus</string>
     <string name="settings_open_url_external">Atvērt pārlūkā</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Ieraksta Izkārtojums</string>
@@ -219,13 +210,10 @@
     <string name="settings_ui_font_scale">Lietotāja interfeisa teksta lielums</string>
     <string name="settings_ui_theme">UI tēmas</string>
     <string name="settings_upvote_color">Upvote krāsa</string>
-    <string name="settings_hide_navigation_bar">Ritinot paslēpt navigācijas ritināšanas laikā
-    </string>
+    <string name="settings_hide_navigation_bar">Ritinot paslēpt navigācijas ritināšanas laikā</string>
     <string name="settings_zombie_mode_interval">Zombiju režīma intervāla ilgums</string>
     <string name="settings_zombie_mode_scroll_amount">Zombiju režīma ritināšanas apjoms</string>
-    <string name="settings_mark_as_read_while_scrolling">Atzīmējiet ziņas kā izlasītas ritināšanas
-        laikā
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Atzīmējiet ziņas kā izlasītas ritināšanas laikā</string>
     <string name="action_quote">Citāts</string>
     <string name="mod_action_allow">Ļaut lietotājam vēlreiz</string>
     <string name="mod_action_ban">Aizliegt lietotāju</string>
@@ -243,10 +231,7 @@
     <string name="report_list_type_unresolved">Neatrisināts</string>
     <string name="report_action_resolve">Atrisināt</string>
     <string name="report_action_unresolve">Neatrisināts</string>
-    <string name="sidebar_not_logged_message">Laipni lūdzam Raccoon for Lemmy!\n\nAnonīmā režīmā,
-        izmantojiet augstāk esošo nolaižamās izvēlnes pogu (▼), lai mainītu gadījumu.\n\nJūs varat
-        pieteikties savā pieteikumā vietnē jebkurā laikā no profila ekrāna.\n\nIzbaudiet Lemiju!
-    </string>
+    <string name="sidebar_not_logged_message">Laipni lūdzam Raccoon for Lemmy!\n\nAnonīmā režīmā, izmantojiet augstāk esošo nolaižamās izvēlnes pogu (▼), lai mainītu gadījumu.\n\nJūs varat pieteikties savā pieteikumā vietnē jebkurā laikā no profila ekrāna.\n\nIzbaudiet Lemiju!</string>
     <string name="settings_default_inbox_type">Noklusējuma iesūtnes veids</string>
     <string name="mod_action_add_mod">Pievienot moderatoru</string>
     <string name="mod_action_remove_mod">Noņemt moderatoru</string>
@@ -347,4 +332,5 @@
     <string name="moderator_zone_title">Rīki moderatoriem</string>
     <string name="moderator_zone_action_comments">Regulēti komentāri</string>
     <string name="moderator_zone_action_posts">Regulētas ziņas</string>
+    <string name="message_auth_issue">Ienesot lietotāja datus, radās kļūda. Mēģiniet atsvaidzināt ekrānu</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Kollha</string>
     <string name="inbox_listing_type_title">Tip ta\' Inbox</string>
     <string name="inbox_listing_type_unread">Mhux moqri</string>
-    <string name="inbox_not_logged_message">Bħalissa m\' intix illoggjat.Jekk\n jogħġbok żid kont
-        mill-iskrin tal-profil biex tara l-inbox tiegħek.
-    </string>
+    <string name="inbox_not_logged_message">Bħalissa m\' intix illoggjat.Jekk\n jogħġbok żid kont mill-iskrin tal-profil biex tara l-inbox tiegħek.</string>
     <string name="inbox_section_mentions">Suġġerimenti</string>
     <string name="inbox_section_messages">Messaġġi</string>
     <string name="inbox_section_replies">Tweġibiet</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Immaniġġja l-kontijiet</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-komunitajiet</string>
     <string name="manage_subscriptions_header_subscriptions">Sottoskrizzjonijiet</string>
-    <string name="message_empty_comments">Hija wisq siekta\n hemmhekk.Tixtieq tkun dik li
-        tikteb l-ewwel kumment?
-    </string>
+    <string name="message_empty_comments">Hija wisq siekta\n hemmhekk.Tixtieq tkun dik li tikteb l-ewwel kumment?</string>
     <string name="message_empty_list">L-ebda oġġett biex jintwera</string>
     <string name="message_error_loading_comments">Seħħ żball fit-tlugħ tal-kummenti.</string>
     <string name="message_generic_error">Żball ġeneriku</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Bħalissa m\' intix illoggjat.Jekk\n jogħġbok żid
-        kont biex tkompli.
-    </string>
+    <string name="profile_not_logged_message">Bħalissa m\' intix illoggjat.Jekk\n jogħġbok żid kont biex tkompli.</string>
     <string name="profile_section_comments">Kummenti</string>
     <string name="profile_section_posts">Postijet</string>
     <string name="profile_thousand_short">k</string>
@@ -186,8 +180,7 @@
     <string name="settings_content_font_smaller">Iktar żgħir</string>
     <string name="settings_content_font_smallest">Żgħir żejjed doppju</string>
     <string name="settings_custom_seed_color">Kulur tat-tema personalizzat</string>
-    <string name="settings_default_comment_sort_type">Tip ta\' għażla ta\' kummenti prestabbiliti
-    </string>
+    <string name="settings_default_comment_sort_type">Tip ta\' għażla ta\' kummenti prestabbiliti</string>
     <string name="settings_default_listing_type">Tip ta\' feed standard</string>
     <string name="settings_default_post_sort_type">Tip ta\' tqassim ta\' postijiet standard</string>
     <string name="settings_downvote_color">Kulur \'l isfel fil-vot</string>
@@ -198,8 +191,7 @@
     <string name="settings_full_height_images">Stampi b\' għoli sħiħ</string>
     <string name="settings_include_nsfw">Inkludi l-kontenut tal-NSFW</string>
     <string name="settings_language">Lingwa</string>
-    <string name="settings_navigation_bar_titles_visible">Uri l-ismijiet tal-bar tan-navigazzjoni
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Uri l-ismijiet tal-bar tan-navigazzjoni</string>
     <string name="settings_open_url_external">Iftaħ il-URLs fil-brawżer estern</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Tqassim tal-post</string>
@@ -218,15 +210,10 @@
     <string name="settings_ui_font_scale">Daqs tat-test tal-UI</string>
     <string name="settings_ui_theme">Tema tal-IU</string>
     <string name="settings_upvote_color">Agħti l-vot bil-kulur</string>
-    <string name="settings_hide_navigation_bar">Aħbi l-bar tan-navigazzjoni waqt li tkun qed
-        tiskrollja
-    </string>
+    <string name="settings_hide_navigation_bar">Aħbi l-bar tan-navigazzjoni waqt li tkun qed tiskrollja</string>
     <string name="settings_zombie_mode_interval">Tul tal-intervall tal-modalità Zombie</string>
-    <string name="settings_zombie_mode_scroll_amount">Ammont ta\' skrolljar tal-modalità Zombie
-    </string>
-    <string name="settings_mark_as_read_while_scrolling">Immarka l-postijiet bħala moqrija waqt li
-        tkun qed tiskrollja
-    </string>
+    <string name="settings_zombie_mode_scroll_amount">Ammont ta\' skrolljar tal-modalità Zombie</string>
+    <string name="settings_mark_as_read_while_scrolling">Immarka l-postijiet bħala moqrija waqt li tkun qed tiskrollja</string>
     <string name="action_quote">Kwotazzjoni</string>
     <string name="mod_action_allow">Jippermetti lill-utent mill-ġdid</string>
     <string name="mod_action_ban">Tipprojbixxi l-utent</string>
@@ -244,10 +231,7 @@
     <string name="report_list_type_unresolved">Mhux solvut</string>
     <string name="report_action_resolve">Issolvi</string>
     <string name="report_action_unresolve">Neħħi s-soluzzjoni</string>
-    <string name="sidebar_not_logged_message">Merħba f\' Raccoon for Lemmy!\n\nBil-modalità anonima,
-        uża l-buttuna drop-down (▼) t\' hawn fuq biex tibdel il-mument.\n\nTista\' tidħol
-        fl-intenzjoni tiegħek fuq fi kwalunkwe ħin\n\n mill-iskrintal-Profil.\n\nEnjoy Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Merħba f\' Raccoon for Lemmy!\n\nBil-modalità anonima, uża l-buttuna drop-down (▼) t\' hawn fuq biex tibdel il-mument.\n\nTista\' tidħol fl-intenzjoni tiegħek fuq fi kwalunkwe ħin\n\n mill-iskrintal-Profil.\n\nEnjoy Lemmy!</string>
     <string name="settings_default_inbox_type">Tip default ta \'inbox</string>
     <string name="mod_action_add_mod">Żid moderatur</string>
     <string name="mod_action_remove_mod">Neħħi moderatur</string>
@@ -348,4 +332,5 @@
     <string name="moderator_zone_title">Għodda għall-moderaturi</string>
     <string name="moderator_zone_action_comments">Kummenti moderati</string>
     <string name="moderator_zone_action_posts">Postijiet moderati</string>
+    <string name="message_auth_issue">Żball seħħ waqt li ġġib id-dejta tal-utent, ipprova aġġorna l-iskrin</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Ongelezen</string>
     <string name="inbox_action_mark_read">Markeren als gelezen</string>
     <string name="inbox_action_mark_unread">Markeren als ongelezen</string>
-    <string name="inbox_not_logged_message">U bent momenteel niet ingelogd.\nVoeg een account toe
-        vanuit het profielscherm om je inbox te zien.
-    </string>
+    <string name="inbox_not_logged_message">U bent momenteel niet ingelogd.\nVoeg een account toe vanuit het profielscherm om je inbox te zien.</string>
     <string name="inbox_section_mentions">Vermeldingen</string>
     <string name="inbox_section_messages">Berichten</string>
     <string name="inbox_section_replies">Antwoorden</string>
@@ -107,13 +105,9 @@
     <string name="manage_accounts_title">Beheer accounts</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-gemeenschappen</string>
     <string name="manage_subscriptions_header_subscriptions">Abonnementen</string>
-    <string name="message_empty_comments">Het is daar te stil.\nZou jij degene willen zijn die de
-        eerste opmerking schrijft?
-    </string>
+    <string name="message_empty_comments">Het is daar te stil.\nZou jij degene willen zijn die de eerste opmerking schrijft?</string>
     <string name="message_empty_list">Geen items om weer te geven</string>
-    <string name="message_error_loading_comments">Er is een fout opgetreden bij het laden van
-        opmerkingen.
-    </string>
+    <string name="message_error_loading_comments">Er is een fout opgetreden bij het laden van opmerkingen.</string>
     <string name="message_generic_error">Algemene fout</string>
     <string name="message_image_loading_error">Fout bij laden van afbeelding</string>
     <string name="message_invalid_field">Ongeldig veld</string>
@@ -146,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">U bent momenteel niet ingelogd.\nVoeg eenaccount om
-        door te gaan.
-    </string>
+    <string name="profile_not_logged_message">U bent momenteel niet ingelogd.\nVoeg eenaccount om door te gaan.</string>
     <string name="profile_section_comments">Opmerkingen</string>
     <string name="profile_section_posts">Berichten</string>
     <string name="profile_thousand_short">k</string>
@@ -218,13 +210,10 @@
     <string name="settings_ui_font_scale">UI-tekstgrootte</string>
     <string name="settings_ui_theme">UI-thema</string>
     <string name="settings_upvote_color">Upvote kleur</string>
-    <string name="settings_hide_navigation_bar">Verberg de navigatiebalk tijdens het scrollen
-    </string>
+    <string name="settings_hide_navigation_bar">Verberg de navigatiebalk tijdens het scrollen</string>
     <string name="settings_zombie_mode_interval">Intervalduur zombiemodus</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie mode scroll amount</string>
-    <string name="settings_mark_as_read_while_scrolling">Markeer berichten als gelezen tijdens het
-        scrollen
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Markeer berichten als gelezen tijdens het scrollen</string>
     <string name="action_quote">Citaat</string>
     <string name="mod_action_allow">Laat de gebruiker opnieuw toe</string>
     <string name="mod_action_ban">Verban gebruiker</string>
@@ -242,10 +231,7 @@
     <string name="report_list_type_unresolved">Onopgelost</string>
     <string name="report_action_resolve">Oplossen</string>
     <string name="report_action_unresolve">Onopgelost</string>
-    <string name="sidebar_not_logged_message">Welkom bij Raccoon for Lemmy!\n\nIn de anonieme modus,
-        gebruik de vervolgkeuzeknop (▼) hierboven om de instantie te wijzigen.\n\nU kunt inloggen op
-        uw instantie op wanneer je maar wilt vanuit het profielscherm.\n\nGeniet van Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Welkom bij Raccoon for Lemmy!\n\nIn de anonieme modus, gebruik de vervolgkeuzeknop (▼) hierboven om de instantie te wijzigen.\n\nU kunt inloggen op uw instantie op wanneer je maar wilt vanuit het profielscherm.\n\nGeniet van Lemmy!</string>
     <string name="settings_default_inbox_type">Standaardtype inbox</string>
     <string name="mod_action_add_mod">Moderator toevoegen</string>
     <string name="mod_action_remove_mod">Moderator verwijderen</string>
@@ -346,4 +332,5 @@
     <string name="moderator_zone_title">Hulpmiddelen voor moderators</string>
     <string name="moderator_zone_action_comments">Gemodereerde opmerkingen</string>
     <string name="moderator_zone_action_posts">Gemodereerde berichten</string>
+    <string name="message_auth_issue">Er is een fout opgetreden tijdens het ophalen van gebruikersgegevens. Probeer het scherm te vernieuwen</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Alle</string>
     <string name="inbox_listing_type_title">Innboks type</string>
     <string name="inbox_listing_type_unread">Ulest</string>
-    <string name="inbox_not_logged_message">Du er ikke logget\n inn.Leggtil konto
-        på profilskjermen for å se innboksen din.
-    </string>
+    <string name="inbox_not_logged_message">Du er ikke logget\n inn.Leggtil konto på profilskjermen for å se innboksen din.</string>
     <string name="inbox_section_mentions">Omtaler</string>
     <string name="inbox_section_messages">Meldinger</string>
     <string name="inbox_section_replies">Svar</string>
@@ -107,13 +105,9 @@
     <string name="manage_accounts_title">Administrer kontoer</string>
     <string name="manage_subscriptions_header_multicommunities">Multisamfunn</string>
     <string name="manage_subscriptions_header_subscriptions">Abonnement</string>
-    <string name="message_empty_comments">Det er for stille der.\nVil du være den som skriver den
-        første kommentaren?
-    </string>
+    <string name="message_empty_comments">Det er for stille der.\nVil du være den som skriver den første kommentaren?</string>
     <string name="message_empty_list">Ingen elementer å vise</string>
-    <string name="message_error_loading_comments">Det oppstod en feil under lasting av
-        kommentarer.
-    </string>
+    <string name="message_error_loading_comments">Det oppstod en feil under lasting av kommentarer.</string>
     <string name="message_generic_error">Allmenn feil</string>
     <string name="message_image_loading_error">Bildeinnlastingsfeil</string>
     <string name="message_invalid_field">Ugyldig felt</string>
@@ -146,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Du er ikke logget\n inn.Please addan
-        konto for å fortsette.
-    </string>
+    <string name="profile_not_logged_message">Du er ikke logget\n inn.Please addan konto for å fortsette.</string>
     <string name="profile_section_comments">Kommentarer</string>
     <string name="profile_section_posts">Nyheter</string>
     <string name="profile_thousand_short">k</string>
@@ -188,8 +180,7 @@
     <string name="settings_content_font_smaller">Ekstra liten</string>
     <string name="settings_content_font_smallest">Dobbel ekstra liten</string>
     <string name="settings_custom_seed_color">Egendefinert temafarge</string>
-    <string name="settings_default_comment_sort_type">Standard sorteringstype for kommentarer
-    </string>
+    <string name="settings_default_comment_sort_type">Standard sorteringstype for kommentarer</string>
     <string name="settings_default_listing_type">Standard innmatingstype</string>
     <string name="settings_default_post_sort_type">Standard innleggstype:</string>
     <string name="settings_downvote_color">Downvote farge</string>
@@ -222,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Skjul navigasjonsfeltet mens du ruller</string>
     <string name="settings_zombie_mode_interval">Zombie-modus intervallvarighet</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie-modus rullebeløp</string>
-    <string name="settings_mark_as_read_while_scrolling">Merk innlegg som lest mens du ruller
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Merk innlegg som lest mens du ruller</string>
     <string name="action_quote">Sitat</string>
     <string name="mod_action_allow">Tillate brukeren igjen</string>
     <string name="mod_action_ban">Utestenge bruker</string>
@@ -241,10 +231,7 @@
     <string name="report_list_type_unresolved">Uløst</string>
     <string name="report_action_resolve">Løs</string>
     <string name="report_action_unresolve">Løs opp</string>
-    <string name="sidebar_not_logged_message">Velkommen til Raccoon for Lemmy!\n\nI anonym modus,
-        bruk rullegardinknappen (▼) ovenfor for å endre forekomst.\n\nDu kan logge på forekomsten
-        din på når som helst fra profilskjermen.\n\nNyt Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Velkommen til Raccoon for Lemmy!\n\nI anonym modus, bruk rullegardinknappen (▼) ovenfor for å endre forekomst.\n\nDu kan logge på forekomsten din på når som helst fra profilskjermen.\n\nNyt Lemmy!</string>
     <string name="settings_default_inbox_type">Standard innbokstype</string>
     <string name="mod_action_add_mod">Legg til moderator</string>
     <string name="mod_action_remove_mod">Fjern moderator</string>
@@ -345,4 +332,5 @@
     <string name="moderator_zone_title">Verktøy for moderatorer</string>
     <string name="moderator_zone_action_comments">Modererte kommentarer</string>
     <string name="moderator_zone_action_posts">Modererte innlegg</string>
+    <string name="message_auth_issue">Det oppstod en feil under henting av brukerdata. Prøv å oppdatere skjermen</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Nieprzeczytany</string>
     <string name="inbox_action_mark_read">Oznacz jako przeczytane</string>
     <string name="inbox_action_mark_unread">Oznacz jako nieprzeczytane</string>
-    <string name="inbox_not_logged_message">Obecnie nie jesteś zalogowany.\nDodaj konto na ekranie
-        profilu, aby zobaczyć swoją skrzynkę odbiorczą."
-    </string>
+    <string name="inbox_not_logged_message">Obecnie nie jesteś zalogowany.\nDodaj konto na ekranie profilu, aby zobaczyć swoją skrzynkę odbiorczą."</string>
     <string name="inbox_section_mentions">Wspomnienia</string>
     <string name="inbox_section_messages">Wiadomości</string>
     <string name="inbox_section_replies">Odpowiedzi</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Zarządzanie kontami</string>
     <string name="manage_subscriptions_header_multicommunities">Wielospołeczności</string>
     <string name="manage_subscriptions_header_subscriptions">Subskrypcje</string>
-    <string name="message_empty_comments">Jest tam zbyt cicho.\nChcesz być tym, który napisze
-        pierwszy komentarz?"
-    </string>
+    <string name="message_empty_comments">Jest tam zbyt cicho.\nChcesz być tym, który napisze pierwszy komentarz?</string>
     <string name="message_empty_list">Brak elementów do wyświetlenia</string>
-    <string name="message_error_loading_comments">Wystąpił błąd podczas ładowania komentarzy.
-    </string>
+    <string name="message_error_loading_comments">Wystąpił błąd podczas ładowania komentarzy.</string>
     <string name="message_generic_error">Błąd ogólny</string>
     <string name="message_image_loading_error">Błąd ładowania obrazu</string>
     <string name="message_invalid_field">Nieprawidłowe pole</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Obecnie nie jesteś zalogowany.\nDodaj konto, aby
-        kontynuować.
-    </string>
+    <string name="profile_not_logged_message">Obecnie nie jesteś zalogowany.\nDodaj konto, aby kontynuować.</string>
     <string name="profile_section_comments">Komentarze</string>
     <string name="profile_section_posts">Posty</string>
     <string name="profile_thousand_short">k</string>
@@ -200,8 +193,7 @@
     <string name="settings_include_nsfw">Dołączanie treści NSFW</string>
     <string name="settings_language">Język</string>
     <string name="settings_navigation_bar_titles_visible">Pokaż tytuły pasków nawigacji</string>
-    <string name="settings_open_url_external">Otwieranie adresów URL w zewnętrznej przeglądarce
-    </string>
+    <string name="settings_open_url_external">Otwieranie adresów URL w zewnętrznej przeglądarce</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Układ posta</string>
     <string name="settings_post_layout_card">Kartka</string>
@@ -221,9 +213,7 @@
     <string name="settings_upvote_color">Kolor głosów pozytywnych</string>
     <string name="settings_zombie_mode_interval">Czas trwania interwału trybu zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Ilość przewijania trybu zombie</string>
-    <string name="settings_mark_as_read_while_scrolling">Oznacz posty jako przeczytane podczas
-        przewijania
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Oznacz posty jako przeczytane podczas przewijania</string>
     <string name="action_quote">Cytat</string>
     <string name="mod_action_allow">Ponownie zezwolić użytkownikowi</string>
     <string name="mod_action_ban">Zablokuj użytkownika</string>
@@ -241,11 +231,7 @@
     <string name="report_list_type_unresolved">Nierozwiązany</string>
     <string name="report_action_resolve">Rozwiąż</string>
     <string name="report_action_unresolve">Cofnij rozwiązanie</string>
-    <string name="sidebar_not_logged_message">Witamy w Raccoon dla Lemmy\'ego!\n\nW trybie
-        anonimowym
-        użyj przycisku rozwijanego (▼) powyżej, aby zmienić instancję.\n\nMożesz zalogować się do
-        swojej instancji pod adresem w dowolnym momencie na ekranie profilu.\n\nCiesz się Lemmym!
-    </string>
+    <string name="sidebar_not_logged_message">Witamy w Raccoon dla Lemmy\'ego!\n\nW trybie anonimowym użyj przycisku rozwijanego (▼) powyżej, aby zmienić instancję.\n\nMożesz zalogować się do swojej instancji pod adresem w dowolnym momencie na ekranie profilu.\n\nCiesz się Lemmym!</string>
     <string name="settings_default_inbox_type">Domyślny typ skrzynki odbiorczej</string>
     <string name="mod_action_add_mod">Dodaj moderatora</string>
     <string name="mod_action_remove_mod">Usuń moderatora</string>
@@ -346,4 +332,5 @@
     <string name="moderator_zone_title">Narzędzia dla moderatorów</string>
     <string name="moderator_zone_action_comments">Moderowane komentarze</string>
     <string name="moderator_zone_action_posts">Moderowane posty</string>
+    <string name="message_auth_issue">Wystąpił błąd podczas pobierania danych użytkownika. Spróbuj odświeżyć ekran</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Todas</string>
     <string name="inbox_listing_type_title">Padrão da caixa</string>
     <string name="inbox_listing_type_unread">Não lidas</string>
-    <string name="inbox_not_logged_message">Você não está logado.\nPor favor, entre na sua conta
-        via ícone de perfil abaixo, para ver as mensagens.
-    </string>
+    <string name="inbox_not_logged_message">Você não está logado.\nPor favor, entre na sua conta via ícone de perfil abaixo, para ver as mensagens.</string>
     <string name="inbox_section_mentions">Menções</string>
     <string name="inbox_section_messages">Mensagens</string>
     <string name="inbox_section_replies">Respostas</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Gerenciar as contas</string>
     <string name="manage_subscriptions_header_multicommunities">Múltiplas comunidades</string>
     <string name="manage_subscriptions_header_subscriptions">Subscripções</string>
-    <string name="message_empty_comments">Super silencioso aqui.\nVocê gostaria de ser
-        o primeiro para escrever um comentário?
-    </string>
+    <string name="message_empty_comments">Super silencioso aqui.\nVocê gostaria de ser o primeiro para escrever um comentário?</string>
     <string name="message_empty_list">Nada por aqui</string>
     <string name="message_error_loading_comments">Ocorreu um erro ao carregar comentários.</string>
     <string name="message_generic_error">Erro genérico</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Você não está logado.\nPor favor, entre na sua
-        conta para continuar.
-    </string>
+    <string name="profile_not_logged_message">Você não está logado.\nPor favor, entre na sua conta para continuar.</string>
     <string name="profile_section_comments">Comentários</string>
     <string name="profile_section_posts">Posts</string>
     <string name="profile_thousand_short">mil</string>
@@ -197,8 +191,7 @@
     <string name="settings_full_height_images">Imagens em tamanho real</string>
     <string name="settings_include_nsfw">Incluir conteúdo NSFW</string>
     <string name="settings_language">Idioma</string>
-    <string name="settings_navigation_bar_titles_visible">Mostrar nomes na barra de navegação
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Mostrar nomes na barra de navegação</string>
     <string name="settings_open_url_external">Abrir links em navegador externo</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Formato de posts</string>
@@ -220,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Esconder a barra de navegação ao deslizar</string>
     <string name="settings_zombie_mode_interval">Duração de intervalo no modo zumbi</string>
     <string name="settings_zombie_mode_scroll_amount">Grau de movimento no modo zumbi</string>
-    <string name="settings_mark_as_read_while_scrolling">Marcar posts como lidos ao deslizar
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marcar posts como lidos ao deslizar</string>
     <string name="action_quote">Citar</string>
     <string name="mod_action_allow">Permitir usuário novamente</string>
     <string name="mod_action_ban">Bloquear usuário</string>
@@ -239,10 +231,7 @@
     <string name="report_list_type_unresolved">Não resolvidos</string>
     <string name="report_action_resolve">Marcar como resolvido</string>
     <string name="report_action_unresolve">Marcar como não resolvido</string>
-    <string name="sidebar_not_logged_message">Bem-vindo ao Raccoon for Lemmy!\n\nNo modo anônimo
-        você pode mudar de instância tocando no triângulo (▼) acima.\n\nTambém pode entrar na
-        sua conta usando ícone de perfil na barra de navegação.\n\nCurte aí o Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Bem-vindo ao Raccoon for Lemmy!\n\nNo modo anônimo você pode mudar de instância tocando no triângulo (▼) acima.\n\nTambém pode entrar na sua conta usando ícone de perfil na barra de navegação.\n\nCurte aí o Lemmy!</string>
     <string name="settings_default_inbox_type">Padrão da caixa</string>
     <string name="mod_action_add_mod">Adicionar moderador</string>
     <string name="mod_action_remove_mod">Remover moderador</string>
@@ -343,4 +332,5 @@
     <string name="moderator_zone_title">Ferramentas para moderadores</string>
     <string name="moderator_zone_action_comments">Comentários moderados</string>
     <string name="moderator_zone_action_posts">Posts moderados</string>
+    <string name="message_auth_issue">Ocorreu um erro ao buscar dados do usuário. Tente atualizar a tela</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Não lidas</string>
     <string name="inbox_action_mark_read">Marcar como lido</string>
     <string name="inbox_action_mark_unread">Marcar como não lido</string>
-    <string name="inbox_not_logged_message">Atualmente, não tem sessão iniciada.\nAdicione uma conta
-        a partir do ecrã de perfil para ver as mensagens.
-    </string>
+    <string name="inbox_not_logged_message">Atualmente, não tem sessão iniciada.\nAdicione uma conta a partir do ecrã de perfil para ver as mensagens.</string>
     <string name="inbox_section_mentions">Menções</string>
     <string name="inbox_section_messages">Mensagens</string>
     <string name="inbox_section_replies">Respostas</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Gestionar as contas</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-comunidades</string>
     <string name="manage_subscriptions_header_subscriptions">Subscripções</string>
-    <string name="message_empty_comments">É demasiado silencioso lá.\nGostarias de ser aquele que
-        escreve o primeiro comentário?
-    </string>
+    <string name="message_empty_comments">É demasiado silencioso lá.\nGostarias de ser aquele que escreve o primeiro comentário?</string>
     <string name="message_empty_list">Nenhum item a apresentar</string>
     <string name="message_error_loading_comments">Ocorreu um erro ao carregar comentários.</string>
     <string name="message_generic_error">Erro genérico</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Atualmente, não tem sessão iniciada.\nAdicione uma
-        conta para continuar.
-    </string>
+    <string name="profile_not_logged_message">Atualmente, não tem sessão iniciada.\nAdicione uma conta para continuar.</string>
     <string name="profile_section_comments">Comentários</string>
     <string name="profile_section_posts">Publicações</string>
     <string name="profile_thousand_short">k</string>
@@ -197,8 +191,7 @@
     <string name="settings_full_height_images">Imagens de altura natural</string>
     <string name="settings_include_nsfw">Incluir conteúdo NSFW</string>
     <string name="settings_language">Idioma</string>
-    <string name="settings_navigation_bar_titles_visible">Mostrar títulos da barra de navegação
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Mostrar títulos da barra de navegação</string>
     <string name="settings_open_url_external">Abrir URLs em navegador externo</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Layout publicações</string>
@@ -220,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Ocultar a barra de navegação ao rolar</string>
     <string name="settings_zombie_mode_interval">Duração do intervalo do modo zumbi</string>
     <string name="settings_zombie_mode_scroll_amount">Zombie mode scroll amount</string>
-    <string name="settings_mark_as_read_while_scrolling">Marcar publicações como lidas durante ao
-        rolar
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marcar publicações como lidas durante ao rolar</string>
     <string name="action_quote">Citar</string>
     <string name="mod_action_allow">Permitir usuário novamente</string>
     <string name="mod_action_ban">Banir usuário</string>
@@ -240,11 +231,7 @@
     <string name="report_list_type_unresolved">Não resolvidos</string>
     <string name="report_action_resolve">Marcar como resolvido</string>
     <string name="report_action_unresolve">Marcar como não resolvido</string>
-    <string name="sidebar_not_logged_message">Bem-vindo ao Raccoon for Lemmy!\n\nNo modo anônimo,
-        use o botão suspenso (▼) acima para alterar a instância.\n\nVocê pode fazer login na sua
-        instância em
-        a qualquer momento na tela de perfil.\n\nAproveite o Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Bem-vindo ao Raccoon for Lemmy!\n\nNo modo anônimo, use o botão suspenso (▼) acima para alterar a instância.\n\nVocê pode fazer login na sua instância em a qualquer momento na tela de perfil.\n\nAproveite o Lemmy!</string>
     <string name="settings_default_inbox_type">Tipo de caixa padrão</string>
     <string name="mod_action_add_mod">Adicionar moderador</string>
     <string name="mod_action_remove_mod">Remover moderador</string>
@@ -345,4 +332,5 @@
     <string name="moderator_zone_title">Ferramentas para moderadores</string>
     <string name="moderator_zone_action_comments">Comentários moderados</string>
     <string name="moderator_zone_action_posts">Postagens moderadas</string>
+    <string name="message_auth_issue">Ocorreu um erro ao buscar dados do usuário. Tente atualizar a tela</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_unread">Necitite</string>
     <string name="inbox_action_mark_read">Marchează ca citit</string>
     <string name="inbox_action_mark_unread">Marchează ca necitit</string>
-    <string name="inbox_not_logged_message">Momentan nu sunteți autentificat.\nVă rugăm să adăugați
-        un cont din ecranul de profil pentru a vedea mesajele.
-    </string>
+    <string name="inbox_not_logged_message">Momentan nu sunteți autentificat.\nVă rugăm să adăugați un cont din ecranul de profil pentru a vedea mesajele.</string>
     <string name="inbox_section_mentions">Mențiuni</string>
     <string name="inbox_section_messages">Mesaje</string>
     <string name="inbox_section_replies">Răspunsuri</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Gestionează conturile</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-comunități</string>
     <string name="manage_subscriptions_header_subscriptions">Abonamente</string>
-    <string name="message_empty_comments">E prea tăcut aici.\nAi vrea să fii cel care scrie
-        primul comentariu?
-    </string>
+    <string name="message_empty_comments">E prea tăcut aici.\nAi vrea să fii cel care scrie primul comentariu?</string>
     <string name="message_empty_list">Niciun element de afișat</string>
-    <string name="message_error_loading_comments">A apărut o eroare la încărcarea comentariilor.
-    </string>
+    <string name="message_error_loading_comments">A apărut o eroare la încărcarea comentariilor.</string>
     <string name="message_generic_error">Eroare generică</string>
     <string name="message_image_loading_error">Eroare la încărcarea imaginii</string>
     <string name="message_invalid_field">Câmp nevalid</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Momentan nu sunteți autentificat.\nVă rugăm să
-        adăugați un cont pentru a continua.
-    </string>
+    <string name="profile_not_logged_message">Momentan nu sunteți autentificat.\nVă rugăm să adăugați un cont pentru a continua.</string>
     <string name="profile_section_comments">Comentării</string>
     <string name="profile_section_posts">Postări</string>
     <string name="profile_thousand_short">k</string>
@@ -198,8 +191,7 @@
     <string name="settings_full_height_images">Imagini pe toată înălțimea</string>
     <string name="settings_include_nsfw">Include conținuturile NSFW</string>
     <string name="settings_language">Limbă</string>
-    <string name="settings_navigation_bar_titles_visible">Afișează titlurile barei de navigare
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Afișează titlurile barei de navigare</string>
     <string name="settings_open_url_external">Deschide URL-urile în browser extern</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Aspect postărilor</string>
@@ -221,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Ascunde bara de navigare la derulare</string>
     <string name="settings_zombie_mode_interval">Durată intervalului modului zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Extensia de derulare modului zombie</string>
-    <string name="settings_mark_as_read_while_scrolling">Marchează postările ca citite la derulare
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Marchează postările ca citite la derulare</string>
     <string name="action_quote">Citează</string>
     <string name="mod_action_allow">Permite utilizatorul din nou</string>
     <string name="mod_action_ban">Interzice utilizatorul</string>
@@ -240,10 +231,7 @@
     <string name="report_list_type_unresolved">Nerezolvate</string>
     <string name="report_action_resolve">Marchează ca rezolvat</string>
     <string name="report_action_unresolve">Anulează marcare ca rezolvat</string>
-    <string name="sidebar_not_logged_message">Bine ați venit la Raccoon for Lemmy!\n\nÎn modul
-        anonim, folosiți butonul drop-down (▼) de mai sus pentru a schimba instanța.\n\nPuteți să
-        vă conectați la instanțele Dvs. oricând din ecranul Profil.\n\nBucurați-vă de Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Bine ați venit la Raccoon for Lemmy!\n\nÎn modul anonim, folosiți butonul drop-down (▼) de mai sus pentru a schimba instanța.\n\nPuteți să vă conectați la instanțele Dvs. oricând din ecranul Profil.\n\nBucurați-vă de Lemmy!</string>
     <string name="settings_default_inbox_type">Tipul implicit de inbox</string>
     <string name="mod_action_add_mod">Adaugă moderator</string>
     <string name="mod_action_remove_mod">Elimină moderator</string>
@@ -344,4 +332,5 @@
     <string name="moderator_zone_title">Instrumente pentru moderatori</string>
     <string name="moderator_zone_action_comments">Comentarii moderate</string>
     <string name="moderator_zone_action_posts">Postări moderate</string>
+    <string name="message_auth_issue">A apărut o eroare la preluarea datelor utilizatorului, încercearcă să reîmprospătezi ecranul</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -88,9 +88,7 @@
     <string name="inbox_listing_type_all">Все</string>
     <string name="inbox_listing_type_title">Тип папки «Входящие»</string>
     <string name="inbox_listing_type_unread">Не прочитано</string>
-    <string name="inbox_not_logged_message">Вы еще не вошли в систему.\nДобавьте аккаунт
-        на экране профиля, чтобы увидеть папку «Входящие».
-    </string>
+    <string name="inbox_not_logged_message">Вы еще не вошли в систему.\nДобавьте аккаунт на экране профиля, чтобы увидеть папку «Входящие».</string>
     <string name="inbox_section_mentions">Упоминания</string>
     <string name="inbox_section_messages">Сообщения</string>
     <string name="inbox_section_replies">Ответы</string>
@@ -106,12 +104,9 @@
     <string name="manage_accounts_title">Управление учётными записями</string>
     <string name="manage_subscriptions_header_multicommunities">Мульти-сообщества</string>
     <string name="manage_subscriptions_header_subscriptions">Подписки</string>
-    <string name="message_empty_comments">Там слишком тихо.\nХотели бы вы быть тем, кто
-        пишет первый комментарий?
-    </string>
+    <string name="message_empty_comments">Там слишком тихо.\nХотели бы вы быть тем, кто пишет первый комментарий?</string>
     <string name="message_empty_list">Нет элементов для отображения</string>
-    <string name="message_error_loading_comments">Произошла ошибка при загрузке комментариев.
-    </string>
+    <string name="message_error_loading_comments">Произошла ошибка при загрузке комментариев.</string>
     <string name="message_generic_error">Общая ошибка</string>
     <string name="message_image_loading_error">Ошибка загрузки изображения</string>
     <string name="message_invalid_field">Неправильное поле</string>
@@ -144,9 +139,7 @@
     <string name="profile_day_short">д</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">м</string>
-    <string name="profile_not_logged_message">Вы еще не вошли в систему.\nДобавьте
-        учетной записи, чтобы продолжить.
-    </string>
+    <string name="profile_not_logged_message">Вы еще не вошли в систему.\nДобавьте учетной записи, чтобы продолжить.</string>
     <string name="profile_section_comments">Комментарии</string>
     <string name="profile_section_posts">Записи</string>
     <string name="profile_thousand_short">k</string>
@@ -186,8 +179,7 @@
     <string name="settings_content_font_smaller">Очень маленький</string>
     <string name="settings_content_font_smallest">Double Extra Small</string>
     <string name="settings_custom_seed_color">Пользовательский цвет темы</string>
-    <string name="settings_default_comment_sort_type">Тип сортировки комментариев по умолчанию
-    </string>
+    <string name="settings_default_comment_sort_type">Тип сортировки комментариев по умолчанию</string>
     <string name="settings_default_listing_type">Тип ленты по умолчанию</string>
     <string name="settings_default_post_sort_type">Тип сортировки</string>
     <string name="settings_downvote_color">Цвет Downvote</string>
@@ -198,8 +190,7 @@
     <string name="settings_full_height_images">Изображения в полный рост</string>
     <string name="settings_include_nsfw">Включить содержимое NSFW</string>
     <string name="settings_language">Язык</string>
-    <string name="settings_navigation_bar_titles_visible">Показать заголовки панели навигации
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Показать заголовки панели навигации</string>
     <string name="settings_open_url_external">Открыть во внешнем браузере</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Шаблон записи</string>
@@ -221,9 +212,7 @@
     <string name="settings_hide_navigation_bar">Скрыть панель навигации при прокрутке</string>
     <string name="settings_zombie_mode_interval">Продолжительность интервала зомби-режима</string>
     <string name="settings_zombie_mode_scroll_amount">Количество прокруток в зомби-режиме</string>
-    <string name="settings_mark_as_read_while_scrolling">Отметить записи как прочитанные при
-        прокрутке
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Отметить записи как прочитанные при прокрутке</string>
     <string name="action_quote">Цитата</string>
     <string name="mod_action_allow">Разрешить пользователю снова</string>
     <string name="mod_action_ban">Забанить пользователя</string>
@@ -241,11 +230,7 @@
     <string name="report_list_type_unresolved">Не устранено</string>
     <string name="report_action_resolve">Решимость</string>
     <string name="report_action_unresolve">Разутвердить</string>
-    <string name="sidebar_not_logged_message">Добро пожаловать в Енот для Лемми!\n\nВ анонимном
-        режиме используйте кнопку раскрывающегося списка (▼) выше,
-        чтобы изменить экземпляр.\n\nВы можете войти в систему по адресу
-        в любое время на экране профиля.\n\nНаслаждайтесь Лемми!
-    </string>
+    <string name="sidebar_not_logged_message">Добро пожаловать в Енот для Лемми!\n\nВ анонимном режиме используйте кнопку раскрывающегося списка (▼) выше, чтобы изменить экземпляр.\n\nВы можете войти в систему по адресу в любое время на экране профиля.\n\nНаслаждайтесь Лемми!</string>
     <string name="settings_default_inbox_type">Тип почтового ящика по умолчанию</string>
     <string name="mod_action_add_mod">Добавить модератора</string>
     <string name="mod_action_remove_mod">Удалить модератора</string>
@@ -304,8 +289,7 @@
     <string name="settings_web_show_bot">Показать аккаунты ботов</string>
     <string name="settings_web_show_nsfw">Показать НФВ</string>
     <string name="settings_web_show_read">Показать прочитанные сообщения</string>
-    <string name="settings_web_email_notifications">Отправлять уведомления по электронной почте
-    </string>
+    <string name="settings_web_email_notifications">Отправлять уведомления по электронной почте</string>
     <string name="settings_manage_ban">Баны и фильтры</string>
     <string name="settings_manage_ban_action_unban">Снять бан</string>
     <string name="settings_manage_ban_section_instances">Экземпляры</string>
@@ -347,4 +331,5 @@
     <string name="moderator_zone_title">Инструменты для модераторов</string>
     <string name="moderator_zone_action_comments">Модерируемые комментарии</string>
     <string name="moderator_zone_action_posts">Модерируемые сообщения</string>
+    <string name="message_auth_issue">Произошла ошибка при получении пользовательских данных. Попробуйте обновить экран.</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Alla</string>
     <string name="inbox_listing_type_title">Inkorgstyp</string>
     <string name="inbox_listing_type_unread">Oläst</string>
-    <string name="inbox_not_logged_message">Du är för närvarande inte inloggad.\nLägg till ett konto
-        från profilskärmen för att se din inkorg.
-    </string>
+    <string name="inbox_not_logged_message">Du är för närvarande inte inloggad.\nLägg till ett konto från profilskärmen för att se din inkorg.</string>
     <string name="inbox_section_mentions">Mentions</string>
     <string name="inbox_section_messages">Meddelanden</string>
     <string name="inbox_section_replies">Svar</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Hantera konton</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-communities</string>
     <string name="manage_subscriptions_header_subscriptions">Prenumerationer</string>
-    <string name="message_empty_comments">Det är för tyst där.\nVill du vara den som
-        skriver den första kommentaren?
-    </string>
+    <string name="message_empty_comments">Det är för tyst där.\nVill du vara den som skriver den första kommentaren?</string>
     <string name="message_empty_list">Inga föremål att visa</string>
-    <string name="message_error_loading_comments">Ett fel uppstod när kommentarer skulle laddas.
-    </string>
+    <string name="message_error_loading_comments">Ett fel uppstod när kommentarer skulle laddas.</string>
     <string name="message_generic_error">Generiskt fel</string>
     <string name="message_image_loading_error">Fel vid inläsning av bild</string>
     <string name="message_invalid_field">Ogiltigt fält</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Du är för närvarande inte\n inloggad.Lägg till en
-        kontot för att fortsätta.
-    </string>
+    <string name="profile_not_logged_message">Du är för närvarande inte\n inloggad.Lägg till en kontot för att fortsätta.</string>
     <string name="profile_section_comments">Kommentarer</string>
     <string name="profile_section_posts">Inlägg</string>
     <string name="profile_thousand_short">k</string>
@@ -187,8 +180,7 @@
     <string name="settings_content_font_smaller">Extra liten</string>
     <string name="settings_content_font_smallest">Dubbel extra liten</string>
     <string name="settings_custom_seed_color">Anpassad tema färg</string>
-    <string name="settings_default_comment_sort_type">Standard sorteringstyp för kommentarer
-    </string>
+    <string name="settings_default_comment_sort_type">Standard sorteringstyp för kommentarer</string>
     <string name="settings_default_listing_type">Standardmatningstyp</string>
     <string name="settings_default_post_sort_type">Standard artikeltyp</string>
     <string name="settings_downvote_color">Nerröstningsfärg</string>
@@ -221,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Dölj navigeringsfältet när du rullar</string>
     <string name="settings_zombie_mode_interval">Zombielägesintervallets varaktighet</string>
     <string name="settings_zombie_mode_scroll_amount">Zombieläge rullningsmängd</string>
-    <string name="settings_mark_as_read_while_scrolling">Markera inlägg som lästa medan du rullar
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Markera inlägg som lästa medan du rullar</string>
     <string name="action_quote">Citat</string>
     <string name="mod_action_allow">Tillåta användaren igen</string>
     <string name="mod_action_ban">Stänga av användare</string>
@@ -240,10 +231,7 @@
     <string name="report_list_type_unresolved">Olöst</string>
     <string name="report_action_resolve">Lös</string>
     <string name="report_action_unresolve">Avlös</string>
-    <string name="sidebar_not_logged_message">Välkommen till Raccoon for Lemmy!\n\nI anonymt läge,
-        använd rullgardinsknappen (▼) ovan för att ändra instans.\n\nDu kan logga in på din
-        förekomst på när som helst från profilskärmen.\n\nNjut av Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Välkommen till Raccoon for Lemmy!\n\nI anonymt läge, använd rullgardinsknappen (▼) ovan för att ändra instans.\n\nDu kan logga in på din förekomst på när som helst från profilskärmen.\n\nNjut av Lemmy!</string>
     <string name="settings_default_inbox_type">Standardtyp av inkorg</string>
     <string name="mod_action_add_mod">Lägg till moderator</string>
     <string name="mod_action_remove_mod">Ta bort moderator</string>
@@ -344,4 +332,5 @@
     <string name="moderator_zone_title">Verktyg för moderatorer</string>
     <string name="moderator_zone_action_comments">Modererade kommentarer</string>
     <string name="moderator_zone_action_posts">Modererade inlägg</string>
+    <string name="message_auth_issue">Ett fel uppstod när användardata skulle hämtas, försök att uppdatera skärmen</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Všetky</string>
     <string name="inbox_listing_type_title">Typ doručenej pošty</string>
     <string name="inbox_listing_type_unread">Neprečítané</string>
-    <string name="inbox_not_logged_message">Momentálne nie ste prihlásený .Pridajte\nsi účet
-        z obrazovky profilu, aby ste videli svoju doručenú poštu.
-    </string>
+    <string name="inbox_not_logged_message">Momentálne nie ste prihlásený .Pridajte\nsi účet z obrazovky profilu, aby ste videli svoju doručenú poštu.</string>
     <string name="inbox_section_mentions">Zmienky o mne</string>
     <string name="inbox_section_messages">Správy</string>
     <string name="inbox_section_replies">Odpovede</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Správca účtov</string>
     <string name="manage_subscriptions_header_multicommunities">Multikomunity</string>
     <string name="manage_subscriptions_header_subscriptions">Predplatné</string>
-    <string name="message_empty_comments">Je tam príliš ticho.\nChceli by ste byť tým, kto
-        píše prvý komentár?
-    </string>
+    <string name="message_empty_comments">Je tam príliš ticho.\nChceli by ste byť tým, kto píše prvý komentár?</string>
     <string name="message_empty_list">Žiadne položky na zobrazenie</string>
-    <string name="message_error_loading_comments">Pri načítavaní komentárov sa vyskytla chyba.
-    </string>
+    <string name="message_error_loading_comments">Pri načítavaní komentárov sa vyskytla chyba.</string>
     <string name="message_generic_error">Všeobecná chyba</string>
     <string name="message_image_loading_error">Chyba načítania obrázka</string>
     <string name="message_invalid_field">Neplatné pole</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Momentálne nie ste prihlásený.\nAk chcete pokračovať,
-        pridajte účet.
-    </string>
+    <string name="profile_not_logged_message">Momentálne nie ste prihlásený.\nAk chcete pokračovať, pridajte účet.</string>
     <string name="profile_section_comments">Pripomienky</string>
     <string name="profile_section_posts">Príspevky</string>
     <string name="profile_thousand_short">k</string>
@@ -179,8 +172,7 @@
     <string name="settings_color_red">🦀 Kúzelný krab</string>
     <string name="settings_color_white">🐼 Hýbavý hazardný</string>
     <string name="settings_content_font_large">Veľký</string>
-    <string name="settings_content_font_larger">Aviators: Zvýraznené nehnuteľnosti box veľký
-    </string>
+    <string name="settings_content_font_larger">Aviators: Zvýraznené nehnuteľnosti box veľký</string>
     <string name="settings_content_font_largest">Dvojité extra veľké</string>
     <string name="settings_content_font_normal">V norme</string>
     <string name="settings_content_font_scale">Veľkosť textu príspevkov</string>
@@ -221,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Skryť navigačný panel pri rolovaní</string>
     <string name="settings_zombie_mode_interval">Trvanie intervalu režimu zombie</string>
     <string name="settings_zombie_mode_scroll_amount">Množstvo posúvania v zombie režime</string>
-    <string name="settings_mark_as_read_while_scrolling">Označte príspevky ako prečítané pri
-        rolovaní
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Označte príspevky ako prečítané pri rolovaní</string>
     <string name="action_quote">Citovať</string>
     <string name="mod_action_allow">Znova povoliť používateľovi</string>
     <string name="mod_action_ban">Zakázať používateľovi</string>
@@ -241,10 +231,7 @@
     <string name="report_list_type_unresolved">Nevyriešené</string>
     <string name="report_action_resolve">Vyriešiť</string>
     <string name="report_action_unresolve">Nevyriešiť</string>
-    <string name="sidebar_not_logged_message">Vitajte v Raccoon for Lemmy!\n\nV anonymnom režime
-        použite rozbaľovacie tlačidlo (▼) vyššie na zmenu inštancie.\n\nDo svojej intancie sa môžete
-        prihlásiť na kedykoľvek z obrazovky profilu.\n\nUžite si Lemmyho!
-    </string>
+    <string name="sidebar_not_logged_message">Vitajte v Raccoon for Lemmy!\n\nV anonymnom režime použite rozbaľovacie tlačidlo (▼) vyššie na zmenu inštancie.\n\nDo svojej intancie sa môžete prihlásiť na kedykoľvek z obrazovky profilu.\n\nUžite si Lemmyho!</string>
     <string name="settings_default_inbox_type">Predvolený typ doručenej pošty</string>
     <string name="mod_action_add_mod">Pridať moderátora</string>
     <string name="mod_action_remove_mod">Odstrániť moderátora</string>
@@ -345,4 +332,5 @@
     <string name="moderator_zone_title">Nástroje pre moderátorov</string>
     <string name="moderator_zone_action_comments">Moderované komentáre</string>
     <string name="moderator_zone_action_posts">Moderované príspevky</string>
+    <string name="message_auth_issue">Pri načítavaní údajov používateľa sa vyskytla chyba, skúste obnoviť obrazovku</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Vsi</string>
     <string name="inbox_listing_type_title">Vrsta mape »Prejeto«</string>
     <string name="inbox_listing_type_unread">Neprebrano</string>
-    <string name="inbox_not_logged_message">Trenutno niste prijavljeni.Dodajte račun\n na zaslonu
-        profila, da si ogledate svoj nabiralnik.
-    </string>
+    <string name="inbox_not_logged_message">Trenutno niste prijavljeni.Dodajte račun\n na zaslonu profila, da si ogledate svoj nabiralnik.</string>
     <string name="inbox_section_mentions">Opombe</string>
     <string name="inbox_section_messages">Sporočila</string>
     <string name="inbox_section_replies">Odgovori</string>
@@ -107,10 +105,9 @@
     <string name="manage_accounts_title">Upravljanje računov</string>
     <string name="manage_subscriptions_header_multicommunities">Več skupnosti</string>
     <string name="manage_subscriptions_header_subscriptions">Naročnine</string>
-    <string name="message_empty_comments">\n</string>
+    <string name="message_empty_comments">Tam je preveč tiho.\nBi želeli biti tisti, ki bo napisal prvi komentar?</string>
     <string name="message_empty_list">Ni elementov za prikaz</string>
-    <string name="message_error_loading_comments">Pri nalaganju komentarjev je prišlo do napake.
-    </string>
+    <string name="message_error_loading_comments">Pri nalaganju komentarjev je prišlo do napake.</string>
     <string name="message_generic_error">Splošna napaka</string>
     <string name="message_image_loading_error">Napaka pri nalaganju slike</string>
     <string name="message_invalid_field">Napačno polje</string>
@@ -143,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Trenutno niste prijavljeni.\nDodajte račun za
-        nadaljevanje.
-    </string>
+    <string name="profile_not_logged_message">Trenutno niste prijavljeni.\nDodajte račun za nadaljevanje.</string>
     <string name="profile_section_comments">Komentarji</string>
     <string name="profile_section_posts">Objave</string>
     <string name="profile_thousand_short">k</string>
@@ -185,8 +180,7 @@
     <string name="settings_content_font_smaller">Zelo majhen</string>
     <string name="settings_content_font_smallest">Dvojno, zelo majhno</string>
     <string name="settings_custom_seed_color">Barva teme po meri</string>
-    <string name="settings_default_comment_sort_type">Privzeta vrsta razvrščanja komentarjev
-    </string>
+    <string name="settings_default_comment_sort_type">Privzeta vrsta razvrščanja komentarjev</string>
     <string name="settings_default_listing_type">Privzeta vrsta vira</string>
     <string name="settings_default_post_sort_type">Privzeta vrsta razvrščanja prispevka</string>
     <string name="settings_downvote_color">Barva spodnjega glasu</string>
@@ -197,8 +191,7 @@
     <string name="settings_full_height_images">Slike polne višine</string>
     <string name="settings_include_nsfw">Vključite vsebino NSFW</string>
     <string name="settings_language">Jezik</string>
-    <string name="settings_navigation_bar_titles_visible">Prikaži naslove navigacijske vrstice
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Prikaži naslove navigacijske vrstice</string>
     <string name="settings_open_url_external">Odprite v zunanjem brskalniku</string>
     <string name="settings_points_short">tč</string>
     <string name="settings_post_layout">Postavitev</string>
@@ -220,8 +213,7 @@
     <string name="settings_hide_navigation_bar">Med pomikanjem skrij navigacijsko vrstico</string>
     <string name="settings_zombie_mode_interval">Trajanje intervala v zombi načinu</string>
     <string name="settings_zombie_mode_scroll_amount">Količina drsenja v zombi načinu</string>
-    <string name="settings_mark_as_read_while_scrolling">Med pomikanjem označi objave kot prebrane
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Med pomikanjem označi objave kot prebrane</string>
     <string name="action_quote">Kvota</string>
     <string name="mod_action_allow">Znova dovoli uporabniku</string>
     <string name="mod_action_ban">Izključi uporabnika</string>
@@ -239,10 +231,7 @@
     <string name="report_list_type_unresolved">Nerazrešeno</string>
     <string name="report_action_resolve">Reši</string>
     <string name="report_action_unresolve">Prekliči razrešitev</string>
-    <string name="sidebar_not_logged_message">Dobrodošli v Raccoon za Lemmyja!\n\nV anonimnem
-        načinu, uporabite spustni gumb (▼) zgoraj, da spremenite instanco.\n\nV svojo instanco se
-        lahko prijavite na kadar koli na zaslonu profila.\n\nUživajte v Lemmyju!
-    </string>
+    <string name="sidebar_not_logged_message">Dobrodošli v Raccoon za Lemmyja!\n\nV anonimnem načinu, uporabite spustni gumb (▼) zgoraj, da spremenite instanco.\n\nV svojo instanco se lahko prijavite na kadar koli na zaslonu profila.\n\nUživajte v Lemmyju!</string>
     <string name="settings_default_inbox_type">privzeta vrsta mape Prejeto</string>
     <string name="mod_action_add_mod">Dodaj moderatorja</string>
     <string name="mod_action_remove_mod">Odstrani moderatorja</string>
@@ -343,4 +332,5 @@
     <string name="moderator_zone_title">Orodja za moderatorje</string>
     <string name="moderator_zone_action_comments">Moderirani komentarji</string>
     <string name="moderator_zone_action_posts">Moderirane objave</string>
+    <string name="message_auth_issue">Pri pridobivanju uporabniških podatkov je prišlo do napake, poskusite osvežiti zaslon</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Të gjithë</string>
     <string name="inbox_listing_type_title">Lloji i kutisë së mesazheve</string>
     <string name="inbox_listing_type_unread">Të palexuara</string>
-    <string name="inbox_not_logged_message">Aktualisht nuk ke hyrë.\nShto një llogari nga ekrani i
-        profilit për të parë kutinë tuaj të mesazheve.
-    </string>
+    <string name="inbox_not_logged_message">Aktualisht nuk ke hyrë.\nShto një llogari nga ekrani i profilit për të parë kutinë tuaj të mesazheve.</string>
     <string name="inbox_section_mentions">Shënime</string>
     <string name="inbox_section_messages">Mesazhe</string>
     <string name="inbox_section_replies">Përgjigjet</string>
@@ -107,12 +105,9 @@
     <string name="manage_accounts_title">Menaxhoni llogaritë</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-komunitete</string>
     <string name="manage_subscriptions_header_subscriptions">Abonimet</string>
-    <string name="message_empty_comments">Është shumë e heshtur atje.\nDo të doje të ishe ti ai që
-        shkruan komentin e parë?
-    </string>
+    <string name="message_empty_comments">Është shumë e heshtur atje.\nDo të doje të ishe ti ai që shkruan komentin e parë?</string>
     <string name="message_empty_list">Nuk ka artikuj për t \'u shfaqur</string>
-    <string name="message_error_loading_comments">Ndodhi një gabim gjatë ngarkimit të komenteve.
-    </string>
+    <string name="message_error_loading_comments">Ndodhi një gabim gjatë ngarkimit të komenteve.</string>
     <string name="message_generic_error">Gabim i përgjithshëm</string>
     <string name="message_image_loading_error">Gabim në ngarkimin e imazhit</string>
     <string name="message_invalid_field">Fushë e pavlefshme</string>
@@ -145,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Aktualisht nuk ke hyrë.\nShto një llogaria për të
-        vazhduar.
-    </string>
+    <string name="profile_not_logged_message">Aktualisht nuk ke hyrë.\nShto një llogaria për të vazhduar.</string>
     <string name="profile_section_comments">Komente</string>
     <string name="profile_section_posts">Postimet</string>
     <string name="profile_thousand_short">k</string>
@@ -187,11 +180,9 @@
     <string name="settings_content_font_smaller">Shumë e vogël</string>
     <string name="settings_content_font_smallest">Dyfish më i vogël</string>
     <string name="settings_custom_seed_color">Ngjyra e personalizuar e temës</string>
-    <string name="settings_default_comment_sort_type">Lloji standard i renditjes së komenteve
-    </string>
+    <string name="settings_default_comment_sort_type">Lloji standard i renditjes së komenteve</string>
     <string name="settings_default_listing_type">Lloji standard i furnizimit</string>
-    <string name="settings_default_post_sort_type">Lloji i paracaktuar i renditjes së postimeve
-    </string>
+    <string name="settings_default_post_sort_type">Lloji i paracaktuar i renditjes së postimeve</string>
     <string name="settings_downvote_color">Ngjyra e votimit të poshtëm</string>
     <string name="settings_dynamic_colors">Përdor ngjyra dinamike</string>
     <string name="settings_enable_crash_report">Aktivizo raportimin e aksidenteve</string>
@@ -200,8 +191,7 @@
     <string name="settings_full_height_images">Imazhe me lartësi të plotë</string>
     <string name="settings_include_nsfw">Përfshi përmbajtjen e NSFW</string>
     <string name="settings_language">Gjuha</string>
-    <string name="settings_navigation_bar_titles_visible">Shfaq titujt e shiritit të navigimit
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Shfaq titujt e shiritit të navigimit</string>
     <string name="settings_open_url_external">Hap URL-të në shfletuesin e jashtëm</string>
     <string name="settings_points_short">length unit</string>
     <string name="settings_post_layout">Planimetria e postimit</string>
@@ -221,13 +211,9 @@
     <string name="settings_ui_theme">Tema e ndërfaqes së përdoruesit</string>
     <string name="settings_upvote_color">Ngjyra e upvote</string>
     <string name="settings_hide_navigation_bar">Fshih shiritin e navigimit gjatë lëvizjes</string>
-    <string name="settings_zombie_mode_interval">Kohëzgjatja e intervalit të modalitetit Zombie
-    </string>
-    <string name="settings_zombie_mode_scroll_amount">Shuma e lëvizjes në modalitetin Zombie
-    </string>
-    <string name="settings_mark_as_read_while_scrolling">Shëno postimet si të lexuara gjatë
-        lëvizjes
-    </string>
+    <string name="settings_zombie_mode_interval">Kohëzgjatja e intervalit të modalitetit Zombie</string>
+    <string name="settings_zombie_mode_scroll_amount">Shuma e lëvizjes në modalitetin Zombie</string>
+    <string name="settings_mark_as_read_while_scrolling">Shëno postimet si të lexuara gjatë lëvizjes</string>
     <string name="action_quote">Citim</string>
     <string name="mod_action_allow">Lejo përdoruesin përsëri</string>
     <string name="mod_action_ban">Ndalo përdoruesin</string>
@@ -245,10 +231,7 @@
     <string name="report_list_type_unresolved">I pazgjidhur</string>
     <string name="report_action_resolve">Zgjidh</string>
     <string name="report_action_unresolve">Zgjidhe</string>
-    <string name="sidebar_not_logged_message">Mirë se erdhe në Rakun për Lemmin!\n\nNë modalitetin
-        anonim, përdorni butonin zbritës (▼) më sipër për të ndryshuar instancën.\n\nMund të hyni në
-        intencën tuaj në çdo kohë nga ekrani i Profilit.\n\nGëzohu Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Mirë se erdhe në Rakun për Lemmin!\n\nNë modalitetin anonim, përdorni butonin zbritës (▼) më sipër për të ndryshuar instancën.\n\nMund të hyni në intencën tuaj në çdo kohë nga ekrani i Profilit.\n\nGëzohu Lemmy!</string>
     <string name="settings_default_inbox_type">Lloji i paracaktuar i kutisë së mesazheve</string>
     <string name="mod_action_add_mod">Shtoni moderator</string>
     <string name="mod_action_remove_mod">Hiqni moderatorin</string>
@@ -349,4 +332,5 @@
     <string name="moderator_zone_title">Mjete për moderatorët</string>
     <string name="moderator_zone_action_comments">Komentet e moderuara</string>
     <string name="moderator_zone_action_posts">Postimet e moderuara</string>
+    <string name="message_auth_issue">Ndodhi një gabim gjatë marrjes së të dhënave të përdoruesit, provoni të rifreskoni ekranin</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">ale</string>
     <string name="inbox_listing_type_title">nasin lukin</string>
     <string name="inbox_listing_type_unread">lukin ala</string>
-    <string name="inbox_not_logged_message">ilo li sona ala e ni: sina seme.\no insa lon lipu \&quot;sona
-        jan\&quot; tawa ni: sina lukin e toki sina.
-    </string>
+    <string name="inbox_not_logged_message">ilo li sona ala e ni: sina seme.\no insa lon lipu \&quot;sona jan\&quot; tawa ni: sina lukin e toki sina.</string>
     <string name="inbox_section_mentions">nimi</string>
     <string name="inbox_section_messages">toki</string>
     <string name="inbox_section_replies">toki lili</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">o lawa e sona jan</string>
     <string name="manage_subscriptions_header_multicommunities">mute-kulupu</string>
     <string name="manage_subscriptions_header_subscriptions">sina wile lukin e</string>
-    <string name="message_empty_comments">kalama ala li lon ni.\nsina wile ala wile sitelen e toki
-        lili nanpa wan?
-    </string>
+    <string name="message_empty_comments">kalama ala li lon ni.\nsina wile ala wile sitelen e toki lili nanpa wan?</string>
     <string name="message_empty_list">Ala li lon ni</string>
     <string name="message_error_loading_comments">kama jo e toki lili la, pakala li lon</string>
     <string name="message_generic_error">pakala pi sona ala li lon</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">ts</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">tm</string>
-    <string name="profile_not_logged_message">ilo li sona ala e ni: sina seme.\no insa tawa
-        sinpin.
-    </string>
+    <string name="profile_not_logged_message">ilo li sona ala e ni: sina seme.\no insa tawa sinpin.</string>
     <string name="profile_section_comments">toki lili</string>
     <string name="profile_section_posts">lipu</string>
     <string name="profile_thousand_short">k</string>
@@ -219,8 +213,7 @@
     <string name="settings_hide_navigation_bar">tawa la, o lukin ala e linja anpa</string>
     <string name="settings_zombie_mode_interval">tenpo nasin pi jan moli</string>
     <string name="settings_zombie_mode_scroll_amount">tawa nasin pi jan moli</string>
-    <string name="settings_mark_as_read_while_scrolling">tawa la, o sitelen e lipu sama lukin
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">tawa la, o sitelen e lipu sama lukin</string>
     <string name="action_quote">o toki lon tenpo nanpa tu</string>
     <string name="mod_action_allow">o insa e jan</string>
     <string name="mod_action_ban">o insa ala e jan</string>
@@ -238,10 +231,7 @@
     <string name="report_list_type_unresolved">wile weka</string>
     <string name="report_action_resolve">o weka</string>
     <string name="report_action_unresolve">o weka ala</string>
-    <string name="sidebar_not_logged_message">o kama pona lon ilo Rakun tawa ma Lemi!\n\nsina tawa
-        insa ala la, o kepeken e ilo (▼) tawa ante e ilo nanpa.\n\nwile la, tenpo ale la, sina ken
-        insa e ilo nanpa sina lon lipo \&quot;sona jan\&quot;.\n\no musi lon ma Lemi!
-    </string>
+    <string name="sidebar_not_logged_message">o kama pona lon ilo Rakun tawa ma Lemi!\n\nsina tawa insa ala la, o kepeken e ilo (▼) tawa ante e ilo nanpa.\n\nwile la, tenpo ale la, sina ken insa e ilo nanpa sina lon lipo \&quot;sona jan\&quot;.\n\no musi lon ma Lemi!</string>
     <string name="settings_default_inbox_type">nasin pi poki toki</string>
     <string name="mod_action_add_mod">o sin e jan lawa</string>
     <string name="mod_action_remove_mod">o sin ala e jan lawa</string>
@@ -342,4 +332,5 @@
     <string name="moderator_zone_title">ilo tawa jan lawa</string>
     <string name="moderator_zone_action_comments">toki lili pi kulupu lawa</string>
     <string name="moderator_zone_action_posts">lipu pi kulupu lawa</string>
+    <string name="message_auth_issue">kama sona ijo la, pakala wan li lon. o lukin open e lipu ni lon tenpo nanpa tu</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">Hepsi</string>
     <string name="inbox_listing_type_title">Gelen kutusu türü</string>
     <string name="inbox_listing_type_unread">Okunmadı</string>
-    <string name="inbox_not_logged_message">Şu anda giriş yapmadınız.Lütfen bir\n hesap ekleyin
-        gelen kutunuzu görmek için profil ekranından.
-    </string>
+    <string name="inbox_not_logged_message">Şu anda giriş yapmadınız.Lütfen bir\n hesap ekleyin gelen kutunuzu görmek için profil ekranından.</string>
     <string name="inbox_section_mentions">Bahsetmeler</string>
     <string name="inbox_section_messages">Mesajlar</string>
     <string name="inbox_section_replies">Cevaplar</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Hesapları yönet</string>
     <string name="manage_subscriptions_header_multicommunities">Çoklu topluluklar</string>
     <string name="manage_subscriptions_header_subscriptions">Abonelikler</string>
-    <string name="message_empty_comments">Orası çok sessiz.Bunu yapan kişi olmak\n ister miydiniz?
-        ilk yorumu yazar?
-    </string>
+    <string name="message_empty_comments">Orası çok sessiz.\nİlk yorumu yazan kişi olmak ister misiniz?</string>
     <string name="message_empty_list">Görüntülenecek hiçbir öğe yok</string>
     <string name="message_error_loading_comments">Yorumlar yüklenirken bir hata oluştu.</string>
     <string name="message_generic_error">Oluşan Hatalar</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">Şu anda giriş yapmadınız.Lütfen bir\n ekleyin
-        devam etmek için hesap.
-    </string>
+    <string name="profile_not_logged_message">Şu anda giriş yapmadınız.Lütfen bir\n ekleyin devam etmek için hesap.</string>
     <string name="profile_section_comments">Yorumlar</string>
     <string name="profile_section_posts">Postlar</string>
     <string name="profile_thousand_short">k</string>
@@ -197,8 +191,7 @@
     <string name="settings_full_height_images">Tam yükseklikte görüntüler</string>
     <string name="settings_include_nsfw">NSFW içeriklerini dahil et</string>
     <string name="settings_language">Dil</string>
-    <string name="settings_navigation_bar_titles_visible">Gezinme çubuğu başlıklarını göster
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Gezinme çubuğu başlıklarını göster</string>
     <string name="settings_open_url_external">Harici Tarayıcıda Aç</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Yazı Düzeni</string>
@@ -220,9 +213,7 @@
     <string name="settings_hide_navigation_bar">Kaydırma sırasında gezinme çubuğunu gizle</string>
     <string name="settings_zombie_mode_interval">Zombi modu aralık süresi</string>
     <string name="settings_zombie_mode_scroll_amount">Zombi modu kaydırma miktarı</string>
-    <string name="settings_mark_as_read_while_scrolling">Kaydırırken gönderileri okundu olarak
-        işaretle
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Kaydırırken gönderileri okundu olarak işaretle</string>
     <string name="action_quote">Fiyat Teklifi</string>
     <string name="mod_action_allow">Kullanıcıya tekrar izin ver</string>
     <string name="mod_action_ban">Kullanıcıyı yasaklama</string>
@@ -240,12 +231,7 @@
     <string name="report_list_type_unresolved">Çözümlenmemiş</string>
     <string name="report_action_resolve">Kararlılık</string>
     <string name="report_action_unresolve">Çöz</string>
-    <string name="sidebar_not_logged_message">Raccon for Lemmy\'ye hoş geldiniz!\n\nAnonim olarak
-        modunda, örneği değiştirmek için yukarıdaki açılır düğmeyi (▼) kullanın.\n\nGiriş
-        yapabilirsiniz
-        Profil ekranından istediğiniz zaman örneğinize ulaşabilirsiniz.\n\nLemmy\'nin tadını
-        çıkarın!
-    </string>
+    <string name="sidebar_not_logged_message">Raccon for Lemmy\'ye hoş geldiniz!\n\nAnonim olarak modunda, örneği değiştirmek için yukarıdaki açılır düğmeyi (▼) kullanın.\n\nGiriş yapabilirsiniz Profil ekranından istediğiniz zaman örneğinize ulaşabilirsiniz.\n\nLemmy\'nin tadını çıkarın!</string>
     <string name="settings_default_inbox_type">Varsayılan gelen kutusu türü</string>
     <string name="mod_action_add_mod">Moderatör ekleyin</string>
     <string name="mod_action_remove_mod">Moderatörü kaldır</string>
@@ -346,4 +332,5 @@
     <string name="moderator_zone_title">Moderatörler için araçlar</string>
     <string name="moderator_zone_action_comments">Denetlenen yorumlar</string>
     <string name="moderator_zone_action_posts">Denetlenen gönderiler</string>
+    <string name="message_auth_issue">Kullanıcı verileri alınırken bir hata oluştu, ekranı yenilemeyi deneyin</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -88,9 +88,7 @@
     <string name="inbox_listing_type_all">Усі</string>
     <string name="inbox_listing_type_title">Тип папки «Вхідні»</string>
     <string name="inbox_listing_type_unread">Непрочитане</string>
-    <string name="inbox_not_logged_message">Наразі ви не ввійшли в систему.\nДодайте обліковий запис
-        на екрані профілю, щоб переглянути папку \"Вхідні\".
-    </string>
+    <string name="inbox_not_logged_message">Наразі ви не ввійшли в систему.\nДодайте обліковий запис на екрані профілю, щоб переглянути папку \"Вхідні\".</string>
     <string name="inbox_section_mentions">Згадування</string>
     <string name="inbox_section_messages">Повідомлення</string>
     <string name="inbox_section_replies">Відповіді</string>
@@ -106,12 +104,9 @@
     <string name="manage_accounts_title">Керування обліковими записами</string>
     <string name="manage_subscriptions_header_multicommunities">Мультиспільноти</string>
     <string name="manage_subscriptions_header_subscriptions">Підписки</string>
-    <string name="message_empty_comments">Там занадто тихо.\nЧи хотіли б ви бути тим, хто
-        пише перший коментар?
-    </string>
+    <string name="message_empty_comments">Там занадто тихо.\nЧи хотіли б ви бути тим, хто пише перший коментар?</string>
     <string name="message_empty_list">елементів для відображення</string>
-    <string name="message_error_loading_comments">Сталася помилка під час завантаження коментарів.
-    </string>
+    <string name="message_error_loading_comments">Сталася помилка під час завантаження коментарів.</string>
     <string name="message_generic_error">Загальна помилка шини</string>
     <string name="message_image_loading_error">Помилка завантаження зображення</string>
     <string name="message_invalid_field">Недійсне поле</string>
@@ -144,9 +139,7 @@
     <string name="profile_day_short">д</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">м</string>
-    <string name="profile_not_logged_message">Наразі ви не ввійшли в систему\n.Додайте облікового
-        запису, щоб продовжити.
-    </string>
+    <string name="profile_not_logged_message">Наразі ви не ввійшли в систему\n.Додайте облікового запису, щоб продовжити.</string>
     <string name="profile_section_comments">Коментарі</string>
     <string name="profile_section_posts">Записи</string>
     <string name="profile_thousand_short">k</string>
@@ -186,8 +179,7 @@
     <string name="settings_content_font_smaller">Дуже малий</string>
     <string name="settings_content_font_smallest">Подвійний екстра малий</string>
     <string name="settings_custom_seed_color">Призначені Колір теми</string>
-    <string name="settings_default_comment_sort_type">Тип сортування коментарів за замовчуванням
-    </string>
+    <string name="settings_default_comment_sort_type">Тип сортування коментарів за замовчуванням</string>
     <string name="settings_default_listing_type">Тип подачі за замовчуванням</string>
     <string name="settings_default_post_sort_type">Порядок сортування за замовчуванням</string>
     <string name="settings_downvote_color">Колір Downvote</string>
@@ -198,8 +190,7 @@
     <string name="settings_full_height_images">Зображення в повний зріст</string>
     <string name="settings_include_nsfw">Включити вміст NSFW</string>
     <string name="settings_language">Мова</string>
-    <string name="settings_navigation_bar_titles_visible">Показати заголовки панелі навігації
-    </string>
+    <string name="settings_navigation_bar_titles_visible">Показати заголовки панелі навігації</string>
     <string name="settings_open_url_external">Відкрити у зовнішньому навігаторі</string>
     <string name="settings_points_short">pt</string>
     <string name="settings_post_layout">Макет дописів</string>
@@ -221,9 +212,7 @@
     <string name="settings_hide_navigation_bar">Сховати панель навігації під час прокрутки</string>
     <string name="settings_zombie_mode_interval">Тривалість інтервалу режиму зомбі</string>
     <string name="settings_zombie_mode_scroll_amount">Кількість прокрутки в зомбі-режимі</string>
-    <string name="settings_mark_as_read_while_scrolling">Позначити дописи як прочитані під час
-        прокрутки
-    </string>
+    <string name="settings_mark_as_read_while_scrolling">Позначити дописи як прочитані під час прокрутки</string>
     <string name="action_quote">Цитата</string>
     <string name="mod_action_allow">Дозволити користувачеві знову</string>
     <string name="mod_action_ban">Бан Користувач</string>
@@ -241,10 +230,7 @@
     <string name="report_list_type_unresolved">Невирішено</string>
     <string name="report_action_resolve">Вирішено</string>
     <string name="report_action_unresolve">Невирішено</string>
-    <string name="sidebar_not_logged_message">Ласкаво просимо до Raccoon for Lemmy!\n\nУ анонімному
-        режимі скористайтеся випадаючою кнопкою (▼) вище, щоб змінити екземпляр\n\n.Ви можете увійти
-        в систему за адресою будь-коли на екрані профілю.\n\nНасолоджуйтесь Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Ласкаво просимо до Raccoon for Lemmy!\n\nУ анонімному режимі скористайтеся випадаючою кнопкою (▼) вище, щоб змінити екземпляр\n\n.Ви можете увійти в систему за адресою будь-коли на екрані профілю.\n\nНасолоджуйтесь Lemmy!</string>
     <string name="settings_default_inbox_type">Тип папки «Вхідні» за замовчуванням</string>
     <string name="mod_action_add_mod">Додати модератора</string>
     <string name="mod_action_remove_mod">Видалити модератора</string>
@@ -308,8 +294,7 @@
     <string name="settings_manage_ban_action_unban">Зняти бан</string>
     <string name="settings_manage_ban_section_instances">Примірники</string>
     <string name="settings_edge_to_edge">Вміст від краю до краю</string>
-    <string name="settings_post_body_max_lines">Максимальна кількість рядків для тіла повідомлення
-    </string>
+    <string name="settings_post_body_max_lines">Максимальна кількість рядків для тіла повідомлення</string>
     <string name="settings_post_body_max_lines_unlimited">Необмежений</string>
     <string name="message_content_removed">(цей вміст було видалено)</string>
     <string name="post_list_load_more_posts">Завантажити більше дописів</string>
@@ -346,4 +331,5 @@
     <string name="moderator_zone_title">Інструменти для модераторів</string>
     <string name="moderator_zone_action_comments">Модеровані коментарі</string>
     <string name="moderator_zone_action_posts">Модеровані дописи</string>
+    <string name="message_auth_issue">Під час отримання даних користувача сталася помилка. Спробуйте оновити екран</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -89,9 +89,7 @@
     <string name="inbox_listing_type_all">All</string>
     <string name="inbox_listing_type_title">Inbox type</string>
     <string name="inbox_listing_type_unread">Unread</string>
-    <string name="inbox_not_logged_message">You are currently not logged in.\nPlease add an account
-        from the profile screen to see your inbox.
-    </string>
+    <string name="inbox_not_logged_message">You are currently not logged in.\nPlease add an account from the profile screen to see your inbox.</string>
     <string name="inbox_section_mentions">Mentions</string>
     <string name="inbox_section_messages">Messages</string>
     <string name="inbox_section_replies">Replies</string>
@@ -107,9 +105,7 @@
     <string name="manage_accounts_title">Manage accounts</string>
     <string name="manage_subscriptions_header_multicommunities">Multi-communities</string>
     <string name="manage_subscriptions_header_subscriptions">Subscriptions</string>
-    <string name="message_empty_comments">It\'s too silent there.\nWould you like to be the one who
-        writes the first comment?
-    </string>
+    <string name="message_empty_comments">It\'s too silent there.\nWould you like to be the one who writes the first comment?</string>
     <string name="message_empty_list">No items to display</string>
     <string name="message_error_loading_comments">An error has occurred loading comments.</string>
     <string name="message_generic_error">Generic error</string>
@@ -144,9 +140,7 @@
     <string name="profile_day_short">d</string>
     <string name="profile_million_short">m</string>
     <string name="profile_month_short">m</string>
-    <string name="profile_not_logged_message">You are currently not logged in.\nPlease add an
-        account to continue.
-    </string>
+    <string name="profile_not_logged_message">You are currently not logged in.\nPlease add an account to continue.</string>
     <string name="profile_section_comments">Comments</string>
     <string name="profile_section_posts">Posts</string>
     <string name="profile_thousand_short">k</string>
@@ -237,10 +231,7 @@
     <string name="report_list_type_unresolved">Unresolved</string>
     <string name="report_action_resolve">Resolve</string>
     <string name="report_action_unresolve">Unresolve</string>
-    <string name="sidebar_not_logged_message">Welcome to Raccoon for Lemmy!\n\nIn anonymous mode,
-        use the drop down button (▼) above to change instance.\n\nYou can log in to your intance at
-        any time from the Profile screen.\n\nEnjoy Lemmy!
-    </string>
+    <string name="sidebar_not_logged_message">Welcome to Raccoon for Lemmy!\n\nIn anonymous mode, use the drop down button (▼) above to change instance.\n\nYou can log in to your intance at any time from the Profile screen.\n\nEnjoy Lemmy!</string>
     <string name="settings_default_inbox_type">Default inbox type</string>
     <string name="mod_action_add_mod">Add moderator</string>
     <string name="mod_action_remove_mod">Remove moderator</string>
@@ -341,4 +332,5 @@
     <string name="moderator_zone_title">Moderation tools</string>
     <string name="moderator_zone_action_comments">Moderated comments</string>
     <string name="moderator_zone_action_posts">Moderated posts</string>
+    <string name="message_auth_issue">An error occurred while fetching user data, try refreshing the screen</string>
 </resources>

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
@@ -35,7 +35,7 @@ interface ProfileLoggedMviModel :
         val section: ProfileLoggedSection = ProfileLoggedSection.Posts,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
-        val initial: Boolean = false,
+        val initial: Boolean = true,
         val canFetchMore: Boolean = true,
         val posts: List<PostModel> = emptyList(),
         val comments: List<CommentModel> = emptyList(),

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
@@ -193,7 +193,7 @@ class ProfileLoggedViewModel(
                     updateState {
                         it.copy(
                             user = user,
-                            moderatedCommunityIds = moderatedCommunities.map { it.id },
+                            moderatedCommunityIds = moderatedCommunities.map { c ->  c.id },
                         )
                     }
                 }
@@ -211,6 +211,9 @@ class ProfileLoggedViewModel(
             )
         }
         loadNextPage()
+        if (identityRepository.isLogged.value == null) {
+            identityRepository.refreshLoggedState()
+        }
     }
 
     private fun changeSection(section: ProfileLoggedSection) {
@@ -285,6 +288,7 @@ class ProfileLoggedViewModel(
                         loading = false,
                         canFetchMore = itemList?.isEmpty() != true,
                         refreshing = false,
+                        initial = false,
                     )
                 }
                 if (!itemList.isNullOrEmpty()) {


### PR DESCRIPTION
This PR adds a message to better handle the case when the profile can not load due to a connectivity issue.