### PR TITLE
feat: show bot accounts in comments

### DIFF
--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/Person.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/Person.kt
@@ -19,7 +19,7 @@ data class Person(
     @SerialName("deleted") val deleted: Boolean,
     @SerialName("matrix_user_id") val matrixUserId: String? = null,
     @SerialName("admin") val admin: Boolean? = null,
-    @SerialName("bot_account") val botAccount: Boolean,
+    @SerialName("bot_account") val botAccount: Boolean? = null,
     @SerialName("ban_expires") val banExpires: String? = null,
     @SerialName("instance_id") val instanceId: InstanceId,
 )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CollapsedCommentCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CollapsedCommentCard.kt
@@ -38,6 +38,7 @@ fun CollapsedCommentCard(
     showScores: Boolean = true,
     actionButtonsActive: Boolean = true,
     isOp: Boolean = false,
+    showBot: Boolean = false,
     options: List<Option> = emptyList(),
     onClick: (() -> Unit)? = null,
     onOpenCreator: ((UserModel) -> Unit)? = null,
@@ -81,8 +82,9 @@ fun CollapsedCommentCard(
                     iconSize = IconSize.s,
                     creator = comment.creator,
                     indicatorExpanded = comment.expanded,
-                    distinguished =  comment.distinguished,
+                    distinguished = comment.distinguished,
                     isOp = isOp,
+                    isBot = comment.creator?.bot?.takeIf { showBot } ?: false,
                     autoLoadImages = autoLoadImages,
                     preferNicknames = preferNicknames,
                     onToggleExpanded = {

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
@@ -58,6 +58,7 @@ fun CommentCard(
     showExpandedIndicator: Boolean = true,
     actionButtonsActive: Boolean = true,
     isOp: Boolean = false,
+    showBot: Boolean = false,
     options: List<Option> = emptyList(),
     onClick: (() -> Unit)? = null,
     onImageClick: ((String) -> Unit)? = null,
@@ -115,6 +116,7 @@ fun CommentCard(
                     indicatorExpanded = comment.expanded.takeIf { showExpandedIndicator },
                     distinguished = comment.distinguished,
                     isOp = isOp,
+                    isBot = comment.creator?.bot.takeIf { showBot } ?: false,
                     onOpenCreator = rememberCallbackArgs { user ->
                         onOpenCreator?.invoke(user, "")
                     },

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommunityAndCreatorInfo.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommunityAndCreatorInfo.kt
@@ -1,8 +1,6 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,13 +24,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ContentFontClass
-import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.ancillaryTextAlpha
@@ -44,6 +38,9 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableName
+
+private const val OP_LABEL = "OP"
+private const val BOT_LABEL = "BOT"
 
 @Composable
 fun CommunityAndCreatorInfo(
@@ -60,6 +57,7 @@ fun CommunityAndCreatorInfo(
     locked: Boolean = false,
     isFromModerator: Boolean = false,
     isOp: Boolean = false,
+    isBot: Boolean = false,
     markRead: Boolean = false,
     onOpenCommunity: ((CommunityModel) -> Unit)? = null,
     onOpenCreator: ((UserModel) -> Unit)? = null,
@@ -186,11 +184,20 @@ fun CommunityAndCreatorInfo(
             }
         }
         if (isOp) {
-            OpIndicator(
+            IndicatorChip(
                 modifier = Modifier.align(Alignment.CenterVertically),
+                text = OP_LABEL,
             )
         }
+        if (isBot) {
+            IndicatorChip(
+                modifier = Modifier.align(Alignment.CenterVertically),
+                text = BOT_LABEL,
+            )
+        }
+
         Spacer(modifier = Modifier.weight(1f))
+
         val buttonModifier = Modifier.size(IconSize.m).padding(3.5.dp)
         if (isFromModerator) {
             Icon(
@@ -248,33 +255,5 @@ fun CommunityAndCreatorInfo(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun OpIndicator(
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .border(
-                color = MaterialTheme.colorScheme.onBackground,
-                width = Dp.Hairline,
-                shape = RoundedCornerShape(CornerSize.m)
-            )
-            .padding(
-                vertical = Spacing.xxxs,
-                horizontal = Spacing.xs,
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = "OP",
-            style = MaterialTheme.typography.labelSmall,
-            fontSize = 8.sp,
-            fontFamily = FontFamily.Default,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
     }
 }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/IndicatorChip.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/IndicatorChip.kt
@@ -1,0 +1,46 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.sp
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.CornerSize
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+
+@Composable
+fun IndicatorChip(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .border(
+                color = MaterialTheme.colorScheme.onBackground,
+                width = Dp.Hairline,
+                shape = RoundedCornerShape(CornerSize.m)
+            )
+            .padding(
+                vertical = Spacing.xxxs,
+                horizontal = Spacing.xs,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            fontSize = 8.sp,
+            fontFamily = FontFamily.Default,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/UserHeader.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/UserHeader.kt
@@ -188,6 +188,13 @@ fun UserHeader(
                         )
                     }
 
+                    if (user.bot) {
+                        if (postScore != null || commentScore != null || user.accountAge.isNotEmpty()) {
+                            Spacer(modifier = Modifier.width(Spacing.xxxs))
+                        }
+                        IndicatorChip(text = "BOT")
+                    }
+
                     Spacer(modifier = Modifier.weight(1f))
 
                     if (onInfo != null) {

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/UserModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/UserModel.kt
@@ -16,6 +16,7 @@ data class UserModel(
     val updateDate: String? = null,
     val admin: Boolean = false,
     val moderator: Boolean = false,
+    val bot: Boolean = false,
 )
 
 fun List<UserModel>.containsId(value: Long?): Boolean = any { it.id == value }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultSiteRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultSiteRepository.kt
@@ -91,7 +91,7 @@ internal class DefaultSiteRepository(
                     avatar = person.avatar,
                     banner = person.banner,
                     bio = person.bio,
-                    bot = person.botAccount,
+                    bot = person.botAccount ?: false,
                     displayName = person.displayName,
                     matrixUserId = person.matrixUserId,
                 )

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
@@ -165,6 +165,7 @@ internal fun Person.toModel() = UserModel(
     matrixUserId = matrixUserId,
     updateDate = updated,
     admin = admin ?: false,
+    bot = botAccount ?: false,
 )
 
 internal fun PersonView.toModel() = person.toModel().copy(

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -616,6 +616,7 @@ class ExploreScreen(
                                                 autoLoadImages = uiState.autoLoadImages,
                                                 preferNicknames = uiState.preferNicknames,
                                                 showScores = uiState.showScores,
+                                                showBot = true,
                                                 showExpandedIndicator = false,
                                                 hideIndent = true,
                                                 actionButtonsActive = uiState.isLogged,

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/components/ModdedCommentCard.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/components/ModdedCommentCard.kt
@@ -43,7 +43,6 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.CommentCar
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.toLocalDp
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
@@ -91,6 +90,7 @@ fun ModdedCommentCard(
                 autoLoadImages = autoLoadImages,
                 preferNicknames = preferNicknames,
                 showExpandedIndicator = false,
+                showBot = true,
                 hideIndent = true,
                 onClick = onOpen,
                 onOpenCreator = onOpenUser,

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -959,6 +959,7 @@ class PostDetailScreen(
                                                             ),
                                                         comment = comment,
                                                         isOp = comment.creator?.id == uiState.post.creator?.id,
+                                                        showBot = true,
                                                         voteFormat = uiState.voteFormat,
                                                         autoLoadImages = uiState.autoLoadImages,
                                                         preferNicknames = uiState.preferNicknames,
@@ -1185,6 +1186,7 @@ class PostDetailScreen(
                                             CollapsedCommentCard(
                                                 comment = comment,
                                                 isOp = comment.creator?.id == uiState.post.creator?.id,
+                                                showBot = true,
                                                 voteFormat = uiState.voteFormat,
                                                 autoLoadImages = uiState.autoLoadImages,
                                                 showScores = uiState.showScores,

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
@@ -355,6 +355,7 @@ class SavedItemsScreen : Screen {
                                     autoLoadImages = uiState.autoLoadImages,
                                     preferNicknames = uiState.preferNicknames,
                                     showScores = uiState.showScores,
+                                    showBot = true,
                                     hideIndent = true,
                                     onClick = {
                                         detailOpener.openPostDetail(


### PR DESCRIPTION
This PR adds an indicator for bot accounts in comments (post detail, explore, saved items, moderated and filtered contents) and in user detail.