### PR TITLE
fix: multi community behaviour

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommunityItem.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommunityItem.kt
@@ -52,6 +52,7 @@ fun CommunityItem(
     community: CommunityModel,
     modifier: Modifier = Modifier,
     small: Boolean = false,
+    noPadding: Boolean = false,
     autoLoadImages: Boolean = true,
     preferNicknames: Boolean = true,
     showSubscribers: Boolean = false,
@@ -71,7 +72,13 @@ fun CommunityItem(
     var optionsMenuOpen by remember { mutableStateOf(false) }
 
     Row(
-        modifier = modifier.padding(Spacing.s),
+        modifier = modifier.then(
+            if (noPadding) {
+                Modifier
+            } else {
+                Modifier.padding(Spacing.s)
+            }
+        ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
     ) {

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
@@ -253,7 +253,7 @@ class ManageSubscriptionsScreen : Screen {
                             ) {
                                 Text(
                                     text = LocalXmlStrings.current.manageSubscriptionsHeaderMulticommunities,
-                                    style = MaterialTheme.typography.headlineSmall,
+                                    style = MaterialTheme.typography.titleLarge,
                                     color = MaterialTheme.colorScheme.onBackground,
                                 )
                                 Spacer(modifier = Modifier.weight(1f))
@@ -293,7 +293,7 @@ class ManageSubscriptionsScreen : Screen {
                                     )
                                     this += Option(
                                         OptionId.Delete,
-                                        LocalXmlStrings.current.communityActionUnsubscribe,
+                                        LocalXmlStrings.current.commentActionDelete,
                                     )
                                 },
                                 onOptionSelected = rememberCallbackArgs(model) { optionId ->
@@ -322,7 +322,7 @@ class ManageSubscriptionsScreen : Screen {
                             ) {
                                 Text(
                                     text = LocalXmlStrings.current.manageSubscriptionsHeaderSubscriptions,
-                                    style = MaterialTheme.typography.headlineSmall,
+                                    style = MaterialTheme.typography.titleLarge,
                                     color = MaterialTheme.colorScheme.onBackground,
                                 )
                             }
@@ -361,16 +361,12 @@ class ManageSubscriptionsScreen : Screen {
                                 onOptionSelected = rememberCallbackArgs(model) { optionId ->
                                     when (optionId) {
                                         OptionId.Unsubscribe -> {
-                                            model.reduce(
-                                                ManageSubscriptionsMviModel.Intent.Unsubscribe(community.id),
-                                            )
+                                            model.reduce(ManageSubscriptionsMviModel.Intent.Unsubscribe(community.id))
                                         }
 
                                         OptionId.Favorite -> {
                                             model.reduce(
-                                                ManageSubscriptionsMviModel.Intent.ToggleFavorite(
-                                                    community.id
-                                                )
+                                                ManageSubscriptionsMviModel.Intent.ToggleFavorite(community.id)
                                             )
                                         }
 

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityMviModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityMviModel.kt
@@ -28,6 +28,7 @@ interface MultiCommunityMviModel :
 
     data class UiState(
         val currentUserId: Int? = null,
+        val initial: Boolean = true,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
         val canFetchMore: Boolean = true,

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -285,8 +285,9 @@ class MultiCommunityScreen(
                         }
                     }
                     items(
-                        uiState.posts,
-                        { it.id.toString() + (it.updateDate ?: it.publishDate) }) { post ->
+                        items = uiState.posts,
+                        key = { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                    ) { post ->
                         LaunchedEffect(post.id) {
                             if (settings.markAsReadWhileScrolling && !post.read) {
                                 model.reduce(MultiCommunityMviModel.Intent.MarkAsRead(post.id))
@@ -576,7 +577,7 @@ class MultiCommunityScreen(
                         }
                     }
 
-                    if (uiState.posts.isEmpty() && !uiState.loading) {
+                    if (uiState.posts.isEmpty() && !uiState.initial) {
                         item {
                             Text(
                                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.xs),

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -105,9 +105,7 @@ class MultiCommunityScreen(
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable
     override fun Content() {
-        val model = getScreenModel<MultiCommunityMviModel>(parameters = {
-            parametersOf(communityId)
-        })
+        val model = getScreenModel<MultiCommunityMviModel>(parameters = { parametersOf(communityId) })
         val uiState by model.uiState.collectAsState()
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -109,7 +109,7 @@ class MultiCommunityViewModel(
                         )
                     }
                     paginator.setCommunities(uiState.value.community.communityIds)
-                    refresh()
+                    refresh(initial = true)
                 }
             }
         }
@@ -164,10 +164,10 @@ class MultiCommunityViewModel(
         }
     }
 
-    private fun refresh() {
+    private fun refresh(initial: Boolean = false) {
         hideReadPosts = false
         paginator.reset()
-        updateState { it.copy(canFetchMore = true, refreshing = true) }
+        updateState { it.copy(canFetchMore = true, refreshing = true, initial = initial) }
         loadNextPage()
     }
 
@@ -222,6 +222,7 @@ class MultiCommunityViewModel(
                     loading = false,
                     canFetchMore = canFetchMore,
                     refreshing = false,
+                    initial = newPosts.isEmpty(),
                 )
             }
         }

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -89,6 +89,9 @@ class MultiCommunityViewModel(
             notificationCenter.subscribe(NotificationCenterEvent.CopyText::class).onEach {
                 emitEffect(MultiCommunityMviModel.Effect.TriggerCopy(it.value))
             }.launchIn(this)
+            identityRepository.isLogged.onEach { logged ->
+                updateState { it.copy(isLogged = logged ?: false) }
+            }.launchIn(this)
 
             if (uiState.value.currentUserId == null) {
                 val auth = identityRepository.authToken.value.orEmpty()
@@ -143,9 +146,7 @@ class MultiCommunityViewModel(
                 if (intent.feedback) {
                     hapticFeedback.vibrate()
                 }
-                toggleUpVote(
-                    post = uiState.value.posts.first { it.id == intent.id },
-                )
+                toggleUpVote(post = uiState.value.posts.first { it.id == intent.id })
             }
 
             MultiCommunityMviModel.Intent.ClearRead -> clearRead()

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
@@ -273,8 +273,14 @@ class MultiCommunityEditorScreen(
                 }
 
                 Spacer(modifier = Modifier.height(Spacing.s))
-                Column {
-                    Text(text = LocalXmlStrings.current.multiCommunityEditorCommunities)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Spacing.s),
+                ) {
+                    Text(
+                        text = LocalXmlStrings.current.multiCommunityEditorCommunities
+                    )
 
                     // search field
                     TextField(
@@ -314,8 +320,9 @@ class MultiCommunityEditorScreen(
                     )
                 }
                 LazyColumn(
-                    modifier = Modifier.fillMaxWidth()
-                        .padding(horizontal = Spacing.m)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Spacing.s)
                         .weight(1f),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
                 ) {
@@ -326,8 +333,10 @@ class MultiCommunityEditorScreen(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             CommunityItem(
-                                modifier = Modifier.fillMaxWidth()
+                                modifier = Modifier
+                                    .weight(1f)
                                     .background(MaterialTheme.colorScheme.background),
+                                noPadding = true,
                                 community = community,
                                 preferNicknames = uiState.preferNicknames,
                             )

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorViewModel.kt
@@ -105,7 +105,7 @@ class MultiCommunityEditorViewModel(
     private fun filterCommunities(): List<Pair<CommunityModel, Boolean>> {
         val searchText = uiState.value.searchText
         val res = if (searchText.isNotEmpty()) {
-            communities.filter { it.first.name.contains(searchText) }
+            communities.filter { it.first.name.contains(other = searchText, ignoreCase = true) }
         } else {
             communities
         }

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/utils/DefaultMultiCommunityPaginator.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/utils/DefaultMultiCommunityPaginator.kt
@@ -40,5 +40,5 @@ class DefaultMultiCommunityPaginator(
                 addAll(elements)
             }
         }
-    }.sortedBy { it.publishDate }
+    }.sortedByDescending { it.publishDate }
 }


### PR DESCRIPTION
This PR solves a series of issues related to multi-communities:

- post not being loaded in the correct order
- initial state not being dealt with correctly
- actions (like/dislike save) not being available
- editor screen layout
- in the manage subscription screen "unsubscribe" and "delete" options were inverted.