### PR TITLE
ehnancement: web settings save confirm

### DIFF
--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">فرض حظر دائم</string>
     <string name="ban_item_remove_data">إزالة البيانات</string>
     <string name="ban_item_duration_days">المدة (أيام)</string>
+    <string name="message_unsaved_changes">هناك تغييرات لم يتم حفظها، هل أنت متأكد من أنك تريد الخروج؟</string>
+    <string name="button_no_stay">لا، ابق هنا</string>
+    <string name="button_yes_quit">نعم، الخروج</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Постоянна забрана</string>
     <string name="ban_item_remove_data">Премахване на данни</string>
     <string name="ban_item_duration_days">Продължителност (дни)</string>
+    <string name="message_unsaved_changes">Има незапазени промени, сигурни ли сте, че искате да излезете?</string>
+    <string name="button_no_stay">Не, остани тук</string>
+    <string name="button_yes_quit">Да, изход</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Trvalý zákaz</string>
     <string name="ban_item_remove_data">Odebrat data</string>
     <string name="ban_item_duration_days">Délka (dny)</string>
+    <string name="message_unsaved_changes">Existují neuložené změny. Opravdu chcete skončit?</string>
+    <string name="button_no_stay">Ne, zůstaň tady</string>
+    <string name="button_yes_quit">Ano, odejít</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Permanent forbud</string>
     <string name="ban_item_remove_data">Fjern data</string>
     <string name="ban_item_duration_days">Varighed (dage)</string>
+    <string name="message_unsaved_changes">Der er ikke-gemte ændringer. Er du sikker på, at du vil afslutte?</string>
+    <string name="button_no_stay">Nej, bliv her</string>
+    <string name="button_yes_quit">Ja, exit</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Permanenter Bann</string>
     <string name="ban_item_remove_data">Daten entfernen</string>
     <string name="ban_item_duration_days">Dauer (Tage)</string>
+    <string name="message_unsaved_changes">Es gibt nicht gespeicherte Änderungen. Möchten Sie den Vorgang wirklich beenden?</string>
+    <string name="button_no_stay">Nein, bleib hier</string>
+    <string name="button_yes_quit">Ja, beenden</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Μόνιμη απαγόρευση</string>
     <string name="ban_item_remove_data">Κατάργηση δεδομένων</string>
     <string name="ban_item_duration_days">Διάρκεια (ημέρες)</string>
+    <string name="message_unsaved_changes">Υπάρχουν μη αποθηκευμένες αλλαγές, είστε βέβαιοι ότι θέλετε να βγείτε;</string>
+    <string name="button_no_stay">Όχι, μείνε εδώ</string>
+    <string name="button_yes_quit">Ναι, βγες</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Konstanta malpermeso</string>
     <string name="ban_item_remove_data">Forigi datumojn</string>
     <string name="ban_item_duration_days">Daŭro (tagoj)</string>
+    <string name="message_unsaved_changes">Estas nekonservitaj ŝanĝoj, ĉu vi certas, ke vi volas eliri?</string>
+    <string name="button_no_stay">Ne, resti ĉi tie</string>
+    <string name="button_yes_quit">Jes, eliri</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Prohibición permanente</string>
     <string name="ban_item_remove_data">Eliminar datos</string>
     <string name="ban_item_duration_days">Duración (días)</string>
+    <string name="message_unsaved_changes">Hay cambios sin guardar, ¿está seguro de que quiere salir?</string>
+    <string name="button_no_stay">No, quedar aquí</string>
+    <string name="button_yes_quit">si, salir</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Alaline keeld</string>
     <string name="ban_item_remove_data">Eemalda andmed</string>
     <string name="ban_item_duration_days">Kestus (päeva)</string>
+    <string name="message_unsaved_changes">On salvestamata muudatusi. Kas soovite kindlasti väljuda?</string>
+    <string name="button_no_stay">Ei, jää siia</string>
+    <string name="button_yes_quit">Jah, välju</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Pysyvä kielto</string>
     <string name="ban_item_remove_data">Poista tiedot</string>
     <string name="ban_item_duration_days">Kesto (päivää)</string>
