### PR TITLE
fix: comment link opening and state restoration

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownWrapper.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownWrapper.kt
@@ -4,7 +4,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
@@ -21,6 +25,8 @@ import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
 import com.mikepenz.markdown.model.markdownPadding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.math.floor
 
 private val String.containsSpoiler: Boolean
@@ -61,10 +67,17 @@ fun CustomMarkdownWrapper(
             (base * maxLines).toDp()
         }
     }
+    val scope = rememberCoroutineScope()
+    var isOpeningUrl by remember { mutableStateOf(false) }
     val customUriHandler = remember {
         object : UriHandler {
             override fun openUri(uri: String) {
+                isOpeningUrl = true
                 onOpenUrl?.invoke(uri)
+                scope.launch {
+                    delay(250)
+                    isOpeningUrl = false
+                }
             }
         }
     }

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
@@ -13,6 +13,17 @@ sealed interface FilteredContentsType {
     data object Moderated : FilteredContentsType
 }
 
+fun FilteredContentsType.toInt(): Int = when (this) {
+    FilteredContentsType.Moderated -> 0
+    FilteredContentsType.Votes -> 1
+}
+
+fun Int.toFilteredContentsType(): FilteredContentsType = when (this) {
+    1 -> FilteredContentsType.Votes
+    else -> FilteredContentsType.Moderated
+}
+
+
 sealed interface FilteredContentsSection {
     data object Posts : FilteredContentsSection
 

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -95,7 +95,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.parameter.parametersOf
 
 class FilteredContentsScreen(
-    private val type: FilteredContentsType,
+    private val type: Int,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class FilteredContentsViewModel(
-    private val contentsType: FilteredContentsType,
+    private val contentsType: Int,
     private val themeRepository: ThemeRepository,
     private val settingsRepository: SettingsRepository,
     private val identityRepository: IdentityRepository,
@@ -52,7 +52,7 @@ class FilteredContentsViewModel(
             settingsRepository.currentSettings.onEach { settings ->
                 updateState {
                     it.copy(
-                        contentsType = contentsType,
+                        contentsType = contentsType.toFilteredContentsType(),
                         autoLoadImages = settings.autoLoadImages,
                         preferNicknames = settings.preferUserNicknames,
                         swipeActionsEnabled = settings.enableSwipeActions,

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -69,6 +69,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.github.diegoberaldin.raccoonforlemmy.unit.drafts.DraftsScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.filteredcontents.FilteredContentsScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.filteredcontents.FilteredContentsType
+import com.github.diegoberaldin.raccoonforlemmy.unit.filteredcontents.toInt
 import com.github.diegoberaldin.raccoonforlemmy.unit.managesubscriptions.ManageSubscriptionsScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.modlog.ModlogScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.myaccount.components.ProfileShortcutSection
@@ -131,7 +132,7 @@ object ProfileLoggedScreen : Tab {
                         }
 
                         ModeratorZoneAction.ModeratedContents -> {
-                            val screen = FilteredContentsScreen(type = FilteredContentsType.Moderated)
+                            val screen = FilteredContentsScreen(type = FilteredContentsType.Moderated.toInt())
                             navigationCoordinator.pushScreen(screen)
                         }
                     }
@@ -205,7 +206,7 @@ object ProfileLoggedScreen : Tab {
                                     navigationCoordinator.showBottomSheet(screen)
                                 },
                                 onOpenVotes = rememberCallback {
-                                    val screen = FilteredContentsScreen(type = FilteredContentsType.Votes)
+                                    val screen = FilteredContentsScreen(type = FilteredContentsType.Votes.toInt())
                                     navigationCoordinator.pushScreen(screen)
                                 },
                             )


### PR DESCRIPTION
This PR fixes a but reported [here](https:///feddit.it/post/6718289) with comment link opening as well as a state restoration issue which led the moderated contents and votes screens (accessible from Profile) to crash when the app was not in the foreground.