### PR TITLE
feat: post navigation in detail screen

### DIFF
--- a/core/commonui/detailopener-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
+++ b/core/commonui/detailopener-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
@@ -23,6 +23,7 @@ interface DetailOpener {
         otherInstance: String = "",
         highlightCommentId: Long? = null,
         isMod: Boolean = false,
+        supportNavigation: Boolean = false,
     )
 
     fun openReply(

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -83,6 +83,7 @@ class DefaultDetailOpener(
         otherInstance: String,
         highlightCommentId: Long?,
         isMod: Boolean,
+        supportNavigation: Boolean
     ) {
         scope.launch {
             withContext(Dispatchers.IO) {
@@ -94,6 +95,7 @@ class DefaultDetailOpener(
                     highlightCommentId = highlightCommentId,
                     otherInstance = otherInstance,
                     isMod = isMod,
+                    supportNavigation = supportNavigation,
                 ),
             )
         }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/CommentPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/CommentPaginationManager.kt
@@ -5,6 +5,6 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 interface CommentPaginationManager {
     val canFetchMore: Boolean
 
-    suspend fun reset(specification: CommentPaginationSpecification)
+    fun reset(specification: CommentPaginationSpecification)
     suspend fun loadNextPage(): List<CommentModel>
 }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/CommentPaginationSpecification.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/CommentPaginationSpecification.kt
@@ -1,19 +1,15 @@
 package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
 
-import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 
 sealed interface CommentPaginationSpecification {
-
-    val history: List<CommentModel>
 
     data class Replies(
         val postId: Long? = null,
         val listingType: ListingType? = null,
         val otherInstance: String? = null,
         val sortType: SortType = SortType.Active,
-        override val history: List<CommentModel> = emptyList(),
     ) : CommentPaginationSpecification
 
     data class User(
@@ -21,12 +17,14 @@ sealed interface CommentPaginationSpecification {
         val name: String? = null,
         val otherInstance: String? = null,
         val sortType: SortType = SortType.New,
-        override val history: List<CommentModel> = emptyList(),
     ) : CommentPaginationSpecification
 
     data class Votes(
         val liked: Boolean = true,
         val sortType: SortType = SortType.New,
-        override val history: List<CommentModel> = emptyList(),
+    ) : CommentPaginationSpecification
+
+    data class Saved(
+        val sortType: SortType = SortType.Active,
     ) : CommentPaginationSpecification
 }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostNavigationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostNavigationManager.kt
@@ -1,0 +1,40 @@
+package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
+
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+
+internal class DefaultPostNavigationManager(
+    private val postPaginationManager: PostPaginationManager,
+) : PostNavigationManager {
+
+
+    override fun setPagination(state: PostPaginationManagerState) {
+        postPaginationManager.restoreState(state)
+    }
+
+    override suspend fun getPrevious(postId: Long): PostModel? {
+        val history = postPaginationManager.history
+        val index = history
+            .indexOfFirst { it.id == postId }
+            .takeIf { it >= 0 } ?: return null
+        return when (index) {
+            0 -> null
+            else -> history.getOrNull(index - 1)
+        }
+    }
+
+    override suspend fun getNext(postId: Long): PostModel? {
+        val history = postPaginationManager.history
+        val index = history
+            .indexOfFirst { it.id == postId }
+            .takeIf { it >= 0 } ?: return null
+        return when {
+            index < history.lastIndex -> history[index + 1]
+            !postPaginationManager.canFetchMore -> null
+            else -> run {
+                val newPosts = postPaginationManager.loadNextPage()
+                val newIndex = newPosts.indexOfFirst { it.id == postId }
+                newPosts.getOrNull(newIndex + 1)
+            }
+        }
+    }
+}

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
@@ -129,6 +129,7 @@ internal class DefaultPostPaginationManager(
                 if (!itemList.isNullOrEmpty()) {
                     currentPage++
                 }
+                canFetchMore = itemList?.isEmpty() != true
                 itemList
                     .orEmpty()
                     .deduplicate()
@@ -155,23 +156,20 @@ internal class DefaultPostPaginationManager(
                     .deduplicate()
             }
 
-            is PostPaginationSpecification.Explore -> {
-                val itemList = communityRepository.search(
+            is PostPaginationSpecification.Saved -> {
+                val itemList = userRepository.getSavedPosts(
                     auth = auth,
                     page = currentPage,
-                    sortType = specification.sortType,
-                    resultType = SearchResultType.Posts,
-                    query = specification.query.orEmpty(),
-                ).mapNotNull {
-                    (it as? SearchResult.Post)?.model
-                }
-                if (itemList.isNotEmpty()) {
+                    sort = specification.sortType,
+                    id = identityRepository.cachedUser?.id ?: 0,
+                )
+                if (!itemList.isNullOrEmpty()) {
                     currentPage++
                 }
-                canFetchMore = itemList.isNotEmpty()
+                canFetchMore = itemList?.isEmpty() != true
                 itemList
+                    .orEmpty()
                     .deduplicate()
-                    .filterNsfw(specification.includeNsfw)
                     .filterDeleted()
             }
         }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
@@ -26,9 +26,9 @@ internal class DefaultPostPaginationManager(
     private var specification: PostPaginationSpecification? = null
     private var currentPage: Int = 1
     private var pageCursor: String? = null
-    private val history: MutableList<PostModel> = mutableListOf()
+    override val history: MutableList<PostModel> = mutableListOf()
 
-    override suspend fun reset(specification: PostPaginationSpecification) {
+    override fun reset(specification: PostPaginationSpecification) {
         this.specification = specification
         history.clear()
         canFetchMore = true

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostNavigationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostNavigationManager.kt
@@ -1,0 +1,9 @@
+package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
+
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+
+interface PostNavigationManager {
+    fun setPagination(state: PostPaginationManagerState)
+    suspend fun getPrevious(postId: Long): PostModel?
+    suspend fun getNext(postId: Long): PostModel?
+}

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostPaginationManager.kt
@@ -7,8 +7,9 @@ interface PostPaginationManagerState
 
 interface PostPaginationManager {
     val canFetchMore: Boolean
+    val history: List<PostModel>
 
-    suspend fun reset(specification: PostPaginationSpecification)
+    fun reset(specification: PostPaginationSpecification)
     suspend fun loadNextPage(): List<PostModel>
     fun extractState(): PostPaginationManagerState
     fun restoreState(state: PostPaginationManagerState)

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostPaginationSpecification.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostPaginationSpecification.kt
@@ -39,11 +39,7 @@ sealed interface PostPaginationSpecification {
         val sortType: SortType = SortType.New,
     ) : PostPaginationSpecification
 
-    data class Explore(
-        val otherInstance: String? = null,
-        val query: String? = null,
-        val listingType: ListingType = ListingType.All,
+    data class Saved(
         val sortType: SortType = SortType.Active,
-        val includeNsfw: Boolean = true,
     ) : PostPaginationSpecification
 }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
@@ -3,8 +3,10 @@ package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.di
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.DefaultCommentPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.DefaultMultiCommunityPaginator
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.DefaultPostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.DefaultPostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.MultiCommunityPaginator
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import org.koin.dsl.module
 
@@ -28,6 +30,11 @@ val paginationModule = module {
             identityRepository = get(),
             userRepository = get(),
             commentRepository = get(),
+        )
+    }
+    single<PostNavigationManager> {
+        DefaultPostNavigationManager(
+            postPaginationManager = get(),
         )
     }
 }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
@@ -41,6 +41,7 @@ interface CommunityDetailMviModel :
         data class SetSearch(val value: String) : Intent
         data class ChangeSearching(val value: Boolean) : Intent
         data class Copy(val value: String) : Intent
+        data object WillOpenDetail : Intent
     }
 
     data class UiState(

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -839,15 +839,13 @@ class CommunityDetailScreen(
                                             fadeRead = uiState.fadeReadPosts,
                                             showUnreadComments = uiState.showUnreadComments,
                                             onClick = rememberCallback(model) {
-                                                model.reduce(
-                                                    CommunityDetailMviModel.Intent.MarkAsRead(
-                                                        post.id
-                                                    )
-                                                )
+                                                model.reduce(CommunityDetailMviModel.Intent.MarkAsRead(post.id))
+                                                model.reduce(CommunityDetailMviModel.Intent.WillOpenDetail)
                                                 detailOpener.openPostDetail(
                                                     post = post,
                                                     otherInstance = otherInstanceName,
                                                     isMod = uiState.moderators.containsId(uiState.currentUserId),
+                                                    supportNavigation = true,
                                                 )
                                             },
                                             onDoubleClick = if (!uiState.doubleTapActionEnabled || !uiState.isLogged || isOnOtherInstance) {
@@ -902,12 +900,12 @@ class CommunityDetailScreen(
                                             },
                                             onReply = rememberCallback {
                                                 if (uiState.isLogged && !isOnOtherInstance) {
-                                                    model.reduce(
-                                                        CommunityDetailMviModel.Intent.MarkAsRead(
-                                                            post.id
-                                                        )
+                                                    model.reduce(CommunityDetailMviModel.Intent.MarkAsRead(post.id))
+                                                    model.reduce(CommunityDetailMviModel.Intent.WillOpenDetail)
+                                                    detailOpener.openPostDetail(
+                                                        post = post,
+                                                        supportNavigation = true,
                                                     )
-                                                    detailOpener.openPostDetail(post)
                                                 }
                                             },
                                             onOpenImage = rememberCallbackArgs(model) { url ->

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.unit.communitydetail
 
 import cafe.adriel.voyager.core.model.screenModelScope
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -63,6 +64,7 @@ class CommunityDetailViewModel(
     private val notificationCenter: NotificationCenter,
     private val itemCache: LemmyItemCache,
     private val communitySortRepository: CommunitySortRepository,
+    private val postNavigationManager: PostNavigationManager,
 ) : CommunityDetailMviModel,
     DefaultMviModel<CommunityDetailMviModel.Intent, CommunityDetailMviModel.UiState, CommunityDetailMviModel.Effect>(
         initialState = CommunityDetailMviModel.UiState(),
@@ -293,6 +295,11 @@ class CommunityDetailViewModel(
             is CommunityDetailMviModel.Intent.SetSearch -> updateSearchText(intent.value)
             is CommunityDetailMviModel.Intent.Copy -> screenModelScope.launch {
                 emitEffect(CommunityDetailMviModel.Effect.TriggerCopy(intent.value))
+            }
+
+            CommunityDetailMviModel.Intent.WillOpenDetail -> {
+                val state = postPaginationManager.extractState()
+                postNavigationManager.setPagination(state)
             }
         }
     }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/di/CommunityDetailModule.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/di/CommunityDetailModule.kt
@@ -27,6 +27,7 @@ val communityDetailModule = module {
             itemCache = get(),
             communitySortRepository = get(),
             postPaginationManager = get(),
+            postNavigationManager = get(),
         )
     }
 }

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
@@ -47,6 +47,7 @@ interface FilteredContentsMviModel :
         data class ModFeaturePost(val id: Long) : Intent
         data class ModLockPost(val id: Long) : Intent
         data class ModDistinguishComment(val commentId: Long) : Intent
+        data object WillOpenDetail: Intent
     }
 
     data class State(

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -379,7 +379,11 @@ class FilteredContentsScreen(
                                             fadeRead = uiState.fadeReadPosts,
                                             showUnreadComments = uiState.showUnreadComments,
                                             onClick = rememberCallback(model) {
-                                                detailOpener.openPostDetail(post)
+                                                model.reduce(FilteredContentsMviModel.Intent.WillOpenDetail)
+                                                detailOpener.openPostDetail(
+                                                    post = post,
+                                                    supportNavigation = true
+                                                )
                                             },
                                             onOpenCommunity = rememberCallbackArgs { community, instance ->
                                                 detailOpener.openCommunityDetail(
@@ -414,7 +418,11 @@ class FilteredContentsScreen(
                                                 )
                                             },
                                             onReply = rememberCallback(model) {
-                                                detailOpener.openPostDetail(post)
+                                                model.reduce(FilteredContentsMviModel.Intent.WillOpenDetail)
+                                                detailOpener.openPostDetail(
+                                                    post = post,
+                                                    supportNavigation = true
+                                                )
                                             },
                                             onOpenImage = rememberCallbackArgs(model, post) { url ->
                                                 navigationCoordinator.pushScreen(
@@ -618,10 +626,12 @@ class FilteredContentsScreen(
                                                 detailOpener.openUserDetail(user, instance)
                                             },
                                             onOpen = rememberCallback {
+                                                model.reduce(FilteredContentsMviModel.Intent.WillOpenDetail)
                                                 detailOpener.openPostDetail(
                                                     post = PostModel(id = comment.postId),
                                                     highlightCommentId = comment.id,
                                                     isMod = true,
+                                                    supportNavigation = true,
                                                 )
                                             },
                                             onUpVote = rememberCallback(model) {

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.unit.filteredcontents
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationSpecification
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -40,6 +41,7 @@ class FilteredContentsViewModel(
     private val imagePreloadManager: ImagePreloadManager,
     private val hapticFeedback: HapticFeedback,
     private val notificationCenter: NotificationCenter,
+    private val postNavigationManager: PostNavigationManager,
 ) : FilteredContentsMviModel,
     DefaultMviModel<FilteredContentsMviModel.Intent, FilteredContentsMviModel.State, FilteredContentsMviModel.Effect>(
         initialState = FilteredContentsMviModel.State(),
@@ -159,6 +161,11 @@ class FilteredContentsViewModel(
                 it.id == intent.commentId
             }?.also { comment ->
                 distinguish(comment)
+            }
+
+            FilteredContentsMviModel.Intent.WillOpenDetail -> {
+                val state = postPaginationManager.extractState()
+                postNavigationManager.setPagination(state)
             }
         }
     }

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/di/FilteredContentsModule.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/di/FilteredContentsModule.kt
@@ -18,6 +18,7 @@ val filteredContentsModule = module {
             notificationCenter = get(),
             postPaginationManager = get(),
             commentPaginationManager = get(),
+            postNavigationManager = get(),
         )
     }
 }

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityMviModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityMviModel.kt
@@ -24,6 +24,7 @@ interface MultiCommunityMviModel :
         data object ClearRead : Intent
         data class Share(val url: String) : Intent
         data class Copy(val value: String) : Intent
+        data object WillOpenDetail: Intent
     }
 
     data class UiState(

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -402,7 +402,11 @@ class MultiCommunityScreen(
                                     showUnreadComments = uiState.showUnreadComments,
                                     onClick = rememberCallback {
                                         model.reduce(MultiCommunityMviModel.Intent.MarkAsRead(post.id))
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(MultiCommunityMviModel.Intent.WillOpenDetail)
+                                        detailOpener.openPostDetail(
+                                            post = post,
+                                            supportNavigation = true,
+                                        )
                                     },
                                     onDoubleClick = if (uiState.swipeActionsEnabled) {
                                         null
@@ -454,8 +458,12 @@ class MultiCommunityScreen(
                                             ),
                                         )
                                     },
-                                    onReply = rememberCallback {
-                                        detailOpener.openPostDetail(post)
+                                    onReply = rememberCallback(model) {
+                                        model.reduce(MultiCommunityMviModel.Intent.WillOpenDetail)
+                                        detailOpener.openPostDetail(
+                                            post = post,
+                                            supportNavigation = true,
+                                        )
                                     },
                                     onOpenImage = rememberCallbackArgs { url ->
                                         model.reduce(MultiCommunityMviModel.Intent.MarkAsRead(post.id))

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.unit.multicommunity.detail
 
 import cafe.adriel.voyager.core.model.screenModelScope
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -42,6 +43,7 @@ class MultiCommunityViewModel(
     private val hapticFeedback: HapticFeedback,
     private val imagePreloadManager: ImagePreloadManager,
     private val getSortTypesUseCase: GetSortTypesUseCase,
+    private val postNavigationManager: PostNavigationManager,
 ) : MultiCommunityMviModel,
     DefaultMviModel<MultiCommunityMviModel.Intent, MultiCommunityMviModel.UiState, MultiCommunityMviModel.Effect>(
         initialState = MultiCommunityMviModel.UiState()
@@ -168,6 +170,11 @@ class MultiCommunityViewModel(
 
             is MultiCommunityMviModel.Intent.Copy -> screenModelScope.launch {
                 emitEffect(MultiCommunityMviModel.Effect.TriggerCopy(intent.value))
+            }
+
+            MultiCommunityMviModel.Intent.WillOpenDetail -> {
+                val state = postPaginationManager.extractState()
+                postNavigationManager.setPagination(state)
             }
         }
     }

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/di/MultiCommunityModule.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/di/MultiCommunityModule.kt
@@ -22,6 +22,7 @@ val multiCommunityModule = module {
             imagePreloadManager = get(),
             getSortTypesUseCase = get(),
             multiCommunityRepository = get(),
+            postNavigationManager = get(),
         )
     }
     factory<MultiCommunityEditorMviModel> { params ->

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
@@ -26,6 +26,7 @@ interface ProfileLoggedMviModel :
         data class UpVoteComment(val id: Long, val feedback: Boolean = false) : Intent
         data class DownVoteComment(val id: Long, val feedback: Boolean = false) : Intent
         data class SaveComment(val id: Long, val feedback: Boolean = false) : Intent
+        data object WillOpenDetail : Intent
     }
 
     data class UiState(

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -225,7 +225,11 @@ object ProfileLoggedScreen : Tab {
                                     hideAuthor = true,
                                     blurNsfw = false,
                                     onClick = rememberCallback {
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(ProfileLoggedMviModel.Intent.WillOpenDetail)
+                                        detailOpener.openPostDetail(
+                                            post = post,
+                                            supportNavigation = true,
+                                        )
                                     },
                                     onOpenCommunity = rememberCallbackArgs { community, instance ->
                                         detailOpener.openCommunityDetail(community, instance)

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.unit.myaccount
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationSpecification
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -47,6 +48,7 @@ class ProfileLoggedViewModel(
     private val shareHelper: ShareHelper,
     private val notificationCenter: NotificationCenter,
     private val hapticFeedback: HapticFeedback,
+    private val postNavigationManager: PostNavigationManager,
 ) : ProfileLoggedMviModel,
     DefaultMviModel<ProfileLoggedMviModel.Intent, ProfileLoggedMviModel.UiState, ProfileLoggedMviModel.Effect>(
         initialState = ProfileLoggedMviModel.UiState()
@@ -189,6 +191,11 @@ class ProfileLoggedViewModel(
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
                     toggleUpVotePost(post = post)
                 }
+            }
+
+            ProfileLoggedMviModel.Intent.WillOpenDetail -> {
+                val state = postPaginationManager.extractState()
+                postNavigationManager.setPagination(state)
             }
         }
     }

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/di/MyAccountModule.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/di/MyAccountModule.kt
@@ -18,6 +18,7 @@ val myAccountModule = module {
             hapticFeedback = get(),
             postPaginationManager = get(),
             commentPaginationManager = get(),
+            postNavigationManager = get(),
         )
     }
 }

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailMviModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailMviModel.kt
@@ -39,6 +39,8 @@ interface PostDetailMviModel :
         data class Copy(val value: String) : Intent
         data class SetSearch(val value: String) : Intent
         data class ChangeSearching(val value: Boolean) : Intent
+        data object NavigatePrevious : Intent
+        data object NavigateNext : Intent
     }
 
     data class UiState(

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.NavigateBefore
+import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.ArrowCircleDown
 import androidx.compose.material.icons.filled.ArrowCircleUp
@@ -153,6 +155,7 @@ class PostDetailScreen(
     private val otherInstance: String = "",
     private val highlightCommentId: Long? = null,
     private val isMod: Boolean = false,
+    private val supportNavigation: Boolean = false,
 ) : Screen {
     override val key: ScreenKey
         get() = super.key + postId.toString()
@@ -173,7 +176,8 @@ class PostDetailScreen(
                     highlightCommentId,
                     isMod,
                 )
-            })
+            },
+        )
         val uiState by model.uiState.collectAsState()
         val isOnOtherInstance = remember { otherInstance.isNotEmpty() }
         val otherInstanceName = remember { otherInstance }
@@ -237,6 +241,7 @@ class PostDetailScreen(
                 }
             }
         }
+        val isNavigationSupported = remember { supportNavigation }
 
         LaunchedEffect(notificationCenter) {
             notificationCenter.resetCache()
@@ -796,7 +801,7 @@ class PostDetailScreen(
                                                             )
                                                             detailOpener.openPostDetail(
                                                                 post = post,
-                                                                otherInstance = otherInstanceName
+                                                                otherInstance = otherInstanceName,
                                                             )
                                                         },
                                                     ),
@@ -1482,6 +1487,21 @@ class PostDetailScreen(
                             }
                             .background(color = MaterialTheme.colorScheme.background.copy(alpha = 0.45f)),
                     ) {
+                        if (isNavigationSupported) {
+                            Icon(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(vertical = Spacing.xs)
+                                    .onClick(
+                                        onClick = rememberCallback(model) {
+                                            model.reduce(PostDetailMviModel.Intent.NavigatePrevious)
+                                        },
+                                    ),
+                                imageVector = Icons.AutoMirrored.Default.NavigateBefore,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
                         Icon(
                             modifier = Modifier
                                 .weight(1f)
@@ -1514,6 +1534,21 @@ class PostDetailScreen(
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onBackground,
                         )
+                        if (isNavigationSupported) {
+                            Icon(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(vertical = Spacing.xs)
+                                    .onClick(
+                                        onClick = rememberCallback(model) {
+                                            model.reduce(PostDetailMviModel.Intent.NavigateNext)
+                                        },
+                                    ),
+                                imageVector = Icons.AutoMirrored.Default.NavigateNext,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
                     }
                 }
             }

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/di/PostDetailModule.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/di/PostDetailModule.kt
@@ -25,6 +25,7 @@ val postDetailModule = module {
             getSortTypesUseCase = get(),
             itemCache = get(),
             commentPaginationManager = get(),
+            postNavigationManager = get(),
         )
     }
 }

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListMviModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListMviModel.kt
@@ -32,6 +32,7 @@ interface PostListMviModel :
         data class StartZombieMode(val index: Int) : Intent
         data object PauseZombieMode : Intent
         data class Copy(val value: String) : Intent
+        data object WillOpenDetail : Intent
     }
 
     data class UiState(

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -451,7 +451,11 @@ class PostListScreen : Screen {
                                         showUnreadComments = uiState.showUnreadComments,
                                         onClick = rememberCallback(model) {
                                             model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
-                                            detailOpener.openPostDetail(post)
+                                            model.reduce(PostListMviModel.Intent.WillOpenDetail)
+                                            detailOpener.openPostDetail(
+                                                post = post,
+                                                supportNavigation = true,
+                                            )
                                         },
                                         onDoubleClick = if (!uiState.doubleTapActionEnabled || !uiState.isLogged) {
                                             null
@@ -492,30 +496,22 @@ class PostListScreen : Screen {
                                         },
                                         onDownVote = rememberCallback(model) {
                                             if (uiState.isLogged) {
-                                                model.reduce(
-                                                    PostListMviModel.Intent.DownVotePost(
-                                                        id = post.id,
-                                                    ),
-                                                )
+                                                model.reduce(PostListMviModel.Intent.DownVotePost(id = post.id))
                                             }
                                         },
                                         onSave = rememberCallback(model) {
                                             if (uiState.isLogged) {
-                                                model.reduce(
-                                                    PostListMviModel.Intent.SavePost(
-                                                        id = post.id,
-                                                    ),
-                                                )
+                                                model.reduce(PostListMviModel.Intent.SavePost(id = post.id))
                                             }
                                         },
                                         onReply = rememberCallback(model) {
                                             if (uiState.isLogged) {
-                                                model.reduce(
-                                                    PostListMviModel.Intent.MarkAsRead(
-                                                        post.id
-                                                    )
+                                                model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
+                                                model.reduce(PostListMviModel.Intent.WillOpenDetail)
+                                                detailOpener.openPostDetail(
+                                                    post = post,
+                                                    supportNavigation = true,
                                                 )
-                                                detailOpener.openPostDetail(post)
                                             }
                                         },
                                         onOpenImage = rememberCallbackArgs(model, post) { url ->

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListViewModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.unit.postlist
 
 import cafe.adriel.voyager.core.model.screenModelScope
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -48,6 +49,7 @@ class PostListViewModel(
     private val zombieModeHelper: ZombieModeHelper,
     private val imagePreloadManager: ImagePreloadManager,
     private val getSortTypesUseCase: GetSortTypesUseCase,
+    private val postNavigationManager: PostNavigationManager,
 ) : PostListMviModel,
     DefaultMviModel<PostListMviModel.Intent, PostListMviModel.UiState, PostListMviModel.Effect>(
         initialState = PostListMviModel.UiState()
@@ -248,6 +250,11 @@ class PostListViewModel(
 
             is PostListMviModel.Intent.Copy -> screenModelScope.launch {
                 emitEffect(PostListMviModel.Effect.TriggerCopy(intent.value))
+            }
+
+            PostListMviModel.Intent.WillOpenDetail -> {
+                val state = postPaginationManager.extractState()
+                postNavigationManager.setPagination(state)
             }
         }
     }

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/di/PostListModule.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/di/PostListModule.kt
@@ -22,6 +22,7 @@ val postListModule = module {
             imagePreloadManager = get(),
             getSortTypesUseCase = get(),
             postPaginationManager = get(),
+            postNavigationManager = get(),
         )
     }
 }

--- a/unit/saveditems/build.gradle.kts
+++ b/unit/saveditems/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
 
                 implementation(projects.domain.identity)
                 implementation(projects.domain.lemmy.data)
+                implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
 
                 implementation(projects.unit.zoomableimage)

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsMviModel.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsMviModel.kt
@@ -26,6 +26,7 @@ interface SavedItemsMviModel :
         data class DownVoteComment(val id: Long, val feedback: Boolean = false) : Intent
         data class SaveComment(val id: Long, val feedback: Boolean = false) : Intent
         data class Share(val url: String) : Intent
+        data object WillOpenSave : Intent
     }
 
     data class UiState(

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -97,6 +98,9 @@ class SavedItemsScreen : Screen {
         val detailOpener = remember { getDetailOpener() }
 
         Scaffold(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .padding(Spacing.xxs),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -167,13 +171,15 @@ class SavedItemsScreen : Screen {
             },
         ) { paddingValues ->
             Column(
-                modifier = Modifier.padding(paddingValues).then(
-                    if (settings.hideNavigationBarWhileScrolling) {
-                        Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
-                    } else {
-                        Modifier
-                    }
-                ).nestedScroll(fabNestedScrollConnection),
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .then(
+                        if (settings.hideNavigationBarWhileScrolling) {
+                            Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+                        } else {
+                            Modifier
+                        }
+                    ).nestedScroll(fabNestedScrollConnection),
                 verticalArrangement = Arrangement.spacedBy(Spacing.s),
             ) {
                 SectionSelector(
@@ -205,7 +211,7 @@ class SavedItemsScreen : Screen {
                 ) {
                     LazyColumn(
                         state = lazyListState,
-                        modifier = Modifier.padding(horizontal = Spacing.xxxs),
+                        modifier = Modifier.padding(horizontal = Spacing.xs),
                     ) {
                         if (uiState.section == SavedItemsSection.Posts) {
                             items(uiState.posts) { post ->
@@ -220,7 +226,11 @@ class SavedItemsScreen : Screen {
                                     showScores = uiState.showScores,
                                     blurNsfw = uiState.blurNsfw,
                                     onClick = rememberCallback {
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(SavedItemsMviModel.Intent.WillOpenSave)
+                                        detailOpener.openPostDetail(
+                                            post = post,
+                                            supportNavigation = true,
+                                        )
                                     },
                                     onOpenCommunity = rememberCallbackArgs { community, instance ->
                                         detailOpener.openCommunityDetail(community, instance)
@@ -260,7 +270,11 @@ class SavedItemsScreen : Screen {
                                         )
                                     },
                                     onReply = rememberCallback {
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(SavedItemsMviModel.Intent.WillOpenSave)
+                                        detailOpener.openPostDetail(
+                                            post = post,
+                                            supportNavigation = true,
+                                        )
                                     },
                                     onOpenImage = rememberCallbackArgs { url ->
                                         navigatorCoordinator.pushScreen(

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/di/SavedItemsModule.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/di/SavedItemsModule.kt
@@ -10,7 +10,8 @@ val savedItemsModule = module {
             identityRepository = get(),
             apiConfigurationRepository = get(),
             siteRepository = get(),
-            userRepository = get(),
+            postPaginationManager = get(),
+            commentPaginationManager = get(),
             postRepository = get(),
             commentRepository = get(),
             themeRepository = get(),
@@ -19,6 +20,7 @@ val savedItemsModule = module {
             hapticFeedback = get(),
             notificationCenter = get(),
             getSortTypesUseCase = get(),
+            postNavigationManager = get(),
         )
     }
 }

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailMviModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailMviModel.kt
@@ -32,6 +32,7 @@ interface UserDetailMviModel :
         data object Block : Intent
         data object BlockInstance : Intent
         data class Copy(val value: String) : Intent
+        data object WillOpenDetail : Intent
     }
 
     data class UiState(

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -596,7 +596,11 @@ class UserDetailScreen(
                                         showScores = uiState.showScores,
                                         actionButtonsActive = uiState.isLogged,
                                         onClick = rememberCallback {
-                                            detailOpener.openPostDetail(post)
+                                            model.reduce(UserDetailMviModel.Intent.WillOpenDetail)
+                                            detailOpener.openPostDetail(
+                                                post = post,
+                                                supportNavigation = true,
+                                            )
                                         },
                                         onDoubleClick = if (!uiState.doubleTapActionEnabled) {
                                             null
@@ -650,10 +654,7 @@ class UserDetailScreen(
                                             )
                                         },
                                         onOpenPost = rememberCallbackArgs { p, instance ->
-                                            detailOpener.openPostDetail(
-                                                post = p,
-                                                otherInstance = instance
-                                            )
+                                            detailOpener.openPostDetail(p, instance)
                                         },
                                         onOpenWeb = rememberCallbackArgs { url ->
                                             navigationCoordinator.pushScreen(WebViewScreen(url))
@@ -661,8 +662,12 @@ class UserDetailScreen(
                                         onReply = if (!uiState.isLogged || isOnOtherInstance) {
                                             null
                                         } else {
+                                            model.reduce(UserDetailMviModel.Intent.WillOpenDetail)
                                             rememberCallback {
-                                                detailOpener.openPostDetail(post)
+                                                detailOpener.openPostDetail(
+                                                    post = post,
+                                                    supportNavigation = true,
+                                                )
                                             }
                                         },
                                         onOpenImage = rememberCallbackArgs { url ->
@@ -938,20 +943,14 @@ class UserDetailScreen(
                                             null
                                         } else {
                                             rememberCallback(model) {
-                                                model.reduce(
-                                                    UserDetailMviModel.Intent.UpVoteComment(comment.id),
-                                                )
+                                                model.reduce(UserDetailMviModel.Intent.UpVoteComment(comment.id))
                                             }
                                         },
                                         onDownVote = if (!uiState.isLogged || isOnOtherInstance) {
                                             null
                                         } else {
                                             rememberCallback(model) {
-                                                model.reduce(
-                                                    UserDetailMviModel.Intent.DownVoteComment(
-                                                        comment.id
-                                                    ),
-                                                )
+                                                model.reduce(UserDetailMviModel.Intent.DownVoteComment(comment.id))
                                             }
                                         },
                                         onReply = if (!uiState.isLogged || isOnOtherInstance) {
@@ -967,19 +966,19 @@ class UserDetailScreen(
                                         onOpenCommunity = rememberCallbackArgs { community, instance ->
                                             detailOpener.openCommunityDetail(
                                                 community = community,
-                                                otherInstance = instance
+                                                otherInstance = instance,
                                             )
                                         },
                                         onOpenCreator = rememberCallbackArgs { user, instance ->
                                             detailOpener.openUserDetail(
                                                 user = user,
-                                                otherInstance = instance
+                                                otherInstance = instance,
                                             )
                                         },
                                         onOpenPost = rememberCallbackArgs { post, instance ->
                                             detailOpener.openPostDetail(
                                                 post = post,
-                                                otherInstance = instance
+                                                otherInstance = instance,
                                             )
                                         },
                                         onOpenWeb = rememberCallbackArgs { url ->

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.unit.userdetail
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.CommentPaginationSpecification
+import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
@@ -57,6 +58,7 @@ class UserDetailViewModel(
     private val imagePreloadManager: ImagePreloadManager,
     private val getSortTypesUseCase: GetSortTypesUseCase,
     private val itemCache: LemmyItemCache,
+    private val postNavigationManager: PostNavigationManager,
 ) : UserDetailMviModel,
     DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.UiState, UserDetailMviModel.Effect>(
         initialState = UserDetailMviModel.UiState(),
@@ -217,6 +219,11 @@ class UserDetailViewModel(
             UserDetailMviModel.Intent.BlockInstance -> blockInstance()
             is UserDetailMviModel.Intent.Copy -> screenModelScope.launch {
                 emitEffect(UserDetailMviModel.Effect.TriggerCopy(intent.value))
+            }
+
+            UserDetailMviModel.Intent.WillOpenDetail -> {
+                val state = postPaginationManager.extractState()
+                postNavigationManager.setPagination(state)
             }
         }
     }

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/di/UserDetailModule.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/di/UserDetailModule.kt
@@ -25,6 +25,7 @@ val userDetailModule = module {
             itemCache = get(),
             postPaginationManager = get(),
             commentPaginationManager = get(),
+            postNavigationManager = get(),
         )
     }
 }


### PR DESCRIPTION
Another PR nobody asked for... to implement the possibility to navigate to the previous and next post in the feed directly from the post detail screen, using the same bottom bar that is used for comment navigation.

This is a feature many users expect and, reading feature request to peer apps, complain when it is missing so I thought it would be nice to include it. It is still experimental (and must be enabled explicitly in the advanced settings screen).