+    <string name="message_unsaved_changes">Tallentamattomia muutoksia on. Haluatko varmasti poistua?</string>
+    <string name="button_no_stay">Ei, pysy täällä</string>
+    <string name="button_yes_quit">Kyllä, poistu</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Interdiction permanente</string>
     <string name="ban_item_remove_data">Supprimer données</string>
     <string name="ban_item_duration_days">Durée (jours)</string>
+    <string name="message_unsaved_changes">Il y a des modifications non enregistrées, êtes-vous sûr de vouloir quitter ?</string>
+    <string name="button_no_stay">Non, rester ici</string>
+    <string name="button_yes_quit">Oui, quitter</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Cosc buan</string>
     <string name="ban_item_remove_data">Bain sonraí</string>
     <string name="ban_item_duration_days">Fad (laethanta)</string>
+    <string name="message_unsaved_changes">Tá athruithe gan sábháil, an bhfuil tú cinnte gur mhaith leat scoir?</string>
+    <string name="button_no_stay">Ní hea, fan anseo</string>
+    <string name="button_yes_quit">Sea, scoir</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Trajna zabrana</string>
     <string name="ban_item_remove_data">Ukloni podatke</string>
     <string name="ban_item_duration_days">Trajanje (dani)</string>
+    <string name="message_unsaved_changes">Postoje nespremljene promjene, jeste li sigurni da želite izaći?</string>
+    <string name="button_no_stay">Ne, ostani ovdje</string>
+    <string name="button_yes_quit">Da, izlaz</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Végleges eltiltás</string>
     <string name="ban_item_remove_data">Távolítsa el az adatokat</string>
     <string name="ban_item_duration_days">Időtartam (nap)</string>
+    <string name="message_unsaved_changes">Vannak nem mentett módosítások. Biztosan kilép?</string>
+    <string name="button_no_stay">Nem, maradj itt</string>
+    <string name="button_yes_quit">Igen, kilép</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Ban permanente</string>
     <string name="ban_item_remove_data">Rimuovi dati</string>
     <string name="ban_item_duration_days">Durata (giorni)</string>
+    <string name="message_unsaved_changes">Ci sono modifiche non salvate. Sei sicuro di voler uscire?</string>
+    <string name="button_no_stay">No, resta qui</string>
+    <string name="button_yes_quit">Sì, esci</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Nuolatinis draudimas</string>
     <string name="ban_item_remove_data">Pašalinti duomenis</string>
     <string name="ban_item_duration_days">Trukmė (dienomis)</string>
+    <string name="message_unsaved_changes">Yra neišsaugotų pakeitimų. Ar tikrai norite išeiti?</string>
+    <string name="button_no_stay">Ne, pasilik čia</string>
+    <string name="button_yes_quit">Taip, išeiti</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Pastāvīgs aizliegums</string>
     <string name="ban_item_remove_data">Noņemiet datus</string>
     <string name="ban_item_duration_days">Ilgums (dienas)</string>
+    <string name="message_unsaved_changes">Ir nesaglabātas izmaiņas. Vai tiešām vēlaties iziet?</string>
+    <string name="button_no_stay">Nē, paliec šeit</string>
+    <string name="button_yes_quit">Jā, iziet</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Projbizzjoni permanenti</string>
     <string name="ban_item_remove_data">Neħħi d-data</string>
     <string name="ban_item_duration_days">Tul (jiem)</string>
+    <string name="message_unsaved_changes">Hemm bidliet mhux salvati, żgur li trid toħroġ?</string>
+    <string name="button_no_stay">Le, oqgħod hawn</string>
+    <string name="button_yes_quit">Iva, ħruġ</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Permanente verbanning</string>
     <string name="ban_item_remove_data">Gegevens verwijderen</string>
     <string name="ban_item_duration_days">Duur (dagen)</string>
+    <string name="message_unsaved_changes">Er zijn niet-opgeslagen wijzigingen. Weet u zeker dat u wilt afsluiten?</string>
+    <string name="button_no_stay">Nee, blijf hier</string>
+    <string name="button_yes_quit">Ja, vertrek</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Permanent forbud</string>
     <string name="ban_item_remove_data">Fjern data</string>
     <string name="ban_item_duration_days">Varighet (dager)</string>
