### PR TITLE
fix: report list loading indicator

### DIFF
--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -699,6 +699,7 @@ class CommunityDetailScreen(
                             .pullRefresh(pullRefreshState),
                     ) {
                         LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
                             state = lazyListState,
                             userScrollEnabled = !uiState.zombieModeActive,
                         ) {

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -150,7 +151,9 @@ class DraftsScreen : Screen {
                         .pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
-                        modifier = Modifier.padding(horizontal = Spacing.xs),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = Spacing.xs),
                         state = lazyListState,
                         verticalArrangement = Arrangement.spacedBy(Spacing.interItem)
                     ) {

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -283,6 +284,7 @@ class ExploreScreen(
                         ).nestedScroll(keyboardScrollConnection).pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                     ) {
                         if (uiState.results.isEmpty() && uiState.loading) {

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -278,6 +279,7 @@ class FilteredContentsScreen(
                         .pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                         verticalArrangement = Arrangement.spacedBy(Spacing.interItem)
                     ) {

--- a/unit/licences/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/licences/LicencesScreen.kt
+++ b/unit/licences/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/licences/LicencesScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -86,7 +87,7 @@ class LicencesScreen : Screen {
             },
         ) { paddingValues ->
             LazyColumn(
-                modifier = Modifier.padding(paddingValues),
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
                 items(uiState.items) { item ->

--- a/unit/manageban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
+++ b/unit/manageban/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -154,6 +155,7 @@ class ManageBanScreen : Screen {
                         .pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                         verticalArrangement = Arrangement.spacedBy(Spacing.s)
                     ) {

--- a/unit/modlog/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/modlog/ModlogScreen.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/modlog/ModlogScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -156,8 +157,8 @@ class ModlogScreen(
                         .pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
-                        verticalArrangement = Arrangement.spacedBy(Spacing.interItem)
                     ) {
                         if (uiState.items.isEmpty() && uiState.loading && uiState.initial) {
                             items(5) {

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -281,6 +282,7 @@ class MultiCommunityScreen(
                     .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
                     state = lazyListState,
                 ) {
                     if (uiState.posts.isEmpty() && uiState.loading) {

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -130,6 +130,7 @@ object ProfileLoggedScreen : Tab {
                 modifier = Modifier.pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
                     state = lazyListState,
                 ) {
                     if (uiState.user == null) {

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -717,6 +717,7 @@ class PostDetailScreen(
                             .pullRefresh(pullRefreshState),
                     ) {
                         LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
                             state = lazyListState
                         ) {
                             item {

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
@@ -329,6 +330,7 @@ class PostListScreen : Screen {
                         .pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                         userScrollEnabled = !uiState.zombieModeActive,
                     ) {

--- a/unit/rawcontent/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/rawcontent/RawContentDialog.kt
+++ b/unit/rawcontent/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/rawcontent/RawContentDialog.kt
@@ -83,8 +83,10 @@ fun RawContentDialog(
             )
             Spacer(modifier = Modifier.height(Spacing.s))
             LazyColumn(
-                modifier = Modifier.padding(vertical = Spacing.s, horizontal = Spacing.m)
-                    .heightIn(max = 400.dp), verticalArrangement = Arrangement.spacedBy(Spacing.xs)
+                modifier = Modifier
+                    .padding(vertical = Spacing.s, horizontal = Spacing.m)
+                    .heightIn(max = 400.dp),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs)
             ) {
                 title?.takeIf { it.trim().isNotEmpty() }?.also {
                     item {

--- a/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/ReportListMviModel.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/ReportListMviModel.kt
@@ -41,5 +41,7 @@ interface ReportListMviModel :
         val commentReports: List<CommentReportModel> = emptyList(),
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
 }

--- a/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
+++ b/unit/saveditems/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/saveditems/SavedItemsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -234,6 +235,7 @@ class SavedItemsScreen : Screen {
                     modifier = Modifier.fillMaxWidth().pullRefresh(pullRefreshState),
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                     ) {
                         if (uiState.section == SavedItemsSection.Posts) {

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -435,6 +436,7 @@ class UserDetailScreen(
                     .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
                     state = lazyListState,
                 ) {
                     item {


### PR DESCRIPTION
This PR fixes a visual bug due to report list not extending to full width, which resulted in an ugly collapsed loader when the list was empty during refresh.

Additionally, a back to top effect was added when changing the report type (unresolved vs all).