### PR TITLE
fix: add event filters based on screen

### DIFF
--- a/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/ListingTypeBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/ListingTypeBottomSheet.kt
@@ -34,6 +34,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toReadableName
 
 class ListingTypeBottomSheet(
     private val isLogged: Boolean = false,
+    private val screenKey: String? = null,
 ) : Screen {
     @Composable
     override fun Content() {
@@ -88,6 +89,7 @@ class ListingTypeBottomSheet(
                                         notificationCenter.send(
                                             NotificationCenterEvent.ChangeFeedType(
                                                 value = value,
+                                                screenKey = screenKey,
                                             )
                                         )
                                         navigationCoordinator.hideBottomSheet()

--- a/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
@@ -46,6 +46,7 @@ class SortBottomSheet(
     private val comments: Boolean = false,
     private val defaultForCommunity: Boolean = false,
     private val expandTop: Boolean = false,
+    private val screenKey: String? = null,
 ) : Screen {
     @Composable
     override fun Content() {
@@ -69,6 +70,7 @@ class SortBottomSheet(
                     expandTop = expandTop,
                     comments = comments,
                     defaultForCommunity = defaultForCommunity,
+                    screenKey = screenKey,
                 )
             )
         }
@@ -80,6 +82,7 @@ internal class SortBottomSheetMain(
     private val values: List<Int>,
     private val expandTop: Boolean = false,
     private val defaultForCommunity: Boolean = false,
+    private val screenKey: String?,
 ) : Screen {
     @Composable
     override fun Content() {
@@ -119,17 +122,20 @@ internal class SortBottomSheetMain(
                                             SortBottomSheetTop(
                                                 comments = comments,
                                                 defaultForCommunity = defaultForCommunity,
+                                                screenKey = screenKey,
                                             )
                                         )
                                     } else {
                                         val event = if (comments) {
                                             NotificationCenterEvent.ChangeCommentSortType(
                                                 value = sortValue,
+                                                screenKey = screenKey,
                                             )
                                         } else {
                                             NotificationCenterEvent.ChangeSortType(
                                                 value = sortValue,
                                                 defaultForCommunity = defaultForCommunity,
+                                                screenKey = screenKey,
                                             )
                                         }
                                         notificationCenter.send(event)
@@ -177,6 +183,7 @@ internal class SortBottomSheetTop(
         SortType.Top.Year,
     ).map { it.toInt() },
     private val defaultForCommunity: Boolean = false,
+    private val screenKey: String?,
 ) : Screen {
     @Composable
     override fun Content() {
@@ -228,11 +235,13 @@ internal class SortBottomSheetTop(
                                     val event = if (comments) {
                                         NotificationCenterEvent.ChangeCommentSortType(
                                             value = sortValue,
+                                            screenKey = screenKey,
                                         )
                                     } else {
                                         NotificationCenterEvent.ChangeSortType(
                                             value = sortValue,
                                             defaultForCommunity = defaultForCommunity,
+                                            screenKey = screenKey,
                                         )
                                     }
                                     notificationCenter.send(event)

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -21,13 +21,13 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 import kotlin.time.Duration
 
 sealed interface NotificationCenterEvent {
-    data class ChangeSortType(val value: SortType, val defaultForCommunity: Boolean) :
+    data class ChangeSortType(val value: SortType, val defaultForCommunity: Boolean, val screenKey: String?) :
         NotificationCenterEvent
 
-    data class ChangeCommentSortType(val value: SortType) :
+    data class ChangeCommentSortType(val value: SortType, val screenKey: String?) :
         NotificationCenterEvent
 
-    data class ChangeFeedType(val value: ListingType) :
+    data class ChangeFeedType(val value: ListingType, val screenKey: String?) :
         NotificationCenterEvent
 
     data class ChangeInboxType(val unreadOnly: Boolean) : NotificationCenterEvent

--- a/feature/search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreScreen.kt
@@ -168,6 +168,7 @@ class ExploreScreen : Screen {
                         focusManager.clearFocus()
                         val sheet = ListingTypeBottomSheet(
                             isLogged = uiState.isLogged,
+                            screenKey = "explore",
                         )
                         navigationCoordinator.showBottomSheet(sheet)
                     },
@@ -176,6 +177,7 @@ class ExploreScreen : Screen {
                         val sheet = SortBottomSheet(
                             values = uiState.availableSortTypes.map { it.toInt() },
                             expandTop = true,
+                            screenKey = "explore",
                         )
                         navigationCoordinator.showBottomSheet(sheet)
                     },

--- a/feature/search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/search/main/ExploreViewModel.kt
@@ -99,12 +99,16 @@ class ExploreViewModel(
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeFeedType::class)
                 .onEach { evt ->
-                    changeListingType(evt.value)
+                    if (evt.screenKey == "explore") {
+                        changeListingType(evt.value)
+                    }
                 }.launchIn(this)
 
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    changeSortType(evt.value)
+                    if (evt.screenKey == "explore") {
+                        changeSortType(evt.value)
+                    }
                 }.launchIn(this)
         }
 

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -172,10 +172,13 @@ class AdvancedSettingsScreen : Screen {
                     )
                     // default explore type
                     SettingsRow(
-                        title =  LocalXmlStrings.current.settingsDefaultExploreType,
+                        title = LocalXmlStrings.current.settingsDefaultExploreType,
                         value = uiState.defaultExploreType.toReadableName(),
                         onTap = rememberCallback {
-                            val sheet = ListingTypeBottomSheet(isLogged = uiState.isLogged)
+                            val sheet = ListingTypeBottomSheet(
+                                isLogged = uiState.isLogged,
+                                screenKey = "advancedSettings",
+                            )
                             navigationCoordinator.showBottomSheet(sheet)
                         },
                     )

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -53,7 +53,9 @@ class AdvancedSettingsViewModel(
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeFeedType::class)
                 .onEach { evt ->
-                    changeExploreType(evt.value)
+                    if (evt.screenKey == "advancedSettings") {
+                        changeExploreType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeZombieScrollAmount::class)
                 .onEach { evt ->

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -205,6 +205,7 @@ class SettingsScreen : Screen {
                         onTap = rememberCallback {
                             val sheet = ListingTypeBottomSheet(
                                 isLogged = uiState.isLogged,
+                                screenKey = "settings",
                             )
                             navigationCoordinator.showBottomSheet(sheet)
                         },
@@ -218,6 +219,7 @@ class SettingsScreen : Screen {
                             val sheet = SortBottomSheet(
                                 values = uiState.availableSortTypesForPosts.map { it.toInt() },
                                 expandTop = true,
+                                screenKey = "settings",
                             )
                             navigationCoordinator.showBottomSheet(sheet)
                         },
@@ -231,6 +233,7 @@ class SettingsScreen : Screen {
                             val sheet = SortBottomSheet(
                                 comments = true,
                                 values = uiState.availableSortTypesForComments.map { it.toInt() },
+                                screenKey = "settings",
                             )
                             navigationCoordinator.showBottomSheet(sheet)
                         },

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
@@ -67,15 +67,21 @@ class SettingsViewModel(
             }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeFeedType::class)
                 .onEach { evt ->
-                    changeDefaultListingType(evt.value)
+                    if (evt.screenKey == "settings") {
+                        changeDefaultListingType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    changeDefaultPostSortType(evt.value)
+                    if (evt.screenKey == "settings") {
+                        changeDefaultPostSortType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeCommentSortType::class)
                 .onEach { evt ->
-                    changeDefaultCommentSortType(evt.value)
+                    if (evt.screenKey == "settings") {
+                        changeDefaultCommentSortType(evt.value)
+                    }
                 }.launchIn(this)
 
             val availableSortTypesForPosts = getSortTypesUseCase.getTypesForPosts()

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
@@ -134,7 +134,7 @@ internal object MainScreen : Screen {
                     when (evt) {
                         is DrawerEvent.ChangeListingType -> {
                             if (tabNavigator.current == HomeTab) {
-                                notificationCenter.send(NotificationCenterEvent.ChangeFeedType(evt.value))
+                                notificationCenter.send(NotificationCenterEvent.ChangeFeedType(evt.value, "postList"))
                             } else {
                                 with(navigationCoordinator) {
                                     changeTab(HomeTab)
@@ -144,7 +144,7 @@ internal object MainScreen : Screen {
                                     // wait for transition to finish
                                     delay(750)
                                     notificationCenter.send(
-                                        NotificationCenterEvent.ChangeFeedType(evt.value)
+                                        NotificationCenterEvent.ChangeFeedType(evt.value, "postList")
                                     )
                                 }
                             }

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -304,6 +304,7 @@ class AccountSettingsScreen : Screen {
                         onTap = rememberCallback {
                             val sheet = ListingTypeBottomSheet(
                                 isLogged = true,
+                                screenKey = "accountSettings",
                             )
                             navigationCoordinator.showBottomSheet(sheet)
                         },
@@ -317,6 +318,7 @@ class AccountSettingsScreen : Screen {
                             val sheet = SortBottomSheet(
                                 values = uiState.availableSortTypes.map { it.toInt() },
                                 expandTop = true,
+                                screenKey = "accountSettings",
                             )
                             navigationCoordinator.showBottomSheet(sheet)
                         },

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
@@ -35,11 +35,15 @@ class AccountSettingsViewModel(
         screenModelScope.launch {
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    updateState { it.copy(defaultSortType = evt.value) }
+                    if (evt.screenKey == "accountSettings") {
+                        updateState { it.copy(defaultSortType = evt.value) }
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeFeedType::class)
                 .onEach { evt ->
-                    updateState { it.copy(defaultListingType = evt.value) }
+                    if (evt.screenKey == "accountSettings") {
+                        updateState { it.copy(defaultListingType = evt.value) }
+                    }
                 }.launchIn(this)
 
             if (accountSettings == null) {

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -289,6 +289,7 @@ class CommunityDetailScreen(
                                     val sheet = SortBottomSheet(
                                         values = uiState.availableSortTypes.map { it.toInt() },
                                         expandTop = true,
+                                        screenKey = uiState.community.readableHandle,
                                     )
                                     navigationCoordinator.showBottomSheet(sheet)
                                 },
@@ -461,6 +462,7 @@ class CommunityDetailScreen(
                                                         values = uiState.availableSortTypes.map { it.toInt() },
                                                         defaultForCommunity = true,
                                                         expandTop = true,
+                                                        screenKey = uiState.community.readableHandle,
                                                     )
                                                     navigationCoordinator.showBottomSheet(screen)
                                                 }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -151,11 +151,13 @@ class CommunityDetailViewModel(
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    if (evt.defaultForCommunity) {
-                        val handle = uiState.value.community.readableHandle
-                        communitySortRepository.saveSort(handle, evt.value.toInt())
+                    if (evt.screenKey == uiState.value.community.readableHandle) {
+                        if (evt.defaultForCommunity) {
+                            val handle = uiState.value.community.readableHandle
+                            communitySortRepository.saveSort(handle, evt.value.toInt())
+                        }
+                        applySortType(evt.value)
                     }
-                    applySortType(evt.value)
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.Share::class).onEach { evt ->
                 shareHelper.share(evt.url)

--- a/unit/instanceinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
@@ -134,6 +134,7 @@ class InstanceInfoScreen(
                                         val sheet = SortBottomSheet(
                                             values = uiState.availableSortTypes.map { it.toInt() },
                                             expandTop = true,
+                                            screenKey = "instanceInfo",
                                         )
                                         navigationCoordinator.showBottomSheet(sheet)
                                     },

--- a/unit/instanceinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/instanceinfo/InstanceInfoViewModel.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/instanceinfo/InstanceInfoViewModel.kt
@@ -42,7 +42,9 @@ class InstanceInfoViewModel(
             }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    changeSortType(evt.value)
+                    if (evt.screenKey == "instanceInfo") {
+                        changeSortType(evt.value)
+                    }
                 }.launchIn(this)
 
             val metadata = siteRepository.getMetadata(url)

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -185,6 +185,7 @@ class MultiCommunityScreen(
                                             val sheet = SortBottomSheet(
                                                 values = uiState.availableSortTypes.map { it.toInt() },
                                                 expandTop = true,
+                                                screenKey = "multiCommunity",
                                             )
                                             navigationCoordinator.showBottomSheet(sheet)
                                         },

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -79,7 +79,9 @@ class MultiCommunityViewModel(
             }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    applySortType(evt.value)
+                    if (evt.screenKey == "multiCommunity") {
+                        applySortType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.Share::class).onEach { evt ->
                 shareHelper.share(evt.url)

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -195,6 +195,7 @@ class PostListScreen : Screen {
                     onSelectListingType = rememberCallback {
                         val sheet = ListingTypeBottomSheet(
                             isLogged = uiState.isLogged,
+                            screenKey = "postList"
                         )
                         navigationCoordinator.showBottomSheet(sheet)
                     },
@@ -207,6 +208,7 @@ class PostListScreen : Screen {
                         val sheet = SortBottomSheet(
                             values = uiState.availableSortTypes.map { it.toInt() },
                             expandTop = true,
+                            screenKey = "postList",
                         )
                         navigationCoordinator.showBottomSheet(sheet)
                     },

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListViewModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListViewModel.kt
@@ -103,11 +103,15 @@ class PostListViewModel(
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeFeedType::class)
                 .onEach { evt ->
-                    applyListingType(evt.value)
+                    if (evt.screenKey == "postList") {
+                        applyListingType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    applySortType(evt.value)
+                    if (evt.screenKey == "postList") {
+                        applySortType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.Logout::class).onEach {
                 handleLogout()

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
@@ -112,6 +112,7 @@ class SavedItemsScreen : Screen {
                                 onClick = rememberCallback {
                                     val sheet = SortBottomSheet(
                                         values = uiState.availableSortTypes.map { it.toInt() },
+                                        screenKey = "savedItems",
                                     )
                                     navigatorCoordinator.showBottomSheet(sheet)
                                 },

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsViewModel.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsViewModel.kt
@@ -69,7 +69,9 @@ class SavedItemsViewModel(
             }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    applySortType(evt.value)
+                    if (evt.screenKey == "savedItems") {
+                        applySortType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.Share::class).onEach { evt ->
                 shareHelper.share(evt.url)

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -222,6 +222,7 @@ class UserDetailScreen(
                                     val sheet = SortBottomSheet(
                                         values = uiState.availableSortTypes.map { it.toInt() },
                                         expandTop = true,
+                                        screenKey = uiState.user.readableHandle,
                                     )
                                     navigationCoordinator.showBottomSheet(sheet)
                                 },

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
@@ -17,6 +17,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.imageUrl
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toSortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
@@ -79,7 +80,9 @@ class UserDetailViewModel(
             }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    applySortType(evt.value)
+                    if (evt.screenKey == uiState.value.user.readableHandle) {
+                        applySortType(evt.value)
+                    }
                 }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.Share::class).onEach { evt ->
                 shareHelper.share(evt.url)


### PR DESCRIPTION
This PR fixes the sort and feed type settings which was accidentally broken by #587 when altering the lifecycle of screen models.