### PR TITLE
feat: select default language for new posts and comments

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/TextFormattingBar.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/TextFormattingBar.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.FormatListBulleted
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.FormatBold
 import androidx.compose.material.icons.filled.FormatItalic
-import androidx.compose.material.icons.filled.FormatListBulleted
 import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.FormatStrikethrough
@@ -367,7 +367,7 @@ fun TextFormattingBar(
                         onTextFieldValueChanged(newValue)
                     },
                 ),
-                imageVector = Icons.Filled.FormatListBulleted,
+                imageVector = Icons.AutoMirrored.Filled.FormatListBulleted,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
             )

--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">التصويتات المؤيدة &amp; التصويت السلبي</string>
     <string name="filtered_contents_type">نوع المحتوى</string>
     <string name="action_search_in_comments">البحث في التعليقات</string>
+    <string name="advanced_settings_default_language">للغة الافتراضية في المحرر</string>
+    <string name="undetermined">غير معرف</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Гласове за &amp; гласове против</string>
     <string name="filtered_contents_type">Тип съдържание</string>
     <string name="action_search_in_comments">Търсете в коментарите</string>
+    <string name="advanced_settings_default_language">Език по подразбиране в редактора</string>
+    <string name="undetermined">Недефиниран</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Hlasy pro &amp; záporné hlasy</string>
     <string name="filtered_contents_type">Typ obsahu</string>
     <string name="action_search_in_comments">Hledejte v komentářích</string>
+    <string name="advanced_settings_default_language">Výchozí jazyk v editoru</string>
+    <string name="undetermined">Nedefinováno</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Opstemmer &amp; nedstemmer</string>
     <string name="filtered_contents_type">Indholdstype</string>
     <string name="action_search_in_comments">Søg i kommentarer</string>
+    <string name="advanced_settings_default_language">Standardsprog i editoren</string>
+    <string name="undetermined">Udefineret</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Upvotes &amp; Downvotes</string>
     <string name="filtered_contents_type">Inhaltstyp</string>
     <string name="action_search_in_comments">Suche in Kommentaren</string>
+    <string name="advanced_settings_default_language">Standardsprache im Editor</string>
+    <string name="undetermined">Nicht definiert</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">θετικές &amp; αρνητικές ψήφοι</string>
     <string name="filtered_contents_type">Τύπος περιεχομένου</string>
     <string name="action_search_in_comments">Αναζήτηση στα σχόλια</string>
+    <string name="advanced_settings_default_language">Προεπιλεγμένη γλώσσα στο πρόγραμμα επεξεργασίας</string>
+    <string name="undetermined">Απροσδιόριστος</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Favoraj &amp; malfavoraj voĉoj</string>
     <string name="filtered_contents_type">Enhavo tipo</string>
     <string name="action_search_in_comments">Serĉi en komentoj</string>
+    <string name="advanced_settings_default_language">Defaŭlta lingvo en la redaktilo</string>
+    <string name="undetermined">Nedifinita</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Votos positivos &amp; negativos</string>
     <string name="filtered_contents_type">Tipo de contenido</string>
     <string name="action_search_in_comments">Buscar en comentarios</string>
+    <string name="advanced_settings_default_language">Idioma predeterminado en el editor</string>
+    <string name="undetermined">Indefinido</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Poolthääled &amp; miinushääli</string>
     <string name="filtered_contents_type">Sisu tüüp</string>
     <string name="action_search_in_comments">Otsi kommentaaridest</string>
+    <string name="advanced_settings_default_language">Vaikimisi keel redaktoris</string>
+    <string name="undetermined">Määratlemata</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Plussat &amp; miinusääniä</string>
     <string name="filtered_contents_type">Sisältötyyppi</string>
     <string name="action_search_in_comments">Hae kommenteista</string>
+    <string name="advanced_settings_default_language">Editorin oletuskieli</string>
+    <string name="undetermined">Määrittämätön</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Votes positifs &amp; négatifs</string>
     <string name="filtered_contents_type">Type de contenu</string>
     <string name="action_search_in_comments">Rechercher dans les commentaires</string>
