### PR TITLE
refactor: injectable resources

### DIFF
--- a/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/theme/Fonts.kt
+++ b/core/appearance/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/theme/Fonts.kt
@@ -2,20 +2,22 @@ package com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiFontFamily
-import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.di.getCoreResources
 
 @Composable
 fun UiFontFamily.toTypography(): Typography {
+    val coreResources = remember { getCoreResources() }
     val fontFamily = when (this) {
-        UiFontFamily.NotoSans -> CoreResources.notoSans
-        UiFontFamily.CharisSIL -> CoreResources.charisSil
-        UiFontFamily.Poppins -> CoreResources.poppins
-        UiFontFamily.Comfortaa -> CoreResources.comfortaa
+        UiFontFamily.NotoSans -> coreResources.notoSans
+        UiFontFamily.CharisSIL -> coreResources.charisSil
+        UiFontFamily.Poppins -> coreResources.poppins
+        UiFontFamily.Comfortaa -> coreResources.comfortaa
         else -> FontFamily.Default
     }
     return Typography(

--- a/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/AppIconBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/AppIconBottomSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
 import cafe.adriel.voyager.core.screen.Screen
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.BottomSheetHandle
@@ -24,7 +23,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
-import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.di.getCoreResources
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.appicon.AppIconVariant
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.appicon.toInt
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.appicon.toReadableName
@@ -34,6 +33,7 @@ class AppIconBottomSheet : Screen {
     override fun Content() {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val notificationCenter = remember { getNotificationCenter() }
+        val coreResources = remember { getCoreResources() }
 
         Column(
             modifier = Modifier
@@ -72,7 +72,10 @@ class AppIconBottomSheet : Screen {
                         SettingsRow(
                             modifier = Modifier.padding(vertical = Spacing.xxs),
                             title = value.toReadableName(),
-                            painter = value.toPainter(),
+                            painter = when (value) {
+                                AppIconVariant.Alt1 -> coreResources.appIconAlt1
+                                else -> coreResources.appIconDefault
+                            },
                             onTap = {
                                 navigationCoordinator.hideBottomSheet()
                                 notificationCenter.send(
@@ -87,8 +90,3 @@ class AppIconBottomSheet : Screen {
     }
 }
 
-@Composable
-fun AppIconVariant.toPainter(): Painter = when (this) {
-    AppIconVariant.Alt1 -> CoreResources.appIconAlt1
-    else -> CoreResources.appIconDefault
-}

--- a/core/resources/build.gradle.kts
+++ b/core/resources/build.gradle.kts
@@ -35,6 +35,8 @@ kotlin {
                 implementation(compose.materialIconsExtended)
                 @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
                 implementation(compose.components.resources)
+
+                implementation(libs.koin.core)
             }
         }
     }

--- a/core/resources/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/Utils.kt
+++ b/core/resources/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/Utils.kt
@@ -1,0 +1,9 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.resources.di
+
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import org.koin.java.KoinJavaComponent
+
+actual fun getCoreResources(): CoreResources {
+    val res by KoinJavaComponent.inject<CoreResources>(CoreResources::class.java)
+    return res
+}

--- a/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/CoreResources.kt
+++ b/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/CoreResources.kt
@@ -3,59 +3,14 @@ package com.github.diegoberaldin.raccoonforlemmy.core.resources
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 
-object CoreResources {
-
-    val github: Painter
-        @Composable
-        get() = drawable("ic_github")
-
-    val lemmy: Painter
-        @Composable
-        get() = drawable("ic_lemmy")
-
-    val appIconDefault: Painter
-        @Composable
-        get() = drawable("ic_default")
-
-    val appIconAlt1: Painter
-        @Composable
-        get() = drawable("ic_alt_1")
-
-    val notoSans: FontFamily
-        @Composable
-        get() = FontFamily(
-            font("NotoSans", "notosans_regular", FontWeight.Normal, FontStyle.Normal),
-            font("NotoSans", "notosans_bold", FontWeight.Bold, FontStyle.Normal),
-            font("NotoSans", "notosans_medium", FontWeight.Medium, FontStyle.Normal),
-            font("NotoSans", "notosans_italic", FontWeight.Normal, FontStyle.Italic),
-        )
-
-    val poppins: FontFamily
-        @Composable
-        get() = FontFamily(
-            font("Poppins", "poppins_regular", FontWeight.Normal, FontStyle.Normal),
-            font("Poppins", "poppins_bold", FontWeight.Bold, FontStyle.Normal),
-            font("Poppins", "poppins_medium", FontWeight.Medium, FontStyle.Normal),
-            font("Poppins", "poppins_italic", FontWeight.Normal, FontStyle.Italic),
-        )
-
-    val charisSil: FontFamily
-        @Composable
-        get() = FontFamily(
-            font("CharisSIL", "charissil_regular", FontWeight.Normal, FontStyle.Normal),
-            font("CharisSIL", "charissil_bold", FontWeight.Bold, FontStyle.Normal),
-            font("CharisSIL", "charissil_italic", FontWeight.Normal, FontStyle.Italic),
-        )
-
-    val comfortaa: FontFamily
-        @Composable
-        get() = FontFamily(
-            font("Comfortaa", "comfortaa_regular", FontWeight.Normal, FontStyle.Normal),
-            font("Comfortaa", "comfortaa_bold", FontWeight.Bold, FontStyle.Normal),
-            font("Comfortaa", "comfortaa_medium", FontWeight.Medium, FontStyle.Normal),
-            font("Comfortaa", "comfortaa_light", FontWeight.Light, FontStyle.Normal),
-        )
+interface CoreResources {
+    val github: Painter @Composable get
+    val lemmy: Painter @Composable get
+    val appIconDefault: Painter @Composable get
+    val appIconAlt1: Painter @Composable get
+    val notoSans: FontFamily @Composable get
+    val poppins: FontFamily @Composable get
+    val charisSil: FontFamily @Composable get
+    val comfortaa: FontFamily @Composable get
 }

--- a/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/DefaultCoreResources.kt
+++ b/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/DefaultCoreResources.kt
@@ -1,0 +1,61 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.resources
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+
+internal class DefaultCoreResources : CoreResources {
+
+    override val github: Painter
+        @Composable
+        get() = drawable("ic_github")
+
+    override val lemmy: Painter
+        @Composable
+        get() = drawable("ic_lemmy")
+
+    override val appIconDefault: Painter
+        @Composable
+        get() = drawable("ic_default")
+
+    override val appIconAlt1: Painter
+        @Composable
+        get() = drawable("ic_alt_1")
+
+    override val notoSans: FontFamily
+        @Composable
+        get() = FontFamily(
+            font("NotoSans", "notosans_regular", FontWeight.Normal, FontStyle.Normal),
+            font("NotoSans", "notosans_bold", FontWeight.Bold, FontStyle.Normal),
+            font("NotoSans", "notosans_medium", FontWeight.Medium, FontStyle.Normal),
+            font("NotoSans", "notosans_italic", FontWeight.Normal, FontStyle.Italic),
+        )
+
+    override val poppins: FontFamily
+        @Composable
+        get() = FontFamily(
+            font("Poppins", "poppins_regular", FontWeight.Normal, FontStyle.Normal),
+            font("Poppins", "poppins_bold", FontWeight.Bold, FontStyle.Normal),
+            font("Poppins", "poppins_medium", FontWeight.Medium, FontStyle.Normal),
+            font("Poppins", "poppins_italic", FontWeight.Normal, FontStyle.Italic),
+        )
+
+    override val charisSil: FontFamily
+        @Composable
+        get() = FontFamily(
+            font("CharisSIL", "charissil_regular", FontWeight.Normal, FontStyle.Normal),
+            font("CharisSIL", "charissil_bold", FontWeight.Bold, FontStyle.Normal),
+            font("CharisSIL", "charissil_italic", FontWeight.Normal, FontStyle.Italic),
+        )
+
+    override val comfortaa: FontFamily
+        @Composable
+        get() = FontFamily(
+            font("Comfortaa", "comfortaa_regular", FontWeight.Normal, FontStyle.Normal),
+            font("Comfortaa", "comfortaa_bold", FontWeight.Bold, FontStyle.Normal),
+            font("Comfortaa", "comfortaa_medium", FontWeight.Medium, FontStyle.Normal),
+            font("Comfortaa", "comfortaa_light", FontWeight.Light, FontStyle.Normal),
+        )
+}

--- a/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/Utils.kt
+++ b/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/Utils.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 
 @Composable
-expect fun font(name: String, res: String, weight: FontWeight, style: FontStyle): Font
+internal expect fun font(name: String, res: String, weight: FontWeight, style: FontStyle): Font
 
 @Composable
-expect fun drawable(res: String): Painter
+internal expect fun drawable(res: String): Painter

--- a/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/CoreResourcesModule.kt
+++ b/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/CoreResourcesModule.kt
@@ -1,0 +1,11 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.resources.di
+
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.DefaultCoreResources
+import org.koin.dsl.module
+
+val coreResourceModule = module {
+    single<CoreResources> {
+        DefaultCoreResources()
+    }
+}

--- a/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/Utils.kt
+++ b/core/resources/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/Utils.kt
@@ -1,0 +1,5 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.resources.di
+
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+
+expect fun getCoreResources(): CoreResources

--- a/core/resources/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/Utils.kt
+++ b/core/resources/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/resources/di/Utils.kt
@@ -1,0 +1,13 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.resources.di
+
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+actual fun getCoreResources(): CoreResources {
+    return CoreResourcesDiHelper.coreResources
+}
+
+internal object CoreResourcesDiHelper : KoinComponent {
+    val coreResources: CoreResources by inject()
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
                 implementation(projects.core.notifications)
                 implementation(projects.core.persistence)
                 implementation(projects.core.preferences)
+                implementation(projects.core.resources)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.identity)

--- a/shared/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/di/DiHelper.kt
+++ b/shared/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/di/DiHelper.kt
@@ -8,6 +8,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.navigationMod
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.coreNotificationModule
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.corePersistenceModule
 import com.github.diegoberaldin.raccoonforlemmy.core.preferences.di.corePreferencesModule
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.di.coreResourceModule
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.crashReportModule
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.di.appIconModule
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.di.imagePreloadModule
@@ -111,5 +112,6 @@ val sharedHelperModule = module {
         licenceModule,
         appIconModule,
         fileSystemModule,
+        coreResourceModule,
     )
 }

--- a/shared/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/di/DiHelper.kt
+++ b/shared/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/di/DiHelper.kt
@@ -8,6 +8,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.navigationMod
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.coreNotificationModule
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.corePersistenceModule
 import com.github.diegoberaldin.raccoonforlemmy.core.preferences.di.corePreferencesModule
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.di.coreResourceModule
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.AppInfo
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.crashReportModule
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.di.appIconModule
@@ -114,6 +115,7 @@ fun initKoin() {
             licenceModule,
             appIconModule,
             fileSystemModule,
+            coreResourceModule,
         )
     }
 

--- a/unit/about/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/about/AboutDialog.kt
+++ b/unit/about/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/about/AboutDialog.kt
@@ -37,7 +37,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigation
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.di.getCoreResources
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.unit.about.components.AboutItem
@@ -57,6 +57,7 @@ class AboutDialog : Screen {
         val uiState by viewModel.uiState.collectAsState()
         val notificationCenter = remember { getNotificationCenter() }
         val detailOpener = remember { getDetailOpener() }
+        val coreResources = remember { getCoreResources() }
 
         BasicAlertDialog(
             onDismissRequest = {
@@ -139,7 +140,7 @@ class AboutDialog : Screen {
                     }
                     item {
                         AboutItem(
-                            painter = CoreResources.github,
+                            painter = coreResources.github,
                             text = LocalXmlStrings.current.settingsAboutViewGithub,
                             textDecoration = TextDecoration.Underline,
                             onClick = rememberCallback {
@@ -173,7 +174,7 @@ class AboutDialog : Screen {
                     }
                     item {
                         AboutItem(
-                            painter = CoreResources.lemmy,
+                            painter = coreResources.lemmy,
                             text = LocalXmlStrings.current.settingsAboutViewLemmy,
                             textDecoration = TextDecoration.Underline,
                             onClick = {

--- a/unit/choosefont/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/choosefont/FontFamilyBottomSheet.kt
+++ b/unit/choosefont/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/choosefont/FontFamilyBottomSheet.kt
@@ -25,7 +25,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
-import com.github.diegoberaldin.raccoonforlemmy.core.resources.CoreResources
+import com.github.diegoberaldin.raccoonforlemmy.core.resources.di.getCoreResources
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 
@@ -47,6 +47,8 @@ class FontFamilyBottomSheet(
     override fun Content() {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val notificationCenter = remember { getNotificationCenter() }
+        val coreResources = remember { getCoreResources() }
+
         Column(
             modifier = Modifier
                 .padding(
@@ -97,10 +99,10 @@ class FontFamilyBottomSheet(
                                 ),
                         ) {
                             val fontFamily = when (family) {
-                                UiFontFamily.NotoSans -> CoreResources.notoSans
-                                UiFontFamily.CharisSIL -> CoreResources.charisSil
-                                UiFontFamily.Poppins -> CoreResources.poppins
-                                UiFontFamily.Comfortaa -> CoreResources.comfortaa
+                                UiFontFamily.NotoSans -> coreResources.notoSans
+                                UiFontFamily.CharisSIL -> coreResources.charisSil
+                                UiFontFamily.Poppins -> coreResources.poppins
+                                UiFontFamily.Comfortaa -> coreResources.comfortaa
                                 else -> FontFamily.Default
                             }
                             Text(


### PR DESCRIPTION
This PR refactors `:core:resources` in order to have injectable resources via Koin, provided that any implementation complies with the CoreResources contract.

This will make a lot easier to migrate towards Compose Multiplatform >1.6.0 resource management without expect/actual mechanism to load raw resources differently on different platforms.

For drawables it could alread be done, however the transition is not possible for fonts, because it is currently [not supported(https://github.com/JetBrains/compose-multiplatform/issues/4229) to load custom fonts in a multi-module project.

Anyway this refactoring makes things more configurable and flexible so I am merging it to the main branch.