### PR TITLE
fix: consistent icons for posts, replies, arrows

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardFooter.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCardFooter.kt
@@ -105,7 +105,7 @@ fun PostCardFooter(
                                     onReply?.invoke()
                                 },
                             ),
-                        imageVector = Icons.AutoMirrored.Filled.Chat,
+                        imageVector = Icons.AutoMirrored.Default.Chat,
                         contentDescription = null,
                         colorFilter = ColorFilter.tint(color = ancillaryColor),
                     )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/TextFormattingBar.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/TextFormattingBar.kt
@@ -367,7 +367,7 @@ fun TextFormattingBar(
                         onTextFieldValueChanged(newValue)
                     },
                 ),
-                imageVector = Icons.AutoMirrored.Filled.FormatListBulleted,
+                imageVector = Icons.AutoMirrored.Default.FormatListBulleted,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground,
             )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/UserHeader.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/UserHeader.kt
@@ -142,7 +142,7 @@ fun UserHeader(
                     if (postScore != null) {
                         Icon(
                             modifier = Modifier.size(iconSize),
-                            imageVector = Icons.AutoMirrored.Filled.Article,
+                            imageVector = Icons.AutoMirrored.Default.Article,
                             contentDescription = null
                         )
                         Text(
@@ -160,7 +160,7 @@ fun UserHeader(
                         }
                         Icon(
                             modifier = Modifier.size(iconSize),
-                            imageVector = Icons.AutoMirrored.Filled.Reply,
+                            imageVector = Icons.AutoMirrored.Default.Reply,
                             contentDescription = null
                         )
                         Text(

--- a/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
@@ -202,7 +202,7 @@ internal class SortBottomSheetTop(
                             navigator.pop()
                         },
                     ),
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
                     tint = MaterialTheme.colorScheme.onBackground,
                     contentDescription = null,
                 )

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/ActionOnSwipe.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/ActionOnSwipe.kt
@@ -93,7 +93,7 @@ fun ActionOnSwipe.toReadableName(): String = when (this) {
 fun ActionOnSwipe.toIcon(): ImageVector? = when (this) {
     ActionOnSwipe.DownVote -> Icons.Default.ArrowCircleDown
     ActionOnSwipe.None -> null
-    ActionOnSwipe.Reply -> Icons.AutoMirrored.Filled.Reply
+    ActionOnSwipe.Reply -> Icons.AutoMirrored.Default.Reply
     ActionOnSwipe.Save -> Icons.Default.Bookmark
     ActionOnSwipe.ToggleRead -> Icons.Default.MarkChatUnread
     ActionOnSwipe.UpVote -> Icons.Default.ArrowCircleUp

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/SearchResultType.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/SearchResultType.kt
@@ -25,7 +25,7 @@ fun SearchResultType.toIcon(): ImageVector = when (this) {
     SearchResultType.All -> Icons.Default.AllInclusive
     SearchResultType.Comments -> Icons.AutoMirrored.Default.Message
     SearchResultType.Communities -> Icons.Default.Groups
-    SearchResultType.Posts -> Icons.AutoMirrored.Filled.Article
+    SearchResultType.Posts -> Icons.AutoMirrored.Default.Article
     SearchResultType.Users -> Icons.Default.Person
     SearchResultType.Urls -> Icons.Default.AlternateEmail
 }

--- a/feature/home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/ui/HomeTab.kt
+++ b/feature/home/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/home/ui/HomeTab.kt
@@ -1,7 +1,7 @@
 package com.github.diegoberaldin.raccoonforlemmy.feature.home.ui
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Adjust
+import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import cafe.adriel.voyager.navigator.Navigator
@@ -15,7 +15,7 @@ object HomeTab : Tab {
     override val options: TabOptions
         @Composable
         get() {
-            val icon = rememberVectorPainter(Icons.Default.Adjust)
+            val icon = rememberVectorPainter(Icons.AutoMirrored.Default.Article)
             val title = LocalXmlStrings.current.navigationHome
 
             return TabOptions(

--- a/feature/profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
@@ -208,7 +208,7 @@ internal object ProfileMainScreen : Tab {
                                             logoutConfirmDialogOpen = true
                                         },
                                     ),
-                                imageVector = Icons.AutoMirrored.Filled.Logout,
+                                imageVector = Icons.AutoMirrored.Default.Logout,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.primary,
                             )

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.DisplaySettings
 import androidx.compose.material.icons.filled.Photo
@@ -130,7 +131,7 @@ class AdvancedSettingsScreen : Screen {
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )
@@ -215,7 +216,7 @@ class AdvancedSettingsScreen : Screen {
 
                     SettingsHeader(
                         title = LocalXmlStrings.current.settingsTitleReading,
-                        icon = Icons.Default.Book,
+                        icon = Icons.AutoMirrored.Default.Article,
                     )
                     if (uiState.isLogged) {
                         // visually differentiate read posts

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
@@ -109,7 +109,7 @@ class SettingsColorAndFontScreen : Screen {
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )

--- a/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -161,7 +161,7 @@ class AccountSettingsScreen : Screen {
                                             }
                                         },
                                     ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )
@@ -296,7 +296,7 @@ class AccountSettingsScreen : Screen {
                     )
 
                     SettingsHeader(
-                        icon = Icons.AutoMirrored.Filled.Article,
+                        icon = Icons.AutoMirrored.Default.Article,
                         title = LocalXmlStrings.current.settingsWebHeaderContents,
                     )
 

--- a/unit/ban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/ban/BanUserScreen.kt
+++ b/unit/ban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/ban/BanUserScreen.kt
@@ -133,7 +133,7 @@ class BanUserScreen(
                             modifier = Modifier.padding(horizontal = Spacing.xs),
                             content = {
                                 Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    imageVector = Icons.AutoMirrored.Default.Send,
                                     contentDescription = null,
                                 )
                             },

--- a/unit/chat/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -157,7 +157,7 @@ class InboxChatScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )
@@ -176,7 +176,7 @@ class InboxChatScreen(
                         onSelectImage = {
                             openImagePicker = true
                         },
-                        lastActionIcon = Icons.AutoMirrored.Filled.Send,
+                        lastActionIcon = Icons.AutoMirrored.Default.Send,
                         onLastAction = rememberCallback {
                             model.reduce(
                                 InboxChatMviModel.Intent.SubmitNewMessage(

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -534,7 +534,7 @@ class CommunityDetailScreen(
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )
@@ -780,7 +780,7 @@ class CommunityDetailScreen(
                                             ActionOnSwipe.Reply -> SwipeAction(
                                                 swipeContent = {
                                                     Icon(
-                                                        imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                        imageVector = Icons.AutoMirrored.Default.Reply,
                                                         contentDescription = null,
                                                         tint = Color.White,
                                                     )
@@ -850,7 +850,11 @@ class CommunityDetailScreen(
                                             fadeRead = uiState.fadeReadPosts,
                                             showUnreadComments = uiState.showUnreadComments,
                                             onClick = rememberCallback(model) {
-                                                model.reduce(CommunityDetailMviModel.Intent.MarkAsRead(post.id))
+                                                model.reduce(
+                                                    CommunityDetailMviModel.Intent.MarkAsRead(
+                                                        post.id
+                                                    )
+                                                )
                                                 model.reduce(CommunityDetailMviModel.Intent.WillOpenDetail)
                                                 detailOpener.openPostDetail(
                                                     post = post,
@@ -910,7 +914,11 @@ class CommunityDetailScreen(
                                             },
                                             onReply = rememberCallback {
                                                 if (uiState.isLogged && !isOnOtherInstance) {
-                                                    model.reduce(CommunityDetailMviModel.Intent.MarkAsRead(post.id))
+                                                    model.reduce(
+                                                        CommunityDetailMviModel.Intent.MarkAsRead(
+                                                            post.id
+                                                        )
+                                                    )
                                                     model.reduce(CommunityDetailMviModel.Intent.WillOpenDetail)
                                                     detailOpener.openPostDetail(post)
                                                 }

--- a/unit/communityinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
+++ b/unit/communityinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
@@ -114,7 +114,7 @@ class CommunityInfoScreen(
                         )
                         DetailInfoItem(
                             modifier = Modifier.fillMaxWidth(),
-                            icon = Icons.AutoMirrored.Filled.Article,
+                            icon = Icons.AutoMirrored.Default.Article,
                             title = LocalXmlStrings.current.communityInfoPosts,
                             value = uiState.community.posts.getPrettyNumber(
                                 thousandLabel = LocalXmlStrings.current.profileThousandShort,
@@ -123,7 +123,7 @@ class CommunityInfoScreen(
                         )
                         DetailInfoItem(
                             modifier = Modifier.fillMaxWidth(),
-                            icon = Icons.AutoMirrored.Filled.Reply,
+                            icon = Icons.AutoMirrored.Default.Reply,
                             title = LocalXmlStrings.current.communityInfoComments,
                             value = uiState.community.comments.getPrettyNumber(
                                 thousandLabel = LocalXmlStrings.current.profileThousandShort,

--- a/unit/configurecontentview/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -85,7 +85,7 @@ class ConfigureContentViewScreen : Screen {
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
@@ -88,7 +88,7 @@ class ConfigureSwipeActionsScreen : Screen {
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )
@@ -116,7 +116,7 @@ class ConfigureSwipeActionsScreen : Screen {
                     item {
                         SettingsHeader(
                             title = LocalXmlStrings.current.exploreResultTypePosts,
-                            icon = Icons.AutoMirrored.Filled.Article,
+                            icon = Icons.AutoMirrored.Default.Article,
                             rightButton = @Composable {
                                 TextButton(
                                     contentPadding = PaddingValues(
@@ -154,7 +154,7 @@ class ConfigureSwipeActionsScreen : Screen {
                         ConfigureActionItem(
                             icon = when (idx) {
                                 1 -> Icons.Default.KeyboardDoubleArrowLeft
-                                else -> Icons.AutoMirrored.Filled.KeyboardArrowLeft
+                                else -> Icons.AutoMirrored.Default.KeyboardArrowLeft
                             },
                             action = action,
                             options = buildList {
@@ -210,7 +210,7 @@ class ConfigureSwipeActionsScreen : Screen {
                         ConfigureActionItem(
                             icon = when (idx) {
                                 1 -> Icons.Default.KeyboardDoubleArrowRight
-                                else -> Icons.AutoMirrored.Filled.KeyboardArrowRight
+                                else -> Icons.AutoMirrored.Default.KeyboardArrowRight
                             },
                             action = action,
                             options = buildList {
@@ -255,7 +255,7 @@ class ConfigureSwipeActionsScreen : Screen {
                     item {
                         SettingsHeader(
                             title = LocalXmlStrings.current.exploreResultTypeComments,
-                            icon = Icons.AutoMirrored.Filled.Message,
+                            icon = Icons.AutoMirrored.Default.Message,
                             rightButton = @Composable {
                                 TextButton(
                                     contentPadding = PaddingValues(
@@ -293,7 +293,7 @@ class ConfigureSwipeActionsScreen : Screen {
                         ConfigureActionItem(
                             icon = when (idx) {
                                 1 -> Icons.Default.KeyboardDoubleArrowLeft
-                                else -> Icons.AutoMirrored.Filled.KeyboardArrowLeft
+                                else -> Icons.AutoMirrored.Default.KeyboardArrowLeft
                             },
                             action = action,
                             options = buildList {
@@ -349,7 +349,7 @@ class ConfigureSwipeActionsScreen : Screen {
                         ConfigureActionItem(
                             icon = when (idx) {
                                 1 -> Icons.Default.KeyboardDoubleArrowRight
-                                else -> Icons.AutoMirrored.Filled.KeyboardArrowRight
+                                else -> Icons.AutoMirrored.Default.KeyboardArrowRight
                             },
                             action = action,
                             options = buildList {
@@ -432,7 +432,7 @@ class ConfigureSwipeActionsScreen : Screen {
                         ConfigureActionItem(
                             icon = when (idx) {
                                 1 -> Icons.Default.KeyboardDoubleArrowLeft
-                                else -> Icons.AutoMirrored.Filled.KeyboardArrowLeft
+                                else -> Icons.AutoMirrored.Default.KeyboardArrowLeft
                             },
                             action = action,
                             options = buildList {
@@ -488,7 +488,7 @@ class ConfigureSwipeActionsScreen : Screen {
                         ConfigureActionItem(
                             icon = when (idx) {
                                 1 -> Icons.Default.KeyboardDoubleArrowRight
-                                else -> Icons.AutoMirrored.Filled.KeyboardArrowRight
+                                else -> Icons.AutoMirrored.Default.KeyboardArrowRight
                             },
                             action = action,
                             options = buildList {

--- a/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -209,7 +209,7 @@ class CreateCommentScreen(
                             modifier = Modifier.padding(horizontal = Spacing.xs),
                             content = {
                                 Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    imageVector = Icons.AutoMirrored.Default.Send,
                                     contentDescription = null,
                                 )
                             },

--- a/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -277,7 +277,7 @@ class CreatePostScreen(
                             modifier = Modifier.padding(horizontal = Spacing.xs),
                             content = {
                                 Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    imageVector = Icons.AutoMirrored.Default.Send,
                                     contentDescription = null,
                                 )
                             },

--- a/unit/createreport/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createreport/CreateReportScreen.kt
+++ b/unit/createreport/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createreport/CreateReportScreen.kt
@@ -123,7 +123,7 @@ class CreateReportScreen(
                             modifier = Modifier.padding(horizontal = Spacing.xs),
                             content = {
                                 Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    imageVector = Icons.AutoMirrored.Default.Send,
                                     contentDescription = null,
                                 )
                             },

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -95,7 +95,7 @@ class DraftsScreen : Screen {
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/components/DraftCard.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/components/DraftCard.kt
@@ -89,8 +89,8 @@ fun DraftCard(
                         horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                     ) {
                         val imageVector = when (draft.type) {
-                            DraftType.Comment -> Icons.AutoMirrored.Filled.Reply
-                            DraftType.Post -> Icons.AutoMirrored.Filled.Article
+                            DraftType.Comment -> Icons.AutoMirrored.Default.Reply
+                            DraftType.Post -> Icons.AutoMirrored.Default.Article
                         }
                         Icon(
                             imageVector = imageVector,

--- a/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -163,7 +163,7 @@ class EditCommunityScreen(
                                             }
                                         },
                                     ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -360,7 +360,7 @@ class ExploreScreen(
                                                 ActionOnSwipe.Reply -> SwipeAction(
                                                     swipeContent = {
                                                         Icon(
-                                                            imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                            imageVector = Icons.AutoMirrored.Default.Reply,
                                                             contentDescription = null,
                                                             tint = Color.White,
                                                         )
@@ -555,7 +555,7 @@ class ExploreScreen(
                                                 ActionOnSwipe.Reply -> SwipeAction(
                                                     swipeContent = {
                                                         Icon(
-                                                            imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                            imageVector = Icons.AutoMirrored.Default.Reply,
                                                             contentDescription = null,
                                                             tint = Color.White,
                                                         )

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
@@ -81,7 +81,7 @@ internal fun ExploreTopBar(
                                 onBack?.invoke()
                             },
                         ),
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        imageVector = Icons.AutoMirrored.Default.ArrowBack,
                         contentDescription = null,
                         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                     )

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -151,7 +151,7 @@ class FilteredContentsScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )
@@ -328,7 +328,7 @@ class FilteredContentsScreen(
                                             ActionOnSwipe.Reply -> SwipeAction(
                                                 swipeContent = {
                                                     Icon(
-                                                        imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                        imageVector = Icons.AutoMirrored.Default.Reply,
                                                         contentDescription = null,
                                                         tint = Color.White,
                                                     )
@@ -570,7 +570,7 @@ class FilteredContentsScreen(
                                             ActionOnSwipe.Reply -> SwipeAction(
                                                 swipeContent = {
                                                     Icon(
-                                                        imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                        imageVector = Icons.AutoMirrored.Default.Reply,
                                                         contentDescription = null,
                                                         tint = Color.White,
                                                     )

--- a/unit/instanceinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
@@ -101,7 +101,7 @@ class InstanceInfoScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/licences/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/licences/LicencesScreen.kt
+++ b/unit/licences/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/licences/LicencesScreen.kt
@@ -76,7 +76,7 @@ class LicencesScreen : Screen {
                                             navigationCoordinator.popScreen()
                                         },
                                     ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )

--- a/unit/login/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/login/LoginBottomSheet.kt
+++ b/unit/login/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/login/LoginBottomSheet.kt
@@ -149,7 +149,7 @@ class LoginBottomSheet : Screen {
                             },
                         ) {
                             Icon(
-                                imageVector = Icons.AutoMirrored.Filled.HelpOutline,
+                                imageVector = Icons.AutoMirrored.Default.HelpOutline,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onBackground,
                             )

--- a/unit/manageban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
+++ b/unit/manageban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
@@ -85,7 +85,7 @@ class ManageBanScreen : Screen {
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
@@ -147,7 +147,7 @@ class ManageSubscriptionsScreen : Screen {
                                     navigatorCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/modlog/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/modlog/ModlogScreen.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/modlog/ModlogScreen.kt
@@ -120,7 +120,7 @@ class ModlogScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/modlog/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/modlog/components/InnerModlogItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/modlog/components/InnerModlogItem.kt
@@ -242,7 +242,7 @@ private fun ModlogFooter(
                                 onOpen.invoke()
                             },
                         ),
-                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                    imageVector = Icons.AutoMirrored.Default.OpenInNew,
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
                 )

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -174,7 +174,7 @@ class MultiCommunityScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )
@@ -339,7 +339,7 @@ class MultiCommunityScreen(
                                     ActionOnSwipe.Reply -> SwipeAction(
                                         swipeContent = {
                                             Icon(
-                                                imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                imageVector = Icons.AutoMirrored.Default.Reply,
                                                 contentDescription = null,
                                                 tint = Color.White,
                                             )

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
@@ -105,7 +105,7 @@ class MultiCommunityEditorScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -386,7 +386,7 @@ class PostDetailScreen(
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )
@@ -428,7 +428,7 @@ class PostDetailScreen(
                             )
                             if (uiState.isLogged && !isOnOtherInstance) {
                                 this += FloatingActionButtonMenuItem(
-                                    icon = Icons.AutoMirrored.Filled.Reply,
+                                    icon = Icons.AutoMirrored.Default.Reply,
                                     text = LocalXmlStrings.current.actionReply,
                                     onSelected = rememberCallback {
                                         detailOpener.openReply(
@@ -879,7 +879,7 @@ class PostDetailScreen(
                                                     ActionOnSwipe.Reply -> SwipeAction(
                                                         swipeContent = {
                                                             Icon(
-                                                                imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                                imageVector = Icons.AutoMirrored.Default.Reply,
                                                                 contentDescription = null,
                                                                 tint = Color.White,
                                                             )

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -389,7 +389,7 @@ class PostListScreen : Screen {
                                         ActionOnSwipe.Reply -> SwipeAction(
                                             swipeContent = {
                                                 Icon(
-                                                    imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                    imageVector = Icons.AutoMirrored.Default.Reply,
                                                     contentDescription = null,
                                                     tint = Color.White,
                                                 )

--- a/unit/remove/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/remove/RemoveScreen.kt
+++ b/unit/remove/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/remove/RemoveScreen.kt
@@ -119,7 +119,7 @@ class RemoveScreen(
                             modifier = Modifier.padding(horizontal = Spacing.xs),
                             content = {
                                 Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    imageVector = Icons.AutoMirrored.Default.Send,
                                     contentDescription = null,
                                 )
                             },

--- a/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -107,7 +107,7 @@ class ReportListScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/components/InnerReportCard.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/components/InnerReportCard.kt
@@ -242,7 +242,7 @@ private fun ReportFooter(
                                 onOpenResolve.invoke()
                             },
                         ),
-                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                    imageVector = Icons.AutoMirrored.Default.OpenInNew,
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
                 )

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
@@ -135,7 +135,7 @@ class SavedItemsScreen : Screen {
                                     navigatorCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -350,7 +350,7 @@ class UserDetailScreen(
                                         navigationCoordinator.popScreen()
                                     },
                                 ),
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                             )
@@ -383,7 +383,7 @@ class UserDetailScreen(
                             )
                             if (uiState.isLogged && !isOnOtherInstance) {
                                 this += FloatingActionButtonMenuItem(
-                                    icon = Icons.AutoMirrored.Filled.Chat,
+                                    icon = Icons.AutoMirrored.Default.Chat,
                                     text = LocalXmlStrings.current.actionChat,
                                     onSelected = rememberCallback {
                                         val screen = InboxChatScreen(otherUserId = userId)
@@ -533,7 +533,7 @@ class UserDetailScreen(
                                         ActionOnSwipe.Reply -> SwipeAction(
                                             swipeContent = {
                                                 Icon(
-                                                    imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                    imageVector = Icons.AutoMirrored.Default.Reply,
                                                     contentDescription = null,
                                                     tint = Color.White,
                                                 )
@@ -833,7 +833,7 @@ class UserDetailScreen(
                                         ActionOnSwipe.Reply -> SwipeAction(
                                             swipeContent = {
                                                 Icon(
-                                                    imageVector = Icons.AutoMirrored.Filled.Reply,
+                                                    imageVector = Icons.AutoMirrored.Default.Reply,
                                                     contentDescription = null,
                                                     tint = Color.White,
                                                 )

--- a/unit/userinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
+++ b/unit/userinfo/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
@@ -117,7 +117,7 @@ class UserInfoScreen(
                         uiState.user.score?.also { score ->
                             DetailInfoItem(
                                 modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.AutoMirrored.Filled.Article,
+                                icon = Icons.AutoMirrored.Default.Article,
                                 title = LocalXmlStrings.current.communityInfoPosts,
                                 value = score.postScore.getPrettyNumber(
                                     thousandLabel = LocalXmlStrings.current.profileThousandShort,
@@ -126,7 +126,7 @@ class UserInfoScreen(
                             )
                             DetailInfoItem(
                                 modifier = Modifier.fillMaxWidth(),
-                                icon = Icons.AutoMirrored.Filled.Reply,
+                                icon = Icons.AutoMirrored.Default.Reply,
                                 title = LocalXmlStrings.current.communityInfoComments,
                                 value = score.commentScore.getPrettyNumber(
                                     thousandLabel = LocalXmlStrings.current.profileThousandShort,

--- a/unit/web/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/web/WebViewScreen.kt
+++ b/unit/web/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/web/WebViewScreen.kt
@@ -67,7 +67,7 @@ class WebViewScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
                         )

--- a/unit/zoomableimage/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
@@ -89,7 +89,7 @@ class ZoomableImageScreen(
                                     navigationCoordinator.popScreen()
                                 },
                             ),
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onBackground,
                         )


### PR DESCRIPTION
This PR makes use of consistent icons for posts and replies. The rest is just renaming.