+    <string name="advanced_settings_default_language">Langue par défaut dans l\'éditeur</string>
+    <string name="undetermined">Indéfini</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Vótaí &amp; vótaí anuas</string>
     <string name="filtered_contents_type">Cineál ábhair</string>
     <string name="action_search_in_comments">Cuardaigh i dtuairimí</string>
+    <string name="advanced_settings_default_language">Teanga réamhshocraithe san eagarthóir</string>
+    <string name="undetermined">Neamhshainithe</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Glasovi za &amp; glasovi protiv</string>
     <string name="filtered_contents_type">Vrsta sadržaja</string>
     <string name="action_search_in_comments">Tražite u komentarima</string>
+    <string name="advanced_settings_default_language">Zadani jezik u uređivaču</string>
+    <string name="undetermined">Nedefiniran</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Pozitív szavazatok &amp; negatív szavazatok</string>
     <string name="filtered_contents_type">Tartalom típus</string>
     <string name="action_search_in_comments">Keress a megjegyzésekben</string>
+    <string name="advanced_settings_default_language">Alapértelmezett nyelv a szerkesztőben</string>
+    <string name="undetermined">Határozatlan</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Voti positivi &amp; negativi</string>
     <string name="filtered_contents_type">Tipo di contenuto</string>
     <string name="action_search_in_comments">Cerca nei commenti</string>
+    <string name="advanced_settings_default_language">Lingua di default nell\'editor</string>
+    <string name="undetermined">Non definito</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Balsavimai &amp; neigiamų balsų</string>
     <string name="filtered_contents_type">Turinio tipas</string>
     <string name="action_search_in_comments">Ieškokite komentaruose</string>
+    <string name="advanced_settings_default_language">Numatytoji kalba redaktoriuje</string>
+    <string name="undetermined">Neapibrėžtas</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Apbalvojumi &amp; negatīvie balsojumi</string>
     <string name="filtered_contents_type">Satura veids</string>
     <string name="action_search_in_comments">Meklējiet komentāros</string>
+    <string name="advanced_settings_default_language">Redaktora noklusējuma valoda</string>
+    <string name="undetermined">nenoteikts</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Voti pożittivi &amp; negattivi</string>
     <string name="filtered_contents_type">Tip ta\' kontenut</string>
     <string name="action_search_in_comments">Fittex fil-kummenti</string>
+    <string name="advanced_settings_default_language">Lingwa default fl-editur</string>
+    <string name="undetermined">Mhux definit</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Stemmen &amp; tegenstemmen</string>
     <string name="filtered_contents_type">Inhoudstype</string>
     <string name="action_search_in_comments">Zoek in opmerkingen</string>
+    <string name="advanced_settings_default_language">Standaardtaal in de editor</string>
+    <string name="undetermined">Ongedefinieerd</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Oppstemmer &amp; nedstemmer</string>
     <string name="filtered_contents_type">Innholdstype</string>
     <string name="action_search_in_comments">Søk i kommentarfeltet</string>
+    <string name="advanced_settings_default_language">Standardspråk i editoren</string>
+    <string name="undetermined">Udefinert</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Głosy za i głosów przeciwnych</string>
     <string name="filtered_contents_type">Typ zawartości</string>
     <string name="action_search_in_comments">Szukaj w komentarzach</string>
+    <string name="advanced_settings_default_language">Domyślny język w edytorze</string>
+    <string name="undetermined">Nieokreślony</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Votos positivos &amp; negativos</string>
     <string name="filtered_contents_type">Tipo de conteúdo</string>
     <string name="action_search_in_comments">Pesquisar nos comentários</string>
+    <string name="advanced_settings_default_language">Idioma padrão no editor</string>
+    <string name="undetermined">Indefinido</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Votos positivos &amp; negativos</string>
     <string name="filtered_contents_type">Tipo de conteúdo</string>
     <string name="action_search_in_comments">Pesquisar nos comentários</string>
+    <string name="advanced_settings_default_language">Idioma padrão no editor</string>
+    <string name="undetermined">Indefinido</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Voturi pozitive &amp; voturi negative</string>
     <string name="filtered_contents_type">Tipul de conținut</string>
     <string name="action_search_in_comments">Căută în comentarii</string>