+    <string name="message_unsaved_changes">Det er ulagrede endringer, er du sikker på at du vil avslutte?</string>
+    <string name="button_no_stay">Nei, bli her</string>
+    <string name="button_yes_quit">Ja, gå ut</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Stały zakaz</string>
     <string name="ban_item_remove_data">Usuń dane</string>
     <string name="ban_item_duration_days">Czas trwania (dni)</string>
+    <string name="message_unsaved_changes">Istnieją niezapisane zmiany. Czy na pewno chcesz wyjść?</string>
+    <string name="button_no_stay">Nie, zostań tutaj</string>
+    <string name="button_yes_quit">Tak, wyjdź</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Proibição permanente</string>
     <string name="ban_item_remove_data">Remover dados</string>
     <string name="ban_item_duration_days">Duração (dias)</string>
+    <string name="message_unsaved_changes">Existem alterações não salvas. Tem certeza de que deseja sair?</string>
+    <string name="button_no_stay">Não, ficar aqui</string>
+    <string name="button_yes_quit">Sim, sair</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Proibição permanente</string>
     <string name="ban_item_remove_data">Remover dados</string>
     <string name="ban_item_duration_days">Duração (dias)</string>
+    <string name="message_unsaved_changes">Existem alterações não salvas. Tem certeza de que deseja sair?</string>
+    <string name="button_no_stay">Não, ficar aqui</string>
+    <string name="button_yes_quit">Sim, sair</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Interdicție permanentă</string>
     <string name="ban_item_remove_data">Elimină datele</string>
     <string name="ban_item_duration_days">Durată (zile)</string>
+    <string name="message_unsaved_changes">Există modificări nesalvate, ești sigur că vrei să ieși?</string>
+    <string name="button_no_stay">Nu, stai aici</string>
+    <string name="button_yes_quit">Da, ieși</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -336,4 +336,7 @@
     <string name="ban_item_permanent">Постоянный бан</string>
     <string name="ban_item_remove_data">Удалить данные</string>
     <string name="ban_item_duration_days">Продолжительность (дни)</string>
+    <string name="message_unsaved_changes">Есть несохраненные изменения. Вы уверены, что хотите выйти?</string>
+    <string name="button_no_stay">Нет, оставайся здесь</string>
+    <string name="button_yes_quit">Да, выход</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Permanent förbud</string>
     <string name="ban_item_remove_data">Ta bort data</string>
     <string name="ban_item_duration_days">Varaktighet (dagar)</string>
+    <string name="message_unsaved_changes">Det finns osparade ändringar, är du säker på att du vill avsluta?</string>
+    <string name="button_no_stay">Nej, stanna här</string>
+    <string name="button_yes_quit">Ja, avsluta</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Trvalý zákaz</string>
     <string name="ban_item_remove_data">Odstráňte údaje</string>
     <string name="ban_item_duration_days">Trvanie (dni)</string>
+    <string name="message_unsaved_changes">Existujú neuložené zmeny. Naozaj chcete skončiť?</string>
+    <string name="button_no_stay">Nie, zostaň tu</string>
+    <string name="button_yes_quit">Áno, odísť</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Trajna prepoved</string>
     <string name="ban_item_remove_data">Odstrani podatke</string>
     <string name="ban_item_duration_days">Trajanje (dnevi)</string>
+    <string name="message_unsaved_changes">Obstajajo neshranjene spremembe. Ste prepričani, da želite zapustiti?</string>
+    <string name="button_no_stay">Ne, ostani tukaj</string>
+    <string name="button_yes_quit">Ja, izhod</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Ndalim i përhershëm</string>
     <string name="ban_item_remove_data">Hiq të dhënat</string>
     <string name="ban_item_duration_days">Kohëzgjatja (ditë)</string>
+    <string name="message_unsaved_changes">Ka ndryshime të paruajtura, je i sigurt që dëshiron të dalësh?</string>
+    <string name="button_no_stay">Jo, rri këtu</string>
+    <string name="button_yes_quit">Po, dil</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">lon tenpo ale</string>
     <string name="ban_item_remove_data">o weka e sona</string>
     <string name="ban_item_duration_days">tenpo suno</string>
