### PR TITLE
enhancement: add reset after changing NSFW setting

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
@@ -187,6 +187,8 @@ class SettingsViewModel(
                 includeNsfw = value
             )
             saveSettings(settings)
+            notificationCenter.send(NotificationCenterEvent.ResetHome)
+            notificationCenter.send(NotificationCenterEvent.ResetExplore)
         }
     }
 


### PR DESCRIPTION
The Home and Explore feeds should be reset after changing NSFW inclusion criteria.