### PR TITLE
Trim whitespaces at the end (or start) of email/username

### DIFF
--- a/unit/login/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/login/LoginViewModel.kt
+++ b/unit/login/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/login/LoginViewModel.kt
@@ -50,7 +50,7 @@ class LoginViewModel(
     }
 
     private fun setUsername(value: String) {
-        updateState { it.copy(username = value) }
+        updateState { it.copy(username = value.trim()) }
     }
 
     private fun setPassword(value: String) {


### PR DESCRIPTION
Hi, first of all thanks for such a nice app! I use a password manager, and for some reason, there was a whitespace at the end of my login email, which I didn't notice because previously I was using Boost for Lemmy, and I guess it used to automatically trim the whitespace. However, I wanted to try out some FOSS client instead, I installed Raccoon, and it kept showing incorrect credentials. After some time, I realized that I had a whitespace at the end of my email saved in Bitwarden. Yes, it's a user error, but I think the app should automatically trim whitespaces for better UX.