### PR TITLE
feat: community/user info in side menu

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/DraggableSideMenu.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/DraggableSideMenu.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
@@ -24,6 +25,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlin.math.roundToInt
@@ -49,8 +51,8 @@ fun DraggableSideMenu(
         AnchoredDraggableState(
             initialValue = SlideAnchorPosition.Closed,
             anchors = DraggableAnchors<SlideAnchorPosition> {
-                SlideAnchorPosition.Closed at with(density) { maxWidth.toPx() }
-                SlideAnchorPosition.Opened at 0f
+                SlideAnchorPosition.Closed at with(density) { availableWidth.toPx() }
+                SlideAnchorPosition.Opened at with(density) { (availableWidth - maxWidth).toPx() }
             },
             positionalThreshold = { distance: Float -> distance * 0.5f },
             velocityThreshold = { with(density) { 100.dp.toPx() } },
@@ -68,8 +70,8 @@ fun DraggableSideMenu(
     }
 
     LaunchedEffect(draggableState) {
-        snapshotFlow { draggableState.targetValue }.onEach { value: SlideAnchorPosition ->
-            if (value == SlideAnchorPosition.Closed && draggableState.currentValue == SlideAnchorPosition.Opened) {
+        snapshotFlow { draggableState.currentValue }.onEach { value: SlideAnchorPosition ->
+            if (value == SlideAnchorPosition.Closed) {
                 onDismiss?.invoke()
             }
         }.launchIn(this)
@@ -89,7 +91,13 @@ fun DraggableSideMenu(
                 state = draggableState,
                 orientation = Orientation.Horizontal,
             )
-            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)),
+            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
+            .padding(
+                top = Spacing.xxl,
+                bottom = Spacing.m,
+                end = Spacing.s,
+                start = Spacing.s
+            ),
     ) {
         content()
     }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommunityHeader.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommunityHeader.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarViewMonth
 import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -48,6 +50,7 @@ fun CommunityHeader(
     autoLoadImages: Boolean = true,
     preferNicknames: Boolean = true,
     onOpenImage: ((String) -> Unit)? = null,
+    onInfo: (() -> Unit)? = null,
 ) {
     Box(
         modifier = modifier.fillMaxWidth(),
@@ -139,7 +142,7 @@ fun CommunityHeader(
                         Icon(
                             modifier = Modifier.size(iconSize),
                             imageVector = Icons.Default.Group,
-                            contentDescription = null
+                            contentDescription = null,
                         )
                         Text(
                             text = community.subscribers.getPrettyNumber(
@@ -154,7 +157,7 @@ fun CommunityHeader(
                         Icon(
                             modifier = Modifier.size(iconSize),
                             imageVector = Icons.Default.CalendarViewMonth,
-                            contentDescription = null
+                            contentDescription = null,
                         )
                         Text(
                             text = community.monthlyActiveUsers.getPrettyNumber(
@@ -163,6 +166,19 @@ fun CommunityHeader(
                             ),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    if (onInfo != null) {
+                        Icon(
+                            modifier = Modifier
+                                .padding(end = Spacing.s)
+                                .size(iconSize)
+                                .onClick(onClick = onInfo),
+                            imageVector = Icons.Default.Info,
+                            contentDescription = null,
                         )
                     }
                 }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/UserHeader.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/UserHeader.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Cake
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -52,6 +53,7 @@ fun UserHeader(
     autoLoadImages: Boolean = true,
     preferNicknames: Boolean = true,
     onOpenImage: ((String) -> Unit)? = null,
+    onInfo: (() -> Unit)? = null,
 ) {
     Box(
         modifier = modifier.fillMaxWidth(),
@@ -184,6 +186,19 @@ fun UserHeader(
                             text = user.accountAge.prettifyDate(),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    if (onInfo != null) {
+                        Icon(
+                            modifier = Modifier
+                                .padding(end = Spacing.s)
+                                .size(iconSize)
+                                .onClick(onClick = onInfo),
+                            imageVector = Icons.Default.Info,
+                            contentDescription = null,
                         )
                     }
                 }

--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
@@ -32,6 +32,7 @@ internal class DefaultNavigationCoordinator : NavigationCoordinator {
     override val inboxUnread = MutableStateFlow(0)
     override val canPop = MutableStateFlow(false)
     override val exitMessageVisible = MutableStateFlow(false)
+    override val sideMenuEvents = MutableSharedFlow<SideMenuEvents>()
 
     private var connection: NestedScrollConnection? = null
     private var navigator: Navigator? = null
@@ -146,5 +147,17 @@ internal class DefaultNavigationCoordinator : NavigationCoordinator {
 
     override fun changeTab(value: Tab) {
         tabNavigator?.current = value
+    }
+
+    override fun openSideMenu(screen: Screen) {
+        scope.launch {
+            sideMenuEvents.emit(SideMenuEvents.Open(screen))
+        }
+    }
+
+    override fun closeSideMenu() {
+        scope.launch {
+            sideMenuEvents.emit(SideMenuEvents.Close)
+        }
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/NavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/NavigationCoordinator.kt
@@ -18,6 +18,11 @@ sealed interface TabNavigationSection {
     data object Settings : TabNavigationSection
 }
 
+sealed interface SideMenuEvents {
+    data class Open(val screen: Screen) : SideMenuEvents
+    data object Close : SideMenuEvents
+}
+
 @Stable
 interface NavigationCoordinator {
 
@@ -27,6 +32,7 @@ interface NavigationCoordinator {
     val deepLinkUrl: Flow<String?>
     val canPop: StateFlow<Boolean>
     val exitMessageVisible: StateFlow<Boolean>
+    val sideMenuEvents: Flow<SideMenuEvents>
 
     fun setCurrentSection(section: TabNavigationSection)
     fun submitDeeplink(url: String)
@@ -44,4 +50,6 @@ interface NavigationCoordinator {
     fun setExitMessageVisible(value: Boolean)
     fun setTabNavigator(value: TabNavigator)
     fun changeTab(value: Tab)
+    fun openSideMenu(screen: Screen)
+    fun closeSideMenu()
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 implementation(projects.core.api)
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
+                implementation(projects.core.commonui.components)
                 implementation(projects.core.commonui.detailopenerApi)
                 implementation(projects.core.commonui.detailopenerImpl)
                 implementation(projects.core.commonui.lemmyui)

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
@@ -125,7 +125,7 @@ internal object MainScreen : Screen {
             navigationCoordinator.setTabNavigator(tabNavigator)
 
             LaunchedEffect(tabNavigator.current) {
-                // when the current tab chanes, reset the bottom bar offset to the default value
+                // when the current tab changes, reset the bottom bar offset to the default value
                 model.reduce(MainScreenMviModel.Intent.SetBottomBarOffsetHeightPx(0f))
             }
 

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -328,10 +328,6 @@ class CommunityDetailScreen(
                         // options menu
                         Box {
                             val options = buildList {
-                                this += Option(
-                                    OptionId.Info,
-                                    LocalXmlStrings.current.communityDetailInfo,
-                                )
                                 if (!isOnOtherInstance) {
                                     this += Option(
                                         OptionId.Search,
@@ -448,16 +444,6 @@ class CommunityDetailScreen(
                                                     navigationCoordinator.pushScreen(
                                                         InstanceInfoScreen(
                                                             url = uiState.community.instanceUrl,
-                                                        ),
-                                                    )
-                                                }
-
-                                                OptionId.Info -> {
-                                                    navigationCoordinator.showBottomSheet(
-                                                        CommunityInfoScreen(
-                                                            communityId = uiState.community.id,
-                                                            communityName = uiState.community.name,
-                                                            otherInstance = otherInstanceName,
                                                         ),
                                                     )
                                                 }
@@ -707,6 +693,14 @@ class CommunityDetailScreen(
                                                 )
                                             )
                                         },
+                                        onInfo = rememberCallback {
+                                            val screen = CommunityInfoScreen(
+                                                communityId = uiState.community.id,
+                                                communityName = uiState.community.name,
+                                                otherInstance = otherInstanceName,
+                                            )
+                                            navigationCoordinator.openSideMenu(screen)
+                                        }
                                     )
                                 }
                             }

--- a/unit/communityinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
+++ b/unit/communityinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
@@ -1,11 +1,9 @@
 package com.github.diegoberaldin.raccoonforlemmy.unit.communityinfo
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -24,6 +22,7 @@ import androidx.compose.material.icons.filled.Group
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -31,10 +30,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ContentFontClass
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.BottomSheetHandle
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.CustomizedContent
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.DetailInfoItem
@@ -71,197 +70,185 @@ class CommunityInfoScreen(
         val scope = rememberCoroutineScope()
         val detailOpener = remember { getDetailOpener() }
 
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background)
-                .padding(
-                    top = Spacing.m,
-                    start = Spacing.s,
-                    end = Spacing.s,
-                    bottom = Spacing.m,
-                )
-                .fillMaxHeight(0.9f)
-                .fillMaxWidth(),
-        ) {
-            BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
-            Scaffold(
-                topBar = {
-                    Row(
-                        modifier = Modifier.padding(top = Spacing.s),
-                        verticalAlignment = Alignment.CenterVertically,
+        Scaffold(
+            contentColor = MaterialTheme.colorScheme.onBackground,
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
+            topBar = {
+                Row(
+                    modifier = Modifier.padding(top = Spacing.s),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = uiState.community.readableName(uiState.preferNicknames),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        ) { paddingValues ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(top = Spacing.xs, start = Spacing.m, end = Spacing.m),
+                verticalArrangement = Arrangement.spacedBy(Spacing.s),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                item {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                     ) {
-                        Spacer(modifier = Modifier.weight(1f))
-                        Text(
-                            text = uiState.community.readableName(uiState.preferNicknames),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onBackground,
+                        SelectionContainer {
+                            DetailInfoItem(
+                                modifier = Modifier.fillMaxWidth(),
+                                icon = Icons.Default.AlternateEmail,
+                                title = uiState.community.readableHandle,
+                            )
+                        }
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.Default.Cake,
+                            title = uiState.community.creationDate?.prettifyDate().orEmpty(),
                         )
-                        Spacer(modifier = Modifier.weight(1f))
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.AutoMirrored.Filled.Article,
+                            title = LocalXmlStrings.current.communityInfoPosts,
+                            value = uiState.community.posts.getPrettyNumber(
+                                thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                millionLabel = LocalXmlStrings.current.profileMillionShort,
+                            ),
+                        )
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.AutoMirrored.Filled.Reply,
+                            title = LocalXmlStrings.current.communityInfoComments,
+                            value = uiState.community.comments.getPrettyNumber(
+                                thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                millionLabel = LocalXmlStrings.current.profileMillionShort,
+                            ),
+                        )
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.Default.Group,
+                            title = LocalXmlStrings.current.communityInfoSubscribers,
+                            value = uiState.community.subscribers.getPrettyNumber(
+                                thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                millionLabel = LocalXmlStrings.current.profileMillionShort,
+                            ),
+                        )
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.Default.CalendarViewMonth,
+                            title = LocalXmlStrings.current.communityInfoMonthlyActiveUsers,
+                            value = uiState.community.monthlyActiveUsers.getPrettyNumber(
+                                thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                millionLabel = LocalXmlStrings.current.profileMillionShort,
+                            ),
+                        )
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.Default.CalendarViewWeek,
+                            title = LocalXmlStrings.current.communityInfoWeeklyActiveUsers,
+                            value = uiState.community.weeklyActiveUsers.getPrettyNumber(
+                                thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                millionLabel = LocalXmlStrings.current.profileMillionShort,
+                            ),
+                        )
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.Default.CalendarViewDay,
+                            title = LocalXmlStrings.current.communityInfoDailyActiveUsers,
+                            value = uiState.community.dailyActiveUsers.getPrettyNumber(
+                                thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                millionLabel = LocalXmlStrings.current.profileMillionShort,
+                            ),
+                        )
                     }
                 }
-            ) { paddingValues ->
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                        .padding(top = Spacing.xs, start = Spacing.m, end = Spacing.m),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
+                if (uiState.moderators.isNotEmpty()) {
                     item {
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    top = Spacing.s,
+                                    bottom = Spacing.xs,
+                                ),
+                            text = LocalXmlStrings.current.communityInfoModerators,
+                        )
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                         ) {
-                            SelectionContainer {
-                                DetailInfoItem(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    icon = Icons.Default.AlternateEmail,
-                                    title = uiState.community.readableHandle,
+                            items(
+                                count = uiState.moderators.size
+                            ) { idx ->
+                                val user = uiState.moderators[idx]
+                                ModeratorCell(
+                                    autoLoadImages = uiState.autoLoadImages,
+                                    user = user,
+                                    onOpenUser = rememberCallbackArgs { _ ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            detailOpener.openUserDetail(user, "")
+                                        }
+                                    }
                                 )
                             }
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.Default.Cake,
-                                title = uiState.community.creationDate?.prettifyDate().orEmpty(),
-                            )
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.AutoMirrored.Filled.Article,
-                                title = LocalXmlStrings.current.communityInfoPosts,
-                                value = uiState.community.posts.getPrettyNumber(
-                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                ),
-                            )
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.AutoMirrored.Filled.Reply,
-                                title = LocalXmlStrings.current.communityInfoComments,
-                                value = uiState.community.comments.getPrettyNumber(
-                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                ),
-                            )
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.Default.Group,
-                                title = LocalXmlStrings.current.communityInfoSubscribers,
-                                value = uiState.community.subscribers.getPrettyNumber(
-                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                ),
-                            )
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.Default.CalendarViewMonth,
-                                title = LocalXmlStrings.current.communityInfoMonthlyActiveUsers,
-                                value = uiState.community.monthlyActiveUsers.getPrettyNumber(
-                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                ),
-                            )
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.Default.CalendarViewWeek,
-                                title = LocalXmlStrings.current.communityInfoWeeklyActiveUsers,
-                                value = uiState.community.weeklyActiveUsers.getPrettyNumber(
-                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                ),
-                            )
-                            DetailInfoItem(
-                                modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.Default.CalendarViewDay,
-                                title = LocalXmlStrings.current.communityInfoDailyActiveUsers,
-                                value = uiState.community.dailyActiveUsers.getPrettyNumber(
-                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                ),
-                            )
                         }
                     }
-                    if (uiState.moderators.isNotEmpty()) {
-                        item {
-                            Text(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(
-                                        top = Spacing.s,
-                                        bottom = Spacing.xs,
-                                    ),
-                                text = LocalXmlStrings.current.communityInfoModerators,
-                            )
-                            LazyRow(
-                                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-                            ) {
-                                items(
-                                    count = uiState.moderators.size
-                                ) { idx ->
-                                    val user = uiState.moderators[idx]
-                                    ModeratorCell(
-                                        autoLoadImages = uiState.autoLoadImages,
-                                        user = user,
-                                        onOpenUser = rememberCallbackArgs { _ ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                detailOpener.openUserDetail(user, "")
-                                            }
-                                        }
+                }
+                item {
+                    CustomizedContent(ContentFontClass.Body) {
+                        PostCardBody(
+                            modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                            text = uiState.community.description,
+                            onOpenImage = { url ->
+                                navigationCoordinator.closeSideMenu()
+                                scope.launch {
+                                    delay(100)
+                                    navigationCoordinator.pushScreen(
+                                        ZoomableImageScreen(
+                                            url = url,
+                                            source = uiState.community.readableHandle,
+                                        )
                                     )
                                 }
-                            }
-                        }
-                    }
-                    item {
-                        CustomizedContent(ContentFontClass.Body) {
-                            PostCardBody(
-                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
-                                text = uiState.community.description,
-                                onOpenImage = { url ->
-                                    navigationCoordinator.hideBottomSheet()
-                                    scope.launch {
-                                        delay(100)
-                                        navigationCoordinator.pushScreen(
-                                            ZoomableImageScreen(
-                                                url = url,
-                                                source = uiState.community.readableHandle,
-                                            )
-                                        )
-                                    }
-                                },
-                                onOpenCommunity = { community, instance ->
-                                    navigationCoordinator.hideBottomSheet()
-                                    scope.launch {
-                                        delay(100)
-                                        detailOpener.openCommunityDetail(community, instance)
+                            },
+                            onOpenCommunity = { community, instance ->
+                                navigationCoordinator.closeSideMenu()
+                                scope.launch {
+                                    delay(100)
+                                    detailOpener.openCommunityDetail(community, instance)
 
-                                    }
-                                },
-                                onOpenPost = { post, instance ->
-                                    navigationCoordinator.hideBottomSheet()
-                                    scope.launch {
-                                        delay(100)
-                                        detailOpener.openPostDetail(post, instance)
+                                }
+                            },
+                            onOpenPost = { post, instance ->
+                                navigationCoordinator.closeSideMenu()
+                                scope.launch {
+                                    delay(100)
+                                    detailOpener.openPostDetail(post, instance)
 
-                                    }
-                                },
-                                onOpenUser = { user, instance ->
-                                    navigationCoordinator.hideBottomSheet()
-                                    scope.launch {
-                                        delay(100)
-                                        detailOpener.openUserDetail(user, instance)
-                                    }
-                                },
-                                onOpenWeb = { url ->
-                                    navigationCoordinator.hideBottomSheet()
-                                    scope.launch {
-                                        delay(100)
-                                        navigationCoordinator.pushScreen(WebViewScreen(url))
-                                    }
-                                },
-                            )
-                        }
+                                }
+                            },
+                            onOpenUser = { user, instance ->
+                                navigationCoordinator.closeSideMenu()
+                                scope.launch {
+                                    delay(100)
+                                    detailOpener.openUserDetail(user, instance)
+                                }
+                            },
+                            onOpenWeb = { url ->
+                                navigationCoordinator.closeSideMenu()
+                                scope.launch {
+                                    delay(100)
+                                    navigationCoordinator.pushScreen(WebViewScreen(url))
+                                }
+                            },
+                        )
                     }
                 }
             }

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -248,10 +248,6 @@ class UserDetailScreen(
                         Box {
                             val options = buildList {
                                 this += Option(
-                                    OptionId.Info,
-                                    LocalXmlStrings.current.userDetailInfo
-                                )
-                                this += Option(
                                     OptionId.ExploreInstance,
                                     buildString {
                                         append(LocalXmlStrings.current.navigationSearch)
@@ -315,16 +311,6 @@ class UserDetailScreen(
 
                                                 OptionId.Block -> {
                                                     model.reduce(UserDetailMviModel.Intent.Block)
-                                                }
-
-                                                OptionId.Info -> {
-                                                    navigationCoordinator.showBottomSheet(
-                                                        UserInfoScreen(
-                                                            userId = uiState.user.id,
-                                                            username = uiState.user.name,
-                                                            otherInstance = otherInstanceName,
-                                                        )
-                                                    )
                                                 }
 
                                                 OptionId.Share -> {
@@ -454,6 +440,14 @@ class UserDetailScreen(
                                         source = uiState.user.readableHandle,
                                     )
                                 )
+                            },
+                            onInfo = rememberCallback {
+                                val screen = UserInfoScreen(
+                                    userId = uiState.user.id,
+                                    username = uiState.user.name,
+                                    otherInstance = otherInstanceName,
+                                )
+                                navigationCoordinator.openSideMenu(screen)
                             },
                         )
                     }

--- a/unit/userinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
+++ b/unit/userinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
@@ -1,11 +1,9 @@
 package com.github.diegoberaldin.raccoonforlemmy.unit.userinfo
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -21,21 +19,21 @@ import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ContentFontClass
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.toTypography
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.BottomSheetHandle
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.CustomizedContent
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.DetailInfoItem
@@ -75,217 +73,205 @@ class UserInfoScreen(
         val family by themeRepository.contentFontFamily.collectAsState()
         val typography = family.toTypography()
 
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background)
-                .padding(
-                    top = Spacing.s,
-                    start = Spacing.s,
-                    end = Spacing.s,
-                    bottom = Spacing.m,
-                )
-                .fillMaxHeight(0.9f)
-                .fillMaxWidth(),
-        ) {
-            BottomSheetHandle(modifier = Modifier.align(Alignment.CenterHorizontally))
-            Scaffold(
-                topBar = {
-                    Row(
-                        modifier = Modifier.padding(top = Spacing.s),
-                    ) {
-                        Spacer(modifier = Modifier.weight(1f))
-                        Text(
-                            text = uiState.user.readableName(uiState.preferNicknames),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onBackground,
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                    }
-                }
-            ) { paddingValues ->
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                        .padding(top = Spacing.xs, start = Spacing.m, end = Spacing.m),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        Scaffold(
+            contentColor = MaterialTheme.colorScheme.onBackground,
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
+            topBar = {
+                Row(
+                    modifier = Modifier.padding(top = Spacing.s),
                 ) {
-                    item {
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-                        ) {
-                            SelectionContainer {
-                                DetailInfoItem(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    icon = Icons.Default.AlternateEmail,
-                                    title = uiState.user.readableHandle,
-                                )
-                            }
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = uiState.user.readableName(uiState.preferNicknames),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        ) { paddingValues ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(top = Spacing.xs, start = Spacing.m, end = Spacing.m),
+                verticalArrangement = Arrangement.spacedBy(Spacing.s),
+            ) {
+                item {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                    ) {
+                        SelectionContainer {
                             DetailInfoItem(
                                 modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.Default.Cake,
-                                title = uiState.user.accountAge.prettifyDate(),
+                                icon = Icons.Default.AlternateEmail,
+                                title = uiState.user.readableHandle,
                             )
-                            uiState.user.score?.also { score ->
-                                DetailInfoItem(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    icon = Icons.AutoMirrored.Filled.Article,
-                                    title = LocalXmlStrings.current.communityInfoPosts,
-                                    value = score.postScore.getPrettyNumber(
-                                        thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                        millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                    ),
-                                )
-                                DetailInfoItem(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    icon = Icons.AutoMirrored.Filled.Reply,
-                                    title = LocalXmlStrings.current.communityInfoComments,
-                                    value = score.commentScore.getPrettyNumber(
-                                        thousandLabel = LocalXmlStrings.current.profileThousandShort,
-                                        millionLabel = LocalXmlStrings.current.profileMillionShort,
-                                    ),
-                                )
-                            }
-                            if (uiState.user.admin) {
-                                DetailInfoItem(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    icon = Icons.Default.Shield,
-                                    title = LocalXmlStrings.current.userInfoAdmin,
-                                )
-                            }
                         }
-                    }
-                    uiState.user.displayName.takeIf { it.isNotEmpty() }?.also { name ->
-                        item {
-                            Text(
+                        DetailInfoItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            icon = Icons.Default.Cake,
+                            title = uiState.user.accountAge.prettifyDate(),
+                        )
+                        uiState.user.score?.also { score ->
+                            DetailInfoItem(
                                 modifier = Modifier.fillMaxWidth(),
-                                text = name,
-                                textAlign = TextAlign.Center,
-                                style = typography.titleMedium,
+                                icon = Icons.AutoMirrored.Filled.Article,
+                                title = LocalXmlStrings.current.communityInfoPosts,
+                                value = score.postScore.getPrettyNumber(
+                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
+                                ),
+                            )
+                            DetailInfoItem(
+                                modifier = Modifier.fillMaxWidth(),
+                                icon = Icons.AutoMirrored.Filled.Reply,
+                                title = LocalXmlStrings.current.communityInfoComments,
+                                value = score.commentScore.getPrettyNumber(
+                                    thousandLabel = LocalXmlStrings.current.profileThousandShort,
+                                    millionLabel = LocalXmlStrings.current.profileMillionShort,
+                                ),
+                            )
+                        }
+                        if (uiState.user.admin) {
+                            DetailInfoItem(
+                                modifier = Modifier.fillMaxWidth(),
+                                icon = Icons.Default.Shield,
+                                title = LocalXmlStrings.current.userInfoAdmin,
                             )
                         }
                     }
-                    uiState.user.bio?.takeIf { it.isNotEmpty() }?.also { biography ->
-                        item {
-                            Column(
-                                verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
-                            ) {
-                                Text(
-                                    text = LocalXmlStrings.current.settingsWebBio,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.75f),
-                                )
-                                CustomizedContent(ContentFontClass.Body) {
-                                    PostCardBody(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        text = biography,
-                                        onOpenImage = { url ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                navigationCoordinator.pushScreen(
-                                                    ZoomableImageScreen(
-                                                        url = url,
-                                                        source = uiState.user.readableHandle,
-                                                    )
-                                                )
-                                            }
-                                        },
-                                        onOpenCommunity = { community, instance ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                detailOpener.openCommunityDetail(
-                                                    community,
-                                                    instance,
-                                                )
-
-                                            }
-                                        },
-                                        onOpenPost = { post, instance ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                detailOpener.openPostDetail(post, instance)
-
-                                            }
-                                        },
-                                        onOpenUser = { user, instance ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                detailOpener.openUserDetail(user, instance)
-                                            }
-                                        },
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                navigationCoordinator.pushScreen(WebViewScreen(url))
-                                            }
-                                        },
-                                    )
-                                }
-                            }
-                        }
+                }
+                uiState.user.displayName.takeIf { it.isNotEmpty() }?.also { name ->
+                    item {
+                        Text(
+                            modifier = Modifier.fillMaxWidth(),
+                            text = name,
+                            textAlign = TextAlign.Center,
+                            style = typography.titleMedium,
+                        )
                     }
-
-                    uiState.user.matrixUserId?.also { matrixUserId ->
-                        item {
-                            Column(
-                                verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
-                            ) {
-                                Text(
-                                    text = LocalXmlStrings.current.settingsWebMatrix,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.75f),
-                                )
-                                CustomizedContent(ContentFontClass.AncillaryText) {
-                                    SelectionContainer {
-                                        Text(
-                                            text = matrixUserId,
-                                            style = MaterialTheme.typography.bodyMedium.copy(
-                                                fontFamily = FontFamily.Monospace
-                                            ),
-                                            color = MaterialTheme.colorScheme.onBackground,
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (uiState.moderatedCommunities.isNotEmpty()) {
-                        item {
+                }
+                uiState.user.bio?.takeIf { it.isNotEmpty() }?.also { biography ->
+                    item {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                        ) {
                             Text(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(
-                                        top = Spacing.s,
-                                        bottom = Spacing.xs,
-                                    ),
-                                text = LocalXmlStrings.current.userInfoModerates,
+                                text = LocalXmlStrings.current.settingsWebBio,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.75f),
                             )
-                            LazyRow(
-                                modifier = Modifier.padding(top = Spacing.xxs),
-                                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-                            ) {
-                                items(
-                                    count = uiState.moderatedCommunities.size
-                                ) { idx ->
-                                    val community = uiState.moderatedCommunities[idx]
-                                    ModeratedCommunityCell(
-                                        autoLoadImages = uiState.autoLoadImages,
-                                        community = community,
-                                        onOpenCommunity = rememberCallbackArgs { _ ->
-                                            navigationCoordinator.hideBottomSheet()
-                                            scope.launch {
-                                                delay(100)
-                                                detailOpener.openCommunityDetail(community)
-                                            }
+                            CustomizedContent(ContentFontClass.Body) {
+                                PostCardBody(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    text = biography,
+                                    onOpenImage = { url ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            navigationCoordinator.pushScreen(
+                                                ZoomableImageScreen(
+                                                    url = url,
+                                                    source = uiState.user.readableHandle,
+                                                )
+                                            )
                                         }
+                                    },
+                                    onOpenCommunity = { community, instance ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            detailOpener.openCommunityDetail(
+                                                community,
+                                                instance,
+                                            )
+
+                                        }
+                                    },
+                                    onOpenPost = { post, instance ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            detailOpener.openPostDetail(post, instance)
+
+                                        }
+                                    },
+                                    onOpenUser = { user, instance ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            detailOpener.openUserDetail(user, instance)
+                                        }
+                                    },
+                                    onOpenWeb = { url ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            navigationCoordinator.pushScreen(WebViewScreen(url))
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+
+                uiState.user.matrixUserId?.also { matrixUserId ->
+                    item {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                        ) {
+                            Text(
+                                text = LocalXmlStrings.current.settingsWebMatrix,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.75f),
+                            )
+                            CustomizedContent(ContentFontClass.AncillaryText) {
+                                SelectionContainer {
+                                    Text(
+                                        text = matrixUserId,
+                                        style = MaterialTheme.typography.bodyMedium.copy(
+                                            fontFamily = FontFamily.Monospace
+                                        ),
+                                        color = MaterialTheme.colorScheme.onBackground,
                                     )
                                 }
+                            }
+                        }
+                    }
+                }
+
+                if (uiState.moderatedCommunities.isNotEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    top = Spacing.s,
+                                    bottom = Spacing.xs,
+                                ),
+                            text = LocalXmlStrings.current.userInfoModerates,
+                        )
+                        LazyRow(
+                            modifier = Modifier.padding(top = Spacing.xxs),
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                        ) {
+                            items(
+                                count = uiState.moderatedCommunities.size
+                            ) { idx ->
+                                val community = uiState.moderatedCommunities[idx]
+                                ModeratedCommunityCell(
+                                    autoLoadImages = uiState.autoLoadImages,
+                                    community = community,
+                                    onOpenCommunity = rememberCallbackArgs { _ ->
+                                        navigationCoordinator.closeSideMenu()
+                                        scope.launch {
+                                            delay(100)
+                                            detailOpener.openCommunityDetail(community)
+                                        }
+                                    }
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
Since #702 introduced a custom draggable menu which can be really handy, this PR moves the user and community info from bottom sheets to this side menu, which can be opened via an :information_source: button in the community or user header.

I like this idea better because the informational screen is referred to as "sidebar" among Lemmy's user base and people assume it will be displayed as a "side" widget, not as a full screen or a dialog.