+    <string name="message_unsaved_changes">sina ante e sona, taso sina awen ala e ona. sina wile ala wile tawa weka?</string>
+    <string name="button_no_stay">o awen</string>
+    <string name="button_yes_quit">o tawa weka</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Kalıcı yasak</string>
     <string name="ban_item_remove_data">Verileri kaldır</string>
     <string name="ban_item_duration_days">Süre (gün)</string>
+    <string name="message_unsaved_changes">Kaydedilmemiş değişiklikler var, çıkmak istediğinizden emin misiniz?</string>
+    <string name="button_no_stay">Hayır, burada kal</string>
+    <string name="button_yes_quit">Evet, çık</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -336,4 +336,7 @@
     <string name="ban_item_permanent">Постійний бан</string>
     <string name="ban_item_remove_data">Видалити дані</string>
     <string name="ban_item_duration_days">Тривалість (дні)</string>
+    <string name="message_unsaved_changes">Є незбережені зміни. Ви впевнені, що бажаєте вийти?</string>
+    <string name="button_no_stay">Ні, залишайся тут</string>
+    <string name="button_yes_quit">Так, вихід</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -337,4 +337,7 @@
     <string name="ban_item_permanent">Permanent ban</string>
     <string name="ban_item_remove_data">Remove data</string>
     <string name="ban_item_duration_days">Duration (days)</string>
+    <string name="message_unsaved_changes">There are unsaved changes, are you sure you want to quit?</string>
+    <string name="button_no_stay">No, stay here</string>
+    <string name="button_yes_quit">Yes, quit</string>
 </resources>

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsMviModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsMviModel.kt
@@ -8,8 +8,8 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 
 @Stable
 interface AccountSettingsMviModel :
