### PR TITLE
fix: refresh completely inbox after account switch

### DIFF
--- a/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsViewModel.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsViewModel.kt
@@ -13,6 +13,8 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PersonMentionM
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -263,5 +265,8 @@ class InboxMentionsViewModel(
 
     private fun handleLogout() {
         updateState { it.copy(mentions = emptyList()) }
+        screenModelScope.launch(Dispatchers.IO) {
+            refresh(initial = true)
+        }
     }
 }

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesViewModel.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesViewModel.kt
@@ -167,5 +167,8 @@ class InboxMessagesViewModel(
 
     private fun handleLogout() {
         updateState { it.copy(chats = emptyList()) }
+        screenModelScope.launch(Dispatchers.IO) {
+            refresh(initial = true)
+        }
     }
 }

--- a/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
+++ b/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
@@ -14,6 +14,8 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -263,5 +265,8 @@ class InboxRepliesViewModel(
 
     private fun handleLogout() {
         updateState { it.copy(replies = emptyList()) }
+        screenModelScope.launch(Dispatchers.IO) {
+            refresh(initial = true)
+        }
     }
 }


### PR DESCRIPTION
As per title, this PR makes sure the inbox is in a consistent state after account switch.