### PR TITLE
fix: add intent for activity alias

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -52,6 +52,11 @@
                 <action android:name="dev.zwander.lemmyredirect.intent.action.OPEN_FEDI_LINK"/>
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
         </activity-alias>
     </application>
 </manifest>


### PR DESCRIPTION
This PR makes it possible to receive contents from the system share menu even when using the alternate icon.