-    MviModel<AccountSettingsMviModel.Intent, AccountSettingsMviModel.UiState, AccountSettingsMviModel.Effect>,
-    ScreenModel {
+    ScreenModel,
+    MviModel<AccountSettingsMviModel.Intent, AccountSettingsMviModel.UiState, AccountSettingsMviModel.Effect> {
 
     sealed interface Intent {
         data class ChangeDisplayName(val value: String) : Intent
@@ -29,9 +29,7 @@ interface AccountSettingsMviModel :
 
                 other as AvatarSelected
 
-                if (!value.contentEquals(other.value)) return false
-
-                return true
+                return value.contentEquals(other.value)
             }
 
             override fun hashCode(): Int {
@@ -46,9 +44,7 @@ interface AccountSettingsMviModel :
 
                 other as BannerSelected
 
-                if (!value.contentEquals(other.value)) return false
-
-                return true
+                return value.contentEquals(other.value)
             }
 
             override fun hashCode(): Int {
@@ -61,6 +57,7 @@ interface AccountSettingsMviModel :
 
     data class UiState(
         val loading: Boolean = false,
+        val hasUnsavedChanges: Boolean = false,
         val avatar: String = "",
         val banner: String = "",
         val bio: String = "",

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -10,9 +10,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -23,6 +23,8 @@ import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -35,17 +37,20 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
@@ -102,6 +107,7 @@ class AccountSettingsScreen : Screen {
         val galleryHelper = remember { getGalleryHelper() }
         var openAvatarPicker by remember { mutableStateOf(false) }
         var openBannerPicker by remember { mutableStateOf(false) }
+        var confirmBackWithUnsavedChangesDialog by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
             model.effects.onEach { evt ->
@@ -117,8 +123,23 @@ class AccountSettingsScreen : Screen {
             }.launchIn(this)
         }
 
+        DisposableEffect(key) {
+            navigationCoordinator.setCanGoBackCallback {
+                if (uiState.hasUnsavedChanges) {
+                    confirmBackWithUnsavedChangesDialog = true
+                    return@setCanGoBackCallback false
+                }
+                true
+            }
+            onDispose {
+                navigationCoordinator.setCanGoBackCallback(null)
+            }
+        }
+
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background)
+            modifier = Modifier
+                .safeContentPadding()
+                .background(MaterialTheme.colorScheme.background)
                 .padding(Spacing.xs),
             topBar = {
                 TopAppBar(
@@ -134,7 +155,11 @@ class AccountSettingsScreen : Screen {
                             Image(
                                 modifier = Modifier.onClick(
                                     onClick = rememberCallback {
-                                        navigationCoordinator.popScreen()
+                                        if (uiState.hasUnsavedChanges) {
+                                            confirmBackWithUnsavedChangesDialog = true
+                                        } else {
+                                            navigationCoordinator.popScreen()
+                                        }
                                     },
                                 ),
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -153,17 +178,11 @@ class AccountSettingsScreen : Screen {
                             )
                         )
                         Icon(
-                            modifier = Modifier
-                                .then(
-                                    if (!uiState.loading) {
-                                        Modifier
-                                    } else Modifier.rotate(iconRotate)
-                                )
-                                .onClick(
-                                    onClick = rememberCallback {
-                                        model.reduce(AccountSettingsMviModel.Intent.Submit)
-                                    },
-                                ),
+                            modifier = Modifier.then(
+                                if (!uiState.loading) {
+                                    Modifier
+                                } else Modifier.rotate(iconRotate)
+                            ),
                             imageVector = Icons.Default.Sync,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onBackground,
@@ -181,7 +200,7 @@ class AccountSettingsScreen : Screen {
                 }
             },
         ) { paddingValues ->
-            Box(
+            Column(
                 modifier = Modifier
                     .padding(paddingValues)
                     .then(
@@ -193,7 +212,7 @@ class AccountSettingsScreen : Screen {
                     )
             ) {
                 Column(
-                    modifier = Modifier.fillMaxSize().verticalScroll(scrollState),
+                    modifier = Modifier.weight(1f).verticalScroll(scrollState),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
                     SettingsHeader(
@@ -218,6 +237,7 @@ class AccountSettingsScreen : Screen {
                     AccountSettingsImageInfo(
                         title = LocalXmlStrings.current.settingsWebBanner,
                         imageModifier = Modifier.fillMaxWidth().aspectRatio(3.5f),
+                        contentScale = ContentScale.Crop,
                         url = uiState.banner,
                         onEdit = rememberCallback {
                             openBannerPicker = true
@@ -361,6 +381,20 @@ class AccountSettingsScreen : Screen {
                         },
                     )
                 }
+
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Button(
+                        enabled = uiState.hasUnsavedChanges,
+                        onClick = {
+                            model.reduce(AccountSettingsMviModel.Intent.Submit)
+                        },
+                    ) {
+                        Text(text = LocalXmlStrings.current.actionSave)
+                    }
+                }
             }
         }
 
@@ -427,6 +461,36 @@ class AccountSettingsScreen : Screen {
                 openBannerPicker = false
                 model.reduce(AccountSettingsMviModel.Intent.BannerSelected(bytes))
             }
+        }
+
+        if (confirmBackWithUnsavedChangesDialog) {
+            AlertDialog(
+                onDismissRequest = {
+                    confirmBackWithUnsavedChangesDialog = false
+                },
+                dismissButton = {
+                    Button(
+                        onClick = {
+                            confirmBackWithUnsavedChangesDialog = false
+                        },
+                    ) {
+                        Text(text = "No, stay here")
+                    }
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            confirmBackWithUnsavedChangesDialog = false
+                            navigationCoordinator.popScreen()
+                        },
+                    ) {
+                        Text(text = "Yes, quit")
+                    }
+                },
+                text = {
+                    Text(text = "There are unsaved changes, are you sure you want to quit?")
+                },
+            )
         }
     }
 }

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -474,7 +474,7 @@ class AccountSettingsScreen : Screen {
                             confirmBackWithUnsavedChangesDialog = false
                         },
                     ) {
-                        Text(text = "No, stay here")
+                        Text(text = LocalXmlStrings.current.buttonNoStay)
                     }
                 },
                 confirmButton = {
@@ -484,11 +484,11 @@ class AccountSettingsScreen : Screen {
                             navigationCoordinator.popScreen()
                         },
                     ) {
-                        Text(text = "Yes, quit")
+                        Text(text = LocalXmlStrings.current.buttonYesQuit)
                     }
                 },
                 text = {
-                    Text(text = "There are unsaved changes, are you sure you want to quit?")
+                    Text(text = LocalXmlStrings.current.messageUnsavedChanges)
                 },
             )
         }

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
@@ -53,43 +53,93 @@ class AccountSettingsViewModel(
     override fun reduce(intent: AccountSettingsMviModel.Intent) {
         when (intent) {
             is AccountSettingsMviModel.Intent.ChangeDisplayName -> {
-                updateState { it.copy(displayName = intent.value) }
+                updateState {
+                    it.copy(
+                        displayName = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeEmail -> {
-                updateState { it.copy(email = intent.value) }
+                updateState {
+                    it.copy(
+                        email = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeMatrixUserId -> {
-                updateState { it.copy(matrixUserId = intent.value) }
+                updateState {
+                    it.copy(
+                        matrixUserId = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeBio -> {
-                updateState { it.copy(bio = intent.value) }
+                updateState {
+                    it.copy(
+                        bio = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeBot -> {
-                updateState { it.copy(bot = intent.value) }
+                updateState {
+                    it.copy(
+                        bot = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeSendNotificationsToEmail -> {
-                updateState { it.copy(sendNotificationsToEmail = intent.value) }
+                updateState {
+                    it.copy(
+                        sendNotificationsToEmail = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeShowBotAccounts -> {
-                updateState { it.copy(showBotAccounts = intent.value) }
+                updateState {
+                    it.copy(
+                        showBotAccounts = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeShowNsfw -> {
-                updateState { it.copy(showNsfw = intent.value) }
+                updateState {
+                    it.copy(
+                        showNsfw = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeShowScores -> {
-                updateState { it.copy(showScores = intent.value) }
+                updateState {
+                    it.copy(
+                        showScores = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.ChangeShowReadPosts -> {
-                updateState { it.copy(showReadPosts = intent.value) }
+                updateState {
+                    it.copy(
+                        showReadPosts = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
             }
 
             is AccountSettingsMviModel.Intent.AvatarSelected -> {
@@ -141,6 +191,7 @@ class AccountSettingsViewModel(
                 updateState {
                     it.copy(
                         avatar = url,
+                        hasUnsavedChanges = true,
                         loading = false,
                     )
                 }
@@ -160,6 +211,7 @@ class AccountSettingsViewModel(
                 updateState {
                     it.copy(
                         banner = url,
+                        hasUnsavedChanges = true,
                         loading = false,
                     )
                 }
@@ -194,6 +246,12 @@ class AccountSettingsViewModel(
                     value = settingsToSave,
                 )
                 refreshSettings()
+                updateState {
+                    it.copy(
+                        loading = false,
+                        hasUnsavedChanges = false,
+                    )
+                }
                 emitEffect(
                     AccountSettingsMviModel.Effect.Success
                 )

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/components/AccountSettingsImageInfo.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/components/AccountSettingsImageInfo.kt
@@ -24,6 +24,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallb
 internal fun AccountSettingsImageInfo(
     modifier: Modifier = Modifier,
     imageModifier: Modifier = Modifier,
+    contentScale : ContentScale = ContentScale.FillBounds,
     title: String = "",
     url: String = "",
     onEdit: (() -> Unit)? = null,
@@ -55,7 +56,7 @@ internal fun AccountSettingsImageInfo(
                     modifier = imageModifier,
                     url = url,
                     quality = FilterQuality.Low,
-                    contentScale = ContentScale.FillBounds,
+                    contentScale = contentScale,
                 )
             } else {
                 Box(

--- a/unit/chat/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/chat/InboxChatMviModel.kt
+++ b/unit/chat/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/chat/InboxChatMviModel.kt
@@ -19,9 +19,7 @@ interface InboxChatMviModel :
 
                 other as ImageSelected
 
-                if (!value.contentEquals(other.value)) return false
-
-                return true
+                return value.contentEquals(other.value)
             }
 
             override fun hashCode(): Int {


### PR DESCRIPTION
This PR makes it nearly impossible to leave the "Account settings" screen without saving:
- a confirmation dialog is displayed if there are unsaved changes
- the "Save" button is much more visible and can not be skipped.