### PR TITLE
fix: status bar color for light theme

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
@@ -23,12 +23,7 @@ class DefaultBarColorProvider : BarColorProvider {
                 }
                 val barColor = when (barTheme) {
                     UiBarTheme.Opaque -> baseColor.copy(alpha = 0.25f)
-                    UiBarTheme.Transparent -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        Color.Transparent
-                    } else {
-                        baseColor
-                    }
-
+                    UiBarTheme.Transparent -> baseColor.copy(alpha = 0.01f)
                     else -> baseColor
                 }.toArgb()
                 statusBarColor = barColor

--- a/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/BottomSheetHandle.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/components/BottomSheetHandle.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.ancillaryTextAlpha
@@ -35,8 +36,9 @@ fun BottomSheetHeader(
                 bottom = Spacing.xs,
             ),
             text = title,
-            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
             style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onBackground,
         )
     }
 }


### PR DESCRIPTION
This PR fixes the status bar (especially in transparent mode) for light theme.

Since bottom sheets with long titles (like the "System notification and navigation bar theme" one) were ugly, the text alignment is fixed here too.