### PR TITLE
fix: moderator tools access from profile

### DIFF
--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -164,7 +164,8 @@ object ProfileLoggedScreen : Tab {
                                         top = Spacing.xs,
                                         bottom = Spacing.s,
                                     )
-                                    .fillMaxWidth()
+                                    .fillMaxWidth(),
+                                isModerator = uiState.user?.moderator == true,
                             )
                             HorizontalDivider()
                         }


### PR DESCRIPTION
The access to moderator tools had accidentally been removed in #712. This PR fixes it.