### PR TITLE
feat: specify user ban duration and data removal

### DIFF
--- a/unit/ban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/ban/BanUserMviModel.kt
+++ b/unit/ban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/ban/BanUserMviModel.kt
@@ -12,10 +12,17 @@ interface BanUserMviModel :
 
     sealed interface Intent {
         data class SetText(val value: String) : Intent
+        data class ChangePermanent(val value: Boolean) : Intent
+        data class ChangeRemoveData(val value: Boolean) : Intent
+        data class ChangeDays(val value: Int) : Intent
         data object Submit : Intent
     }
 
     data class UiState(
+        val permanent: Boolean = true,
+        val days: Int? = null,
+        val targetBanValue: Boolean = false,
+        val removeData: Boolean = false,
         val text: String = "",
         val textError: ValidationError? = null,
         val loading: Boolean = false,

--- a/unit/ban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/ban/BanUserViewModel.kt
+++ b/unit/ban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/ban/BanUserViewModel.kt
@@ -23,23 +23,31 @@ class BanUserViewModel(
         initialState = BanUserMviModel.UiState(),
     ) {
 
+    override fun onStarted() {
+        super.onStarted()
+        updateState {
+            it.copy(targetBanValue = newValue)
+        }
+    }
+
     override fun reduce(intent: BanUserMviModel.Intent) {
         when (intent) {
-            is BanUserMviModel.Intent.SetText -> {
-                updateState {
-                    it.copy(text = intent.value)
-                }
-            }
-
+            is BanUserMviModel.Intent.ChangeDays -> updateState { it.copy(days = intent.value) }
+            is BanUserMviModel.Intent.ChangePermanent -> updateState { it.copy(permanent = intent.value) }
+            is BanUserMviModel.Intent.ChangeRemoveData -> updateState { it.copy(removeData = intent.value) }
+            is BanUserMviModel.Intent.SetText -> updateState { it.copy(text = intent.value) }
             BanUserMviModel.Intent.Submit -> submit()
         }
     }
 
     private fun submit() {
-        if (uiState.value.loading) {
+        val currentState = uiState.value
+        if (currentState.loading) {
             return
         }
-        val text = uiState.value.text
+        val text = currentState.text
+        val removeData = currentState.removeData.takeIf { newValue } ?: false
+        val days = currentState.days?.toLong().takeIf { newValue }
 
         updateState { it.copy(loading = true) }
         scope?.launch(Dispatchers.IO) {
@@ -50,8 +58,9 @@ class BanUserViewModel(
                     userId = userId,
                     communityId = communityId,
                     ban = newValue,
+                    expires = days,
                     reason = text,
-                    removeData = false,
+                    removeData = removeData,
                 )
                 if (newUser != null) {
                     postId?.also {


### PR DESCRIPTION
This PR completes the ban feature by adding the possibility to configure:
- ban duration (permaban or a given amount of days)
- whether to remove or not the data

according to the Lemmy API specification.