### PR TITLE
enhancement: notify subscription event

### DIFF
--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -90,4 +90,6 @@ sealed interface NotificationCenterEvent {
 
     data class ChangeSearchResultType(val value: SearchResultType, val screenKey: String?) :
         NotificationCenterEvent
+
+    data class CommunitySubscriptionChanged(val value: CommunityModel) : NotificationCenterEvent
 }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -556,6 +556,7 @@ class CommunityDetailViewModel(
             )
             if (community != null) {
                 updateState { it.copy(community = community) }
+                notificationCenter.send(NotificationCenterEvent.CommunitySubscriptionChanged(community))
             }
         }
     }
@@ -569,6 +570,7 @@ class CommunityDetailViewModel(
             )
             if (community != null) {
                 updateState { it.copy(community = community) }
+                notificationCenter.send(NotificationCenterEvent.CommunitySubscriptionChanged(community))
             }
         }
     }

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsViewModel.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsViewModel.kt
@@ -44,10 +44,12 @@ class ManageSubscriptionsViewModel(
                     )
                 }
             }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.MultiCommunityCreated::class)
-                .onEach { evt ->
-                    handleMultiCommunityCreated(evt.model)
-                }.launchIn(this)
+            notificationCenter.subscribe(NotificationCenterEvent.MultiCommunityCreated::class).onEach { evt ->
+                handleMultiCommunityCreated(evt.model)
+            }.launchIn(this)
+            notificationCenter.subscribe(NotificationCenterEvent.CommunitySubscriptionChanged::class).onEach { evt ->
+                handleCommunityUpdate(evt.value)
+            }.launchIn(this)
         }
         if (uiState.value.communities.isEmpty()) {
             refresh()
@@ -60,7 +62,7 @@ class ManageSubscriptionsViewModel(
             ManageSubscriptionsMviModel.Intent.Refresh -> refresh()
             is ManageSubscriptionsMviModel.Intent.Unsubscribe -> {
                 uiState.value.communities.firstOrNull { it.id == intent.id }?.also { community ->
-                    handleUnsubscription(community)
+                    unsubscribe(community)
                 }
             }
 
@@ -108,7 +110,7 @@ class ManageSubscriptionsViewModel(
         }
     }
 
-    private fun handleUnsubscription(community: CommunityModel) {
+    private fun unsubscribe(community: CommunityModel) {
         screenModelScope.launch(Dispatchers.IO) {
             val auth = identityRepository.authToken.value
             communityRepository.unsubscribe(


### PR DESCRIPTION
This PR adds a notification to make sure the Explore screen and manage subscription screen are in sync if a subscription changes from the community detail.