+    <string name="advanced_settings_default_language">Limba implicită în editor</string>
+    <string name="undetermined">Nedefinit</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -355,4 +355,6 @@
     <string name="profile_upvotes_downvotes">Голоса за &amp; отрицательные голоса</string>
     <string name="filtered_contents_type">Тип содержимого</string>
     <string name="action_search_in_comments">Искать в комментариях</string>
+    <string name="advanced_settings_default_language">Язык по умолчанию в редакторе</string>
+    <string name="undetermined">Неопределенный</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Uppröster &amp; nedröster</string>
     <string name="filtered_contents_type">Innehållstyp</string>
     <string name="action_search_in_comments">Sök i kommentarer</string>
+    <string name="advanced_settings_default_language">Standardspråk i editorn</string>
+    <string name="undetermined">Odefinierad</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Hlasy za &amp; záporné hlasy</string>
     <string name="filtered_contents_type">Druh obsahu</string>
     <string name="action_search_in_comments">Hľadajte v komentároch</string>
+    <string name="advanced_settings_default_language">Predvolený jazyk v editore</string>
+    <string name="undetermined">Nedefinované</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Glasovi za &amp; glasovi proti</string>
     <string name="filtered_contents_type">Vrsta vsebine</string>
     <string name="action_search_in_comments">Išči v komentarjih</string>
+    <string name="advanced_settings_default_language">Privzeti jezik v urejevalniku</string>
+    <string name="undetermined">Nedoločeno</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Vota pozitive &amp; vota kundër</string>
     <string name="filtered_contents_type">Lloji i përmbajtjes</string>
     <string name="action_search_in_comments">Kërkoni në komente</string>
+    <string name="advanced_settings_default_language">Gjuha e parazgjedhur në redaktues</string>
+    <string name="undetermined">E papërcaktuar</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sr/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Гласови за &amp; довнвотес</string>
     <string name="filtered_contents_type">Тип садржаја</string>
     <string name="action_search_in_comments">Тражи у коментарима</string>
+    <string name="advanced_settings_default_language">Подразумевани језик у уређивачу</string>
+    <string name="undetermined">Недефинисан</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">pana wile pona &amp; ike</string>
     <string name="filtered_contents_type">nasin</string>
     <string name="action_search_in_comments">o lukin lon toki lili</string>
+    <string name="advanced_settings_default_language">toki pi ilo sitelen</string>
+    <string name="undetermined">sona ala</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Olumlu oylar &amp; olumsuz oylar</string>
     <string name="filtered_contents_type">İçerik türü</string>
     <string name="action_search_in_comments">Yorumlarda ara</string>
+    <string name="advanced_settings_default_language">Düzenleyicideki varsayılan dil</string>
+    <string name="undetermined">Tanımsız</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -355,4 +355,6 @@
     <string name="profile_upvotes_downvotes">Голоси за &amp; голоси проти</string>
     <string name="filtered_contents_type">Тип вмісту</string>
     <string name="action_search_in_comments">Шукайте в коментарях</string>
+    <string name="advanced_settings_default_language">Мова за замовчуванням у редакторі</string>
+    <string name="undetermined">Невизначено</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -356,4 +356,6 @@
     <string name="profile_upvotes_downvotes">Upvotes &amp; downvotes</string>
     <string name="filtered_contents_type">Content type</string>
     <string name="action_search_in_comments">Search in comments</string>
+    <string name="advanced_settings_default_language">Default language in editor</string>
+    <string name="undetermined">Undefined</string>
 </resources>

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
@@ -55,4 +55,5 @@ data class SettingsModel(
     val preferUserNicknames: Boolean = true,
     val commentBarThickness: Int = 1,
     val imageSourcePath: Boolean = false,
+    val defaultLanguageId: Int? = null,
 )

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -58,6 +58,7 @@ private object KeyStoreKeys {
     const val PREFER_USER_NICKNAMES = "preferUserNicknames"
     const val COMMENT_BAR_THICKNESS = "commentBarThickness"
     const val IMAGE_SOURCE_PATH = "imageSourcePath"
+    const val DEFAULT_LANGUAGE_ID = "defaultLanguageId"
 }
 
 internal class DefaultSettingsRepository(
@@ -130,6 +131,7 @@ internal class DefaultSettingsRepository(
                 commentBarThickness = settings.commentBarThickness.toLong(),
                 imageSourcePath = if (settings.imageSourcePath) 1L else 0L,
                 defaultExploreType = settings.defaultExploreType.toLong(),
+                defaultLanguageId = settings.defaultLanguageId?.toLong(),
             )
         }
 
