### PR TITLE
feat: create post from home

### DIFF
--- a/core/commonui/detailopener-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
+++ b/core/commonui/detailopener-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
@@ -42,5 +42,6 @@ interface DetailOpener {
         initialTitle: String? = null,
         initialUrl: String? = null,
         initialNsfw: Boolean? = null,
+        forceCommunitySelection: Boolean = false,
     )
 }

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -49,7 +49,9 @@ class DefaultDetailOpener(
                     defaultResult
                 }
             }
-            itemCache.putCommunity(actualCommunity)
+            withContext(Dispatchers.IO) {
+                itemCache.putCommunity(actualCommunity)
+            }
             navigationCoordinator.pushScreen(
                 CommunityDetailScreen(
                     communityId = actualCommunity.id,
@@ -61,7 +63,9 @@ class DefaultDetailOpener(
 
     override fun openUserDetail(user: UserModel, otherInstance: String) {
         scope.launch {
-            itemCache.putUser(user)
+            withContext(Dispatchers.IO) {
+                itemCache.putUser(user)
+            }
             navigationCoordinator.pushScreen(
                 UserDetailScreen(
                     userId = user.id,
@@ -78,7 +82,9 @@ class DefaultDetailOpener(
         isMod: Boolean,
     ) {
         scope.launch {
-            itemCache.putPost(post)
+            withContext(Dispatchers.IO) {
+                itemCache.putPost(post)
+            }
             navigationCoordinator.pushScreen(
                 PostDetailScreen(
                     postId = post.id,
@@ -98,14 +104,16 @@ class DefaultDetailOpener(
         initialText: String?,
     ) {
         scope.launch {
-            if (originalPost != null) {
-                itemCache.putPost(originalPost)
-            }
-            if (originalComment != null) {
-                itemCache.putComment(originalComment)
-            }
-            if (editedComment != null) {
-                itemCache.putComment(editedComment)
+            withContext(Dispatchers.IO) {
+                if (originalPost != null) {
+                    itemCache.putPost(originalPost)
+                }
+                if (originalComment != null) {
+                    itemCache.putComment(originalComment)
+                }
+                if (editedComment != null) {
+                    itemCache.putComment(editedComment)
+                }
             }
             val screen = CreateCommentScreen(
                 draftId = draftId,
@@ -127,13 +135,16 @@ class DefaultDetailOpener(
         initialTitle: String?,
         initialUrl: String?,
         initialNsfw: Boolean?,
+        forceCommunitySelection: Boolean,
     ) {
         scope.launch {
-            if (editedPost != null) {
-                itemCache.putPost(editedPost)
-            }
-            if (crossPost != null) {
-                itemCache.putPost(crossPost)
+            withContext(Dispatchers.IO) {
+                if (editedPost != null) {
+                    itemCache.putPost(editedPost)
+                }
+                if (crossPost != null) {
+                    itemCache.putPost(crossPost)
+                }
             }
             val screen = CreatePostScreen(
                 draftId = draftId,
@@ -144,6 +155,7 @@ class DefaultDetailOpener(
                 initialTitle = initialTitle,
                 initialUrl = initialUrl,
                 initialNsfw = initialNsfw,
+                forceCommunitySelection = forceCommunitySelection,
             )
             navigationCoordinator.pushScreen(screen)
         }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -953,7 +953,10 @@ class CommunityDetailScreen(
                                                     }
 
                                                     OptionId.CrossPost -> {
-                                                        detailOpener.openCreatePost(crossPost = post)
+                                                        detailOpener.openCreatePost(
+                                                            crossPost = post,
+                                                            forceCommunitySelection = true,
+                                                        )
                                                     }
 
                                                     OptionId.SeeRaw -> {

--- a/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -94,6 +94,7 @@ class CreatePostScreen(
     private val initialTitle: String? = null,
     private val initialUrl: String? = null,
     private val initialNsfw: Boolean? = null,
+    private val forceCommunitySelection: Boolean = false,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -292,7 +293,7 @@ class CreatePostScreen(
                 modifier = Modifier.padding(padding).verticalScroll(rememberScrollState()),
             ) {
                 // community
-                if (crossPost != null) {
+                if (forceCommunitySelection) {
                     TextField(
                         modifier = Modifier.fillMaxWidth().onFocusChanged(
                             rememberCallbackArgs { state ->

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -97,7 +97,7 @@ class DraftsScreen : Screen {
                     },
                     title = {
                         Text(
-                            text =  LocalXmlStrings.current.navigationDrawerTitleDrafts,
+                            text = LocalXmlStrings.current.navigationDrawerTitleDrafts,
                             style = MaterialTheme.typography.titleMedium,
                         )
                     },
@@ -185,6 +185,7 @@ class DraftsScreen : Screen {
                                             initialTitle = draft.title,
                                             initialUrl = draft.url,
                                             initialNsfw = draft.nsfw,
+                                            forceCommunitySelection = true,
                                         )
                                     },
                                     options = buildList {

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/components/DraftCard.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/components/DraftCard.kt
@@ -58,7 +58,7 @@ fun DraftCard(
     postLayout: PostLayout,
     modifier: Modifier = Modifier,
     options: List<Option> = emptyList(),
-    onOpen: (() -> Unit?)? = null,
+    onOpen: () -> Unit,
     onOptionSelected: ((OptionId) -> Unit)? = null,
 ) {
     Box(
@@ -76,11 +76,7 @@ fun DraftCard(
             } else {
                 Modifier.background(MaterialTheme.colorScheme.background)
             }
-        ).onClick(
-            onClick = rememberCallback {
-                onOpen?.invoke()
-            },
-        ),
+        ).onClick(onClick = onOpen),
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
@@ -118,6 +114,7 @@ fun DraftCard(
                             horizontal = Spacing.xs,
                         ),
                         text = title,
+                        onClick = onOpen,
                     )
                 }
             }
@@ -128,7 +125,8 @@ fun DraftCard(
                         horizontal = Spacing.xs,
                     ),
                     text = draft.body,
-                    maxLines = 50,
+                    maxLines = 40,
+                    onClick = onOpen
                 )
             }
             DraftFooter(

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -446,7 +446,10 @@ class PostDetailScreen(
                                         }
 
                                         OptionId.CrossPost -> {
-                                            detailOpener.openCreatePost(crossPost = uiState.post)
+                                            detailOpener.openCreatePost(
+                                                crossPost = uiState.post,
+                                                forceCommunitySelection = true,
+                                            )
                                         }
 
                                         OptionId.SeeRaw -> {

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.ArrowCircleDown
 import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.ClearAll
+import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.SyncDisabled
@@ -268,6 +269,16 @@ class PostListScreen : Screen {
                                             topAppBarState.heightOffset = 0f
                                             topAppBarState.contentOffset = 0f
                                         }
+                                    },
+                                )
+
+                                this += FloatingActionButtonMenuItem(
+                                    icon = Icons.Default.Create,
+                                    text = LocalXmlStrings.current.actionCreatePost,
+                                    onSelected = rememberCallback {
+                                        detailOpener.openCreatePost(
+                                            forceCommunitySelection = true,
+                                        )
                                     },
                                 )
                             }
@@ -565,7 +576,10 @@ class PostListScreen : Screen {
                                                 }
 
                                                 OptionId.CrossPost -> {
-                                                    detailOpener.openCreatePost(crossPost = post)
+                                                    detailOpener.openCreatePost(
+                                                        crossPost = post,
+                                                        forceCommunitySelection = true,
+                                                    )
                                                 }
 
                                                 OptionId.SeeRaw -> {

--- a/unit/selectcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/selectcommunity/SelectCommunityDialog.kt
+++ b/unit/selectcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/selectcommunity/SelectCommunityDialog.kt
@@ -108,7 +108,7 @@ class SelectCommunityDialog : Screen {
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 500.dp, max = 500.dp)
-                        .padding(horizontal = Spacing.m)
+                        .padding(horizontal = Spacing.xs)
                 ) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -699,7 +699,8 @@ class UserDetailScreen(
 
                                                 OptionId.CrossPost -> {
                                                     detailOpener.openCreatePost(
-                                                        crossPost = post
+                                                        crossPost = post,
+                                                        forceCommunitySelection = true,
                                                     )
                                                 }
 


### PR DESCRIPTION
A user has complained recently about not being able to create posts, because it's difficult to understand that you have to be inside a community to create one (in that community).

This PR makes it possible for logged users to create posts even from the home screen, but they will have to manually select the community in a similar fashion to what happens for cross posts.