### PR TITLE
fix: zoomable image

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/ZoomableImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/ZoomableImage.kt
@@ -22,8 +22,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 
@@ -47,7 +49,7 @@ fun ZoomableImage(
     ) {
         val transformableState =
             rememberTransformableState { zoomChange, panChange, _ ->
-                scale = (scale * zoomChange).coerceIn(1f, 5f)
+                scale = (scale * zoomChange).coerceIn(1f, 16f)
 
                 val extraWidth = (scale - 1) * constraints.maxWidth
                 val extraHeight = (scale - 1) * constraints.maxHeight
@@ -74,6 +76,8 @@ fun ZoomableImage(
                 )
                 .transformable(transformableState),
             url = url,
+            contentScale = ContentScale.FillWidth,
+            quality = FilterQuality.High,
             autoload = autoLoadImages,
             onFailure = {
                 Text(

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/PostModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/PostModel.kt
@@ -33,9 +33,7 @@ data class PostModel(
 )
 
 val PostModel.imageUrl: String
-    get() = url?.takeIf { it.looksLikeAnImage }?.takeIf { it.isNotEmpty() } ?: run {
-        thumbnailUrl
-    }.orEmpty()
+    get() = (thumbnailUrl?.takeIf { it.isNotEmpty() } ?: url?.takeIf { it.looksLikeAnImage }).orEmpty()
 
 val PostModel.videoUrl: String
     get() = url?.takeIf { it.looksLikeAVideo }?.takeIf { it.isNotEmpty() }.orEmpty()


### PR DESCRIPTION
There were a couple of problems in the zoomable image screen:

- instead of giving precedence to the thumbnail URL, the URL of the post was preferred (the correct order should be the other way round)
- the image was downscaled and zoom was limited to a small range.

This PR fixes both issues.