@@ -186,6 +188,9 @@ internal class DefaultSettingsRepository(
                     preferUserNicknames = keyStore[KeyStoreKeys.PREFER_USER_NICKNAMES, true],
                     commentBarThickness = keyStore[KeyStoreKeys.COMMENT_BAR_THICKNESS, 1],
                     imageSourcePath = keyStore[KeyStoreKeys.IMAGE_SOURCE_PATH, false],
+                    defaultLanguageId = if (keyStore.containsKey(KeyStoreKeys.DEFAULT_LANGUAGE_ID)) {
+                        keyStore[KeyStoreKeys.DEFAULT_LANGUAGE_ID, 0]
+                    } else null,
                 )
             } else {
                 val entity = db.settingsQueries.getBy(accountId).executeAsOneOrNull()
@@ -288,6 +293,11 @@ internal class DefaultSettingsRepository(
                 keyStore.save(KeyStoreKeys.PREFER_USER_NICKNAMES, settings.preferUserNicknames)
                 keyStore.save(KeyStoreKeys.COMMENT_BAR_THICKNESS, settings.commentBarThickness)
                 keyStore.save(KeyStoreKeys.IMAGE_SOURCE_PATH, settings.imageSourcePath)
+                if (settings.defaultLanguageId != null) {
+                    keyStore.save(KeyStoreKeys.DEFAULT_LANGUAGE_ID, settings.defaultLanguageId)
+                } else {
+                    keyStore.remove(KeyStoreKeys.DEFAULT_LANGUAGE_ID)
+                }
             } else {
                 db.settingsQueries.update(
                     theme = settings.theme?.toLong(),
@@ -348,6 +358,7 @@ internal class DefaultSettingsRepository(
                     commentBarThickness = settings.commentBarThickness.toLong(),
                     imageSourcePath = if (settings.imageSourcePath) 1L else 0L,
                     defaultExploreType = settings.defaultExploreType.toLong(),
+                    defaultLanguageId = settings.defaultLanguageId?.toLong(),
                 )
             }
         }
@@ -424,4 +435,5 @@ private fun GetBy.toModel() = SettingsModel(
     commentBarThickness = commentBarThickness.toInt(),
     imageSourcePath = imageSourcePath == 1L,
     defaultExploreType = defaultExploreType.toInt(),
+    defaultLanguageId = defaultLanguageId?.toInt(),
 )

--- a/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
@@ -52,6 +52,7 @@ CREATE TABLE SettingsEntity (
     commentBarThickness INTEGER NOT NULL DEFAULT 0,
     imageSourcePath INTEGER NOT NULL DEFAULT 0,
     defaultExploreType INTEGER NOT NULL DEFAULT 2,
+    defaultLanguageId INTEGER DEFAULT NULL,
     FOREIGN KEY (account_id) REFERENCES AccountEntity(id) ON DELETE CASCADE,
     UNIQUE(account_id)
 );
@@ -109,8 +110,10 @@ INSERT OR IGNORE INTO SettingsEntity (
     commentBarThickness,
     imageSourcePath,
     defaultExploreType,
+    defaultLanguageId,
     account_id
 ) VALUES (
+    ?,
     ?,
     ?,
     ?,
@@ -217,7 +220,8 @@ SET theme = ?,
     preferUserNicknames = ?,
     commentBarThickness = ?,
     imageSourcePath = ?,
-    defaultExploreType = ?
+    defaultExploreType = ?,
+    defaultLanguageId = ?
 WHERE account_id = ?;
 
 getBy:
@@ -273,6 +277,7 @@ SELECT
     preferUserNicknames,
     commentBarThickness,
     imageSourcePath,
-    defaultExploreType
+    defaultExploreType,
+    defaultLanguageId
 FROM SettingsEntity
 WHERE account_id = ?;

--- a/core/persistence/src/commonMain/sqldelight/migrations/28.sqm
+++ b/core/persistence/src/commonMain/sqldelight/migrations/28.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE SettingsEntity
+ADD COLUMN  defaultLanguageId INTEGER DEFAULT NULL;

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.feature.settings.advanced
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.LanguageModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -21,6 +22,7 @@ interface AdvancedSettingsMviModel :
         data class ChangeEdgeToEdge(val value: Boolean) : Intent
         data class ChangeInfiniteScrollDisabled(val value: Boolean) : Intent
         data class ChangeImageSourcePath(val value: Boolean) : Intent
+        data class ChangeDefaultLanguage(val value: Int?) : Intent
     }
 
     data class UiState(
@@ -41,6 +43,8 @@ interface AdvancedSettingsMviModel :
         val opaqueSystemBars: Boolean = false,
         val imageSourceSupported: Boolean = true,
         val imageSourcePath: Boolean = false,
+        val defaultLanguageId: Int? = null,
+        val availableLanguages: List<LanguageModel> = emptyList(),
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -45,6 +45,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.BarThemeBot
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.DurationBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.InboxTypeSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.ListingTypeBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectLanguageDialog
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SliderBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -68,6 +69,7 @@ class AdvancedSettingsScreen : Screen {
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
         val scrollState = rememberScrollState()
         var screenWidth by remember { mutableStateOf(0f) }
+        var languageDialogOpened by remember { mutableStateOf(false) }
 
         Scaffold(
             modifier = Modifier
@@ -198,6 +200,20 @@ class AdvancedSettingsScreen : Screen {
                         )
                     }
 
+                    // default language
+                    val languageValue = uiState.availableLanguages.firstOrNull { l ->
+                        l.id == uiState.defaultLanguageId
+                    }?.takeIf { l ->
+                        l.id > 0 // undetermined language
+                    }?.name ?: LocalXmlStrings.current.undetermined
+                    SettingsRow(
+                        title = LocalXmlStrings.current.advancedSettingsDefaultLanguage,
+                        value = languageValue,
+                        onTap = rememberCallback {
+                            languageDialogOpened = true
+                        },
+                    )
+
                     // infinite scrolling
                     SettingsSwitchRow(
                         title = LocalXmlStrings.current.settingsInfiniteScrollDisabled,
@@ -327,6 +343,19 @@ class AdvancedSettingsScreen : Screen {
                     )
                 }
             }
+        }
+
+        if (languageDialogOpened) {
+            SelectLanguageDialog(
+                currentLanguageId = uiState.defaultLanguageId,
+                languages = uiState.availableLanguages,
+                onSelect = { languageId ->
+                    model.reduce(AdvancedSettingsMviModel.Intent.ChangeDefaultLanguage(languageId))
+                },
+                onDismiss = {
+                    languageDialogOpened = false
+                }
+            )
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/di/SettingsModule.kt
@@ -41,6 +41,7 @@ val settingsTabModule = module {
             identityRepository = get(),
             notificationCenter = get(),
             galleryHelper = get(),
+            siteRepository = get(),
         )
     }
 }

--- a/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentViewModel.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentViewModel.kt
@@ -95,6 +95,7 @@ class CreateCommentViewModel(
                         preferNicknames = settings.preferUserNicknames,
                         fullHeightImages = settings.fullHeightImages,
                         showScores = settings.showScores,
+                        currentLanguageId = settings.defaultLanguageId,
                     )
                 }
             }.launchIn(this)

--- a/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostViewModel.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostViewModel.kt
@@ -64,6 +64,7 @@ class CreatePostViewModel(
                         preferNicknames = settings.preferUserNicknames,
                         fullHeightImages = settings.fullHeightImages,
                         showScores = settings.showScores,
+                        currentLanguageId = settings.defaultLanguageId,
                     )
                 }
             }.launchIn(this)


### PR DESCRIPTION
This PR adds the selection of a default language to use for newly created posts and comments in the "Advanced settings screen".

This language will be the preselected one in the formatting toolbar when composing posts and comments. It will be possible at any time to reset the selection to the "Underdermined" predefined language.