### PR TITLE
feat: explore other instance

### DIFF
--- a/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
+++ b/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
@@ -74,7 +74,7 @@ class DefaultDetailOpenerTest {
         val community = CommunityModel(name = communityName, id = 1, host = otherInstance)
         every { identityRepository.authToken } returns MutableStateFlow(token)
         coEvery {
-            communityRepository.getAll(
+            communityRepository.search(
                 query = any(),
                 auth = any(),
                 page = any(),
@@ -94,7 +94,7 @@ class DefaultDetailOpenerTest {
                     assertIs<CommunityDetailScreen>(it)
                 },
             )
-            communityRepository.getAll(
+            communityRepository.search(
                 query = communityName,
                 auth = token,
                 page = any(),

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -165,7 +165,7 @@ class DefaultDetailOpener(
         val auth = identityRepository.authToken.value
 
         tailrec suspend fun searchRec(page: Int = 0): CommunityModel? {
-            val results = communityRepository.getAll(
+            val results = communityRepository.search(
                 auth = auth,
                 query = name,
                 resultType = SearchResultType.Communities,

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -40,11 +40,12 @@ class DefaultDetailOpener(
             val (actualCommunity, actualInstance) = withContext(Dispatchers.IO) {
                 val defaultResult = community to otherInstance
                 if (otherInstance.isEmpty()) {
-                    return@withContext defaultResult
-                }
-                val found = searchCommunity(name = community.name, host = otherInstance)
-                if (found != null) {
-                    found to ""
+                    val found = searchCommunity(name = community.name, host = otherInstance)
+                    if (found != null) {
+                        found to ""
+                    } else {
+                        defaultResult
+                    }
                 } else {
                     defaultResult
                 }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/Options.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/Options.kt
@@ -32,4 +32,5 @@ sealed class OptionId(val value: Int) {
     data object SetCustomSort : OptionId(24)
     data object Search : OptionId(25)
     data object Copy : OptionId(26)
+    data object ExploreInstance : OptionId(27)
 }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
@@ -13,12 +13,13 @@ interface CommunityRepository {
         const val DEFAULT_PAGE_SIZE = 20
     }
 
-    suspend fun getAll(
+    suspend fun search(
         query: String = "",
         auth: String? = null,
         page: Int,
         limit: Int = DEFAULT_PAGE_SIZE,
         communityId: Int? = null,
+        instance: String? = null,
         listingType: ListingType = ListingType.All,
         sortType: SortType = SortType.Active,
         resultType: SearchResultType = SearchResultType.All,

--- a/unit/communitydetail/build.gradle.kts
+++ b/unit/communitydetail/build.gradle.kts
@@ -55,18 +55,19 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.repository)
 
-                implementation(projects.unit.zoomableimage)
-                implementation(projects.unit.web)
-                implementation(projects.unit.createreport)
-                implementation(projects.unit.createcomment)
-                implementation(projects.unit.createpost)
-                implementation(projects.unit.remove)
                 implementation(projects.unit.ban)
                 implementation(projects.unit.communityinfo)
+                implementation(projects.unit.createcomment)
+                implementation(projects.unit.createpost)
+                implementation(projects.unit.createreport)
+                implementation(projects.unit.explore)
                 implementation(projects.unit.instanceinfo)
-                implementation(projects.unit.reportlist)
                 implementation(projects.unit.modlog)
                 implementation(projects.unit.rawcontent)
+                implementation(projects.unit.remove)
+                implementation(projects.unit.reportlist)
+                implementation(projects.unit.web)
+                implementation(projects.unit.zoomableimage)
             }
         }
         val commonTest by getting {

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.animateScrollBy
@@ -127,6 +126,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.unit.ban.BanUserScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.communityinfo.CommunityInfoScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.createreport.CreateReportScreen
+import com.github.diegoberaldin.raccoonforlemmy.unit.explore.ExploreScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.instanceinfo.InstanceInfoScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.modlog.ModlogScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.rawcontent.RawContentDialog
@@ -147,7 +147,7 @@ class CommunityDetailScreen(
     override val key: ScreenKey
         get() = super.key + communityId.toString()
 
-    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable
     override fun Content() {
         val model = getScreenModel<CommunityDetailMviModel>(
@@ -339,6 +339,17 @@ class CommunityDetailScreen(
                                     LocalXmlStrings.current.communityDetailInstanceInfo
                                 )
                                 this += Option(
+                                    OptionId.ExploreInstance,
+                                    buildString {
+                                        append(LocalXmlStrings.current.navigationSearch)
+                                        append(" ")
+                                        append(uiState.community.host)
+                                        append(" (")
+                                        append(LocalXmlStrings.current.beta)
+                                        append(")")
+                                    },
+                                )
+                                this += Option(
                                     OptionId.Share, LocalXmlStrings.current.postActionShare
                                 )
                                 if (uiState.isLogged) {
@@ -479,6 +490,11 @@ class CommunityDetailScreen(
 
                                                 OptionId.Search -> {
                                                     model.reduce(CommunityDetailMviModel.Intent.ChangeSearching(!uiState.searching))
+                                                }
+
+                                                OptionId.ExploreInstance -> {
+                                                    val screen = ExploreScreen(otherInstance = uiState.community.host)
+                                                    navigationCoordinator.pushScreen(screen)
                                                 }
 
                                                 else -> Unit
@@ -754,12 +770,12 @@ class CommunityDetailScreen(
                                     onGestureBegin = rememberCallback(model) {
                                         model.reduce(CommunityDetailMviModel.Intent.HapticIndication)
                                     },
-                                    swipeToStartActions = if (uiState.isLogged) {
+                                    swipeToStartActions = if (uiState.isLogged && !isOnOtherInstance) {
                                         uiState.actionsOnSwipeToStartPosts.toSwipeActions()
                                     } else {
                                         emptyList()
                                     },
-                                    swipeToEndActions = if (uiState.isLogged) {
+                                    swipeToEndActions = if (uiState.isLogged && !isOnOtherInstance) {
                                         uiState.actionsOnSwipeToEndPosts.toSwipeActions()
                                     } else {
                                         emptyList()

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -390,7 +390,7 @@ class CommunityDetailScreen(
                             Image(
                                 modifier = Modifier.onGloballyPositioned {
                                     optionsOffset = it.positionInParent()
-                                }.padding(start = Spacing.s).onClick(
+                                }.onClick(
                                     onClick = rememberCallback {
                                         optionsExpanded = true
                                     },

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -352,7 +352,7 @@ class CommunityDetailViewModel(
         val includeNsfw = settingsRepository.currentSettings.value.includeNsfw
 
         val (itemList, nextPage) = if (currentState.searching) {
-            communityRepository.getAll(
+            communityRepository.search(
                 auth = auth,
                 communityId = community.id,
                 page = currentPage,

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -34,15 +35,30 @@ internal fun ExploreTopBar(
     listingType: ListingType,
     sortType: SortType,
     resultType: SearchResultType,
+    otherInstance: String = "",
     onSelectListingType: (() -> Unit)? = null,
     onSelectSortType: (() -> Unit)? = null,
     onSelectResultTypeType: (() -> Unit)? = null,
     onHamburgerTapped: (() -> Unit)? = null,
+    onBack: (() -> Unit)? = null,
 ) {
     TopAppBar(
         scrollBehavior = scrollBehavior,
         navigationIcon = {
             when {
+                otherInstance.isNotEmpty() -> {
+                    Image(
+                        modifier = Modifier.onClick(
+                            onClick = rememberCallback {
+                                onBack?.invoke()
+                            },
+                        ),
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                    )
+                }
+
                 onHamburgerTapped != null -> {
                     Image(
                         modifier = Modifier.onClick(
@@ -77,18 +93,29 @@ internal fun ExploreTopBar(
                     .padding(horizontal = Spacing.s)
                     .onClick(
                         onClick = rememberCallback {
-                            onSelectListingType?.invoke()
+                            if (otherInstance.isEmpty()) {
+                                onSelectListingType?.invoke()
+                            }
                         },
                     ),
             ) {
                 Text(
-                    text = LocalXmlStrings.current.navigationSearch,
+                    text = buildString {
+                        append(LocalXmlStrings.current.navigationSearch)
+                        if (otherInstance.isNotEmpty()) {
+                            append(" (")
+                            append(otherInstance)
+                            append(")")
+                        }
+                    },
                     style = MaterialTheme.typography.titleMedium,
                 )
-                Text(
-                    text = listingType.toReadableName(),
-                    style = MaterialTheme.typography.titleSmall,
-                )
+                if (otherInstance.isEmpty()) {
+                    Text(
+                        text = listingType.toReadableName(),
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                }
             }
         },
         actions = {

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/di/ExploreModule.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/di/ExploreModule.kt
@@ -5,8 +5,9 @@ import com.github.diegoberaldin.raccoonforlemmy.unit.explore.ExploreViewModel
 import org.koin.dsl.module
 
 val exploreModule = module {
-    factory<ExploreMviModel> {
+    factory<ExploreMviModel> { params ->
         ExploreViewModel(
+            otherInstance = params[0],
             apiConfigRepository = get(),
             identityRepository = get(),
             communityRepository = get(),

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -293,7 +293,7 @@ class PostDetailScreen(
                             Image(
                                 modifier = Modifier.onGloballyPositioned {
                                     optionsOffset = it.positionInParent()
-                                }.padding(start = Spacing.s).onClick(
+                                }.onClick(
                                     onClick = rememberCallback {
                                         optionsExpanded = true
                                     },

--- a/unit/userdetail/build.gradle.kts
+++ b/unit/userdetail/build.gradle.kts
@@ -55,16 +55,17 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.repository)
 
-                implementation(projects.unit.zoomableimage)
-                implementation(projects.unit.web)
-                implementation(projects.unit.createreport)
-                implementation(projects.unit.createcomment)
-                implementation(projects.unit.createpost)
-                implementation(projects.unit.remove)
                 implementation(projects.unit.ban)
                 implementation(projects.unit.chat)
-                implementation(projects.unit.userinfo)
+                implementation(projects.unit.createcomment)
+                implementation(projects.unit.createpost)
+                implementation(projects.unit.createreport)
+                implementation(projects.unit.explore)
                 implementation(projects.unit.rawcontent)
+                implementation(projects.unit.remove)
+                implementation(projects.unit.userinfo)
+                implementation(projects.unit.web)
+                implementation(projects.unit.zoomableimage)
             }
         }
         val commonTest by getting {

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -281,7 +281,7 @@ class UserDetailScreen(
                             Image(
                                 modifier = Modifier.onGloballyPositioned {
                                     optionsOffset = it.positionInParent()
-                                }.padding(start = Spacing.s).onClick(
+                                }.onClick(
                                     onClick = rememberCallback {
                                         optionsExpanded = true
                                     },

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -113,6 +113,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.unit.chat.InboxChatScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.createreport.CreateReportScreen
+import com.github.diegoberaldin.raccoonforlemmy.unit.explore.ExploreScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.rawcontent.RawContentDialog
 import com.github.diegoberaldin.raccoonforlemmy.unit.userinfo.UserInfoScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.web.WebViewScreen
@@ -246,10 +247,23 @@ class UserDetailScreen(
                         Box {
                             val options = buildList {
                                 this += Option(
-                                    OptionId.Info, LocalXmlStrings.current.userDetailInfo
+                                    OptionId.Info,
+                                    LocalXmlStrings.current.userDetailInfo
                                 )
                                 this += Option(
-                                    OptionId.Share, LocalXmlStrings.current.postActionShare
+                                    OptionId.ExploreInstance,
+                                    buildString {
+                                        append(LocalXmlStrings.current.navigationSearch)
+                                        append(" ")
+                                        append(uiState.user.host)
+                                        append(" (")
+                                        append(LocalXmlStrings.current.beta)
+                                        append(")")
+                                    },
+                                )
+                                this += Option(
+                                    OptionId.Share,
+                                    LocalXmlStrings.current.postActionShare
                                 )
                                 if (uiState.isLogged) {
                                     this += Option(
@@ -294,18 +308,16 @@ class UserDetailScreen(
                                         onClick = rememberCallback {
                                             optionsExpanded = false
                                             when (option.id) {
-                                                OptionId.BlockInstance -> model.reduce(
-                                                    UserDetailMviModel.Intent.BlockInstance
-                                                )
+                                                OptionId.BlockInstance -> {
+                                                    model.reduce(UserDetailMviModel.Intent.BlockInstance)
+                                                }
 
-                                                OptionId.Block -> model.reduce(
-                                                    UserDetailMviModel.Intent.Block
-                                                )
+                                                OptionId.Block -> {
+                                                    model.reduce(UserDetailMviModel.Intent.Block)
+                                                }
 
                                                 OptionId.Info -> {
-                                                    navigationCoordinator.showBottomSheet(
-                                                        UserInfoScreen(uiState.user.id),
-                                                    )
+                                                    navigationCoordinator.showBottomSheet(UserInfoScreen(uiState.user.id))
                                                 }
 
                                                 OptionId.Share -> {
@@ -317,17 +329,17 @@ class UserDetailScreen(
                                                     }
                                                     if (urls.size == 1) {
                                                         model.reduce(
-                                                            UserDetailMviModel.Intent.Share(
-                                                                urls.first()
-                                                            )
+                                                            UserDetailMviModel.Intent.Share(urls.first())
                                                         )
                                                     } else {
-                                                        val screen =
-                                                            ShareBottomSheet(urls = urls)
-                                                        navigationCoordinator.showBottomSheet(
-                                                            screen
-                                                        )
+                                                        val screen = ShareBottomSheet(urls = urls)
+                                                        navigationCoordinator.showBottomSheet(screen)
                                                     }
+                                                }
+
+                                                OptionId.ExploreInstance -> {
+                                                    val screen = ExploreScreen(otherInstance = uiState.user.host)
+                                                    navigationCoordinator.pushScreen(screen)
                                                 }
 
                                                 else -> Unit
@@ -495,9 +507,7 @@ class UserDetailScreen(
                                                 ?: defaultUpvoteColor,
                                             onTriggered = rememberCallback {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.UpVotePost(
-                                                        post.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.UpVotePost(post.id),
                                                 )
                                             },
                                         )
@@ -514,9 +524,7 @@ class UserDetailScreen(
                                                 ?: defaultDownVoteColor,
                                             onTriggered = rememberCallback {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.DownVotePost(
-                                                        post.id,
-                                                    )
+                                                    UserDetailMviModel.Intent.DownVotePost(post.id)
                                                 )
                                             },
                                         )
@@ -548,9 +556,7 @@ class UserDetailScreen(
                                                 ?: defaultSaveColor,
                                             onTriggered = rememberCallback {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.SavePost(
-                                                        id = post.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.SavePost(id = post.id),
                                                 )
                                             },
                                         )
@@ -609,9 +615,7 @@ class UserDetailScreen(
                                         } else {
                                             rememberCallback(model) {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.UpVotePost(
-                                                        id = post.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.UpVotePost(id = post.id),
                                                 )
                                             }
                                         },
@@ -620,9 +624,7 @@ class UserDetailScreen(
                                         } else {
                                             rememberCallback(model) {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.DownVotePost(
-                                                        id = post.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.DownVotePost(post.id),
                                                 )
                                             }
                                         },
@@ -631,28 +633,30 @@ class UserDetailScreen(
                                         } else {
                                             rememberCallback(model) {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.SavePost(
-                                                        id = post.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.SavePost(post.id),
                                                 )
                                             }
                                         },
                                         onOpenCommunity = rememberCallbackArgs { community, instance ->
                                             detailOpener.openCommunityDetail(
-                                                community,
-                                                instance,
+                                                community = community,
+                                                otherInstance = instance,
                                             )
                                         },
                                         onOpenCreator = rememberCallbackArgs { user, instance ->
-                                            detailOpener.openUserDetail(user, instance)
+                                            detailOpener.openUserDetail(
+                                                user = user,
+                                                otherInstance = instance
+                                            )
                                         },
                                         onOpenPost = rememberCallbackArgs { p, instance ->
-                                            detailOpener.openPostDetail(p, instance)
+                                            detailOpener.openPostDetail(
+                                                post = p,
+                                                otherInstance = instance
+                                            )
                                         },
                                         onOpenWeb = rememberCallbackArgs { url ->
-                                            navigationCoordinator.pushScreen(
-                                                WebViewScreen(url)
-                                            )
+                                            navigationCoordinator.pushScreen(WebViewScreen(url))
                                         },
                                         onReply = if (!uiState.isLogged || isOnOtherInstance) {
                                             null
@@ -697,9 +701,7 @@ class UserDetailScreen(
                                             when (optionId) {
                                                 OptionId.Report -> {
                                                     navigationCoordinator.pushScreen(
-                                                        CreateReportScreen(
-                                                            postId = post.id
-                                                        )
+                                                        CreateReportScreen(post.id)
                                                     )
                                                 }
 
@@ -721,16 +723,11 @@ class UserDetailScreen(
                                                     ).distinct()
                                                     if (urls.size == 1) {
                                                         model.reduce(
-                                                            UserDetailMviModel.Intent.Share(
-                                                                urls.first()
-                                                            )
+                                                            UserDetailMviModel.Intent.Share(urls.first())
                                                         )
                                                     } else {
-                                                        val screen =
-                                                            ShareBottomSheet(urls = urls)
-                                                        navigationCoordinator.showBottomSheet(
-                                                            screen
-                                                        )
+                                                        val screen = ShareBottomSheet(urls = urls)
+                                                        navigationCoordinator.showBottomSheet(screen)
                                                     }
                                                 }
 
@@ -803,9 +800,7 @@ class UserDetailScreen(
                                                 ?: defaultUpvoteColor,
                                             onTriggered = rememberCallback {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.UpVoteComment(
-                                                        comment.id
-                                                    )
+                                                    UserDetailMviModel.Intent.UpVoteComment(comment.id)
                                                 )
                                             },
                                         )
@@ -822,9 +817,7 @@ class UserDetailScreen(
                                                 ?: defaultDownVoteColor,
                                             onTriggered = rememberCallback {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.DownVoteComment(
-                                                        comment.id
-                                                    ),
+                                                    UserDetailMviModel.Intent.DownVoteComment(comment.id),
                                                 )
                                             },
                                         )
@@ -859,9 +852,7 @@ class UserDetailScreen(
                                                 ?: defaultSaveColor,
                                             onTriggered = rememberCallback {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.SaveComment(
-                                                        id = comment.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.SaveComment(comment.id),
                                                 )
                                             },
                                         )
@@ -930,9 +921,7 @@ class UserDetailScreen(
                                         } else {
                                             rememberCallback(model) {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.SaveComment(
-                                                        id = comment.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.SaveComment(comment.id),
                                                 )
                                             }
                                         },
@@ -941,9 +930,7 @@ class UserDetailScreen(
                                         } else {
                                             rememberCallback(model) {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.UpVoteComment(
-                                                        id = comment.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.UpVoteComment(comment.id),
                                                 )
                                             }
                                         },
@@ -952,9 +939,7 @@ class UserDetailScreen(
                                         } else {
                                             rememberCallback(model) {
                                                 model.reduce(
-                                                    UserDetailMviModel.Intent.DownVoteComment(
-                                                        id = comment.id,
-                                                    ),
+                                                    UserDetailMviModel.Intent.DownVoteComment(comment.id),
                                                 )
                                             }
                                         },
@@ -969,30 +954,35 @@ class UserDetailScreen(
                                             }
                                         },
                                         onOpenCommunity = rememberCallbackArgs { community, instance ->
-                                            detailOpener.openCommunityDetail(community, instance)
+                                            detailOpener.openCommunityDetail(
+                                                community = community,
+                                                otherInstance = instance
+                                            )
                                         },
                                         onOpenCreator = rememberCallbackArgs { user, instance ->
-                                            detailOpener.openUserDetail(user, instance)
+                                            detailOpener.openUserDetail(
+                                                user = user,
+                                                otherInstance = instance
+                                            )
                                         },
                                         onOpenPost = rememberCallbackArgs { post, instance ->
-                                            detailOpener.openPostDetail(post, instance)
+                                            detailOpener.openPostDetail(
+                                                post = post,
+                                                otherInstance = instance
+                                            )
                                         },
                                         onOpenWeb = rememberCallbackArgs { url ->
                                             navigationCoordinator.pushScreen(WebViewScreen(url))
                                         },
                                         options = buildList {
-                                            add(
-                                                Option(
-                                                    OptionId.SeeRaw,
-                                                    LocalXmlStrings.current.postActionSeeRaw
-                                                )
+                                            this += Option(
+                                                OptionId.SeeRaw,
+                                                LocalXmlStrings.current.postActionSeeRaw,
                                             )
                                             if (uiState.isLogged && !isOnOtherInstance) {
-                                                add(
-                                                    Option(
-                                                        OptionId.Report,
-                                                        LocalXmlStrings.current.postActionReport
-                                                    )
+                                                this += Option(
+                                                    OptionId.Report,
+                                                    LocalXmlStrings.current.postActionReport,
                                                 )
                                             }
                                         },
@@ -1000,9 +990,7 @@ class UserDetailScreen(
                                             when (optionId) {
                                                 OptionId.Report -> {
                                                     navigationCoordinator.pushScreen(
-                                                        CreateReportScreen(
-                                                            commentId = comment.id
-                                                        ),
+                                                        CreateReportScreen(comment.id),
                                                     )
                                                 }
 
@@ -1146,7 +1134,8 @@ class UserDetailScreen(
                                     },
                                 )
                             }
-                        })
+                        },
+                    )
                 }
             }
         }


### PR DESCRIPTION
This PR makes use of the "new" modularized explore screen introduced in #619 to open an "Explore instance" screen from a community or user detail.

This will make it possible to search local posts, community, users, etc. as guests on other instances.