### PR TITLE
chore: change fab icon and read/unread improvements

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/FloatingActionButtonMenu.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/FloatingActionButtonMenu.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -166,7 +166,7 @@ fun FloatingActionButtonMenu(
             content = {
                 Icon(
                     modifier = Modifier.rotate(fabRotation),
-                    imageVector = Icons.Default.Add,
+                    imageVector = Icons.Default.MyLocation,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -304,7 +304,9 @@ private fun CompactPost(
             voteFormat = voteFormat,
             score = post.score,
             showScores = showScores,
-            unreadComments = post.unreadComments.takeIf { it != null && it > 0 && showUnreadComments },
+            unreadComments = post.unreadComments.takeIf {
+                it != null && it > 0 && showUnreadComments && it != post.comments
+            },
             upVotes = post.upvotes,
             downVotes = post.downvotes,
             upVoted = post.myVote > 0,
@@ -526,7 +528,9 @@ private fun ExtendedPost(
             voteFormat = voteFormat,
             score = post.score,
             showScores = showScores,
-            unreadComments = post.unreadComments.takeIf { it != null && it > 0 && showUnreadComments },
+            unreadComments = post.unreadComments.takeIf {
+                it != null && it > 0 && showUnreadComments && it != post.comments
+            },
             upVotes = post.upvotes,
             downVotes = post.downvotes,
             upVoted = post.myVote > 0,

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardFooter.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardFooter.kt
@@ -117,6 +117,7 @@ fun PostCardFooter(
             if (unreadComments != null) {
                 Text(
                     modifier = Modifier
+                        .padding(start = Spacing.xxs)
                         .background(
                             color = MaterialTheme.colorScheme.secondary,
                             shape = RoundedCornerShape(CornerSize.s)

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
@@ -65,6 +65,8 @@ interface FilteredContentsMviModel :
         val section: FilteredContentsSection = FilteredContentsSection.Posts,
         val posts: List<PostModel> = emptyList(),
         val comments: List<CommentModel> = emptyList(),
+        val fadeReadPosts: Boolean = false,
+        val showUnreadComments: Boolean = false,
         val actionsOnSwipeToStartPosts: List<ActionOnSwipe> = emptyList(),
         val actionsOnSwipeToEndPosts: List<ActionOnSwipe> = emptyList(),
         val actionsOnSwipeToStartComments: List<ActionOnSwipe> = emptyList(),

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -373,6 +373,8 @@ class FilteredContentsScreen(
                                             voteFormat = uiState.voteFormat,
                                             autoLoadImages = uiState.autoLoadImages,
                                             preferNicknames = uiState.preferNicknames,
+                                            fadeRead = uiState.fadeReadPosts,
+                                            showUnreadComments = uiState.showUnreadComments,
                                             onClick = rememberCallback(model) {
                                                 detailOpener.openPostDetail(post)
                                             },

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
@@ -58,6 +58,8 @@ class FilteredContentsViewModel(
                         swipeActionsEnabled = settings.enableSwipeActions,
                         voteFormat = settings.voteFormat,
                         fullHeightImages = settings.fullHeightImages,
+                        fadeReadPosts = settings.fadeReadPosts,
+                        showUnreadComments = settings.showUnreadComments,
                         actionsOnSwipeToStartPosts = settings.actionsOnSwipeToStartPosts,
                         actionsOnSwipeToEndPosts = settings.actionsOnSwipeToEndPosts,
                         actionsOnSwipeToStartComments = settings.actionsOnSwipeToStartComments,

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
@@ -44,6 +44,7 @@ interface ProfileLoggedMviModel :
         val autoLoadImages: Boolean = true,
         val preferNicknames: Boolean = true,
         val showScores: Boolean = true,
+        val showUnreadComments: Boolean = false,
     )
 
     sealed interface Effect

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -207,6 +207,7 @@ object ProfileLoggedScreen : Tab {
                                     autoLoadImages = uiState.autoLoadImages,
                                     preferNicknames = uiState.preferNicknames,
                                     showScores = uiState.showScores,
+                                    showUnreadComments = uiState.showUnreadComments,
                                     hideAuthor = true,
                                     blurNsfw = false,
                                     onClick = rememberCallback {

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
@@ -78,6 +78,7 @@ class ProfileLoggedViewModel(
                         preferNicknames = settings.preferUserNicknames,
                         fullHeightImages = settings.fullHeightImages,
                         showScores = settings.showScores,
+                        showUnreadComments = settings.showUnreadComments,
                     )
                 }
             }.launchIn(this)

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
@@ -124,9 +124,6 @@ class PostDetailViewModel(
             notificationCenter.subscribe(NotificationCenterEvent.CopyText::class).onEach {
                 emitEffect(PostDetailMviModel.Effect.TriggerCopy(it.value))
             }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.PostUpdated::class).onEach { evt ->
-                handlePostUpdate(evt.model)
-            }.launchIn(this)
             notificationCenter.subscribe(NotificationCenterEvent.UserBannedComment::class)
                 .onEach { evt ->
                     val commentId = evt.commentId
@@ -174,6 +171,10 @@ class PostDetailViewModel(
                 updateState {
                     it.copy(post = updatedPost)
                 }
+                // reset unread comments
+                notificationCenter.send(
+                    event = NotificationCenterEvent.PostUpdated(updatedPost.copy(unreadComments = 0)),
+                )
             }
 
             if (highlightCommentId != null) {


### PR DESCRIPTION
This PR contains some fixes for bugs (kinda) introduced by #681 and #684:

- changes the FAB icon to avoid users thinking it just allows to create new contents
- resets unread comments after opening a post detail
- fade read posts in Upvotes & downvotes screen
- shows unread comments in Profile and Upvotes & downvotes screens.