### PR TITLE
chore: add pagination tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: build
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
@@ -23,15 +23,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 8.6
-
-      - name: Cleanup localization resources
-        run: ./gradlew :core:l10n:clean
-
-      - name: Regenerate localization resources
-        run: ./gradlew :core:l10n:kspCommonMainKotlinMetadata
-
-      - name: Build Android app
-        run: ./gradlew build
 
       - name: Run unit tests
         run: ./gradlew test

--- a/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
+++ b/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
@@ -32,7 +32,6 @@ import kotlin.test.assertIs
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DefaultDetailOpenerTest {
-
     @get:Rule
     val dispatcherRule = DispatcherTestRule()
 
@@ -44,146 +43,164 @@ class DefaultDetailOpenerTest {
 
     private val navigationCoordinator = mockk<NavigationCoordinator>(relaxed = true)
 
-    private val sut: DetailOpener = DefaultDetailOpener(
-        navigationCoordinator = navigationCoordinator,
-        itemCache = lemmyItemCache,
-        identityRepository = identityRepository,
-        communityRepository = communityRepository,
-    )
+    private val sut: DetailOpener =
+        DefaultDetailOpener(
+            navigationCoordinator = navigationCoordinator,
+            itemCache = lemmyItemCache,
+            identityRepository = identityRepository,
+            communityRepository = communityRepository,
+        )
 
     @Test
-    fun whenOpenCommunityDetailOnSameInstance_thenNavigatesAccordingly() = runTest {
-        val community = CommunityModel(name = "test", id = 1)
+    fun whenOpenCommunityDetailOnSameInstance_thenNavigatesAccordingly() =
+        runTest {
+            val community = CommunityModel(name = "test", id = 1)
 
-        sut.openCommunityDetail(community)
+            sut.openCommunityDetail(community)
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            lemmyItemCache.putCommunity(community)
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<CommunityDetailScreen>(it)
-                },
-            )
-            identityRepository wasNot Called
-            communityRepository wasNot Called
+            coVerify {
+                lemmyItemCache.putCommunity(community)
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<CommunityDetailScreen>(it)
+                    },
+                )
+                identityRepository wasNot Called
+                communityRepository wasNot Called
+            }
         }
-    }
 
     @Test
-    fun whenOpenCommunityDetailOnDifferentInstance_thenNavigatesAccordingly() = runTest {
-        val token = "token"
-        val communityName = "test"
-        val otherInstance = "otherInstance"
-        val community = CommunityModel(name = communityName, id = 1, host = otherInstance)
-        every { identityRepository.authToken } returns MutableStateFlow(token)
-        coEvery {
-            communityRepository.search(
-                query = any(),
-                auth = any(),
-                page = any(),
-                limit = any(),
-                listingType = any(),
-                sortType = any(),
-                resultType = any(),
-            )
-        } returns listOf(SearchResult.Community(community))
+    fun whenOpenCommunityDetailOnDifferentInstance_thenNavigatesAccordingly() =
+        runTest {
+            val token = "token"
+            val communityName = "test"
+            val otherInstance = "otherInstance"
+            val community = CommunityModel(name = communityName, id = 1, host = otherInstance)
+            every { identityRepository.authToken } returns MutableStateFlow(token)
+            coEvery {
+                communityRepository.search(
+                    query = any(),
+                    auth = any(),
+                    page = any(),
+                    limit = any(),
+                    listingType = any(),
+                    sortType = any(),
+                    resultType = any(),
+                )
+            } returns listOf(SearchResult.Community(community))
 
-        sut.openCommunityDetail(community, otherInstance)
-        advanceTimeBy(500)
+            sut.openCommunityDetail(community, otherInstance)
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            lemmyItemCache.putCommunity(community)
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<CommunityDetailScreen>(it)
-                },
-            )
-            communityRepository.search(
-                query = communityName,
-                auth = token,
-                page = any(),
-                limit = any(),
-                listingType = ListingType.All,
-                sortType = any(),
-                resultType = SearchResultType.Communities,
-            )
+            coVerify {
+                lemmyItemCache.putCommunity(community)
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<CommunityDetailScreen>(it)
+                    },
+                )
+                communityRepository.search(
+                    query = communityName,
+                    auth = token,
+                    page = any(),
+                    limit = any(),
+                    listingType = ListingType.All,
+                    sortType = any(),
+                    resultType = SearchResultType.Communities,
+                )
+            }
         }
-    }
 
     @Test
-    fun whenOpenUserDetail_thenNavigatesAccordingly() = runTest {
-        val user = UserModel(name = "test", id = 1)
+    fun whenOpenUserDetail_thenNavigatesAccordingly() =
+        runTest {
+            val user = UserModel(name = "test", id = 1)
 
-        sut.openUserDetail(user)
+            sut.openUserDetail(user)
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            lemmyItemCache.putUser(user)
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<UserDetailScreen>(it)
-                },
-            )
+            coVerify {
+                lemmyItemCache.putUser(user)
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<UserDetailScreen>(it)
+                    },
+                )
+            }
         }
-    }
 
     @Test
-    fun whenOpenPostDetail_thenNavigatesAccordingly() = runTest {
-        val post = PostModel(title = "test", id = 1)
+    fun whenOpenPostDetail_thenNavigatesAccordingly() =
+        runTest {
+            val post = PostModel(title = "test", id = 1)
 
-        sut.openPostDetail(post)
+            sut.openPostDetail(post)
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            lemmyItemCache.putPost(post)
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<PostDetailScreen>(it)
-                },
-            )
+            coVerify {
+                lemmyItemCache.putPost(post)
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<PostDetailScreen>(it)
+                    },
+                )
+            }
         }
-    }
 
     @Test
-    fun whenOpenReplyToPost_thenNavigatesAccordingly() = runTest {
-        val post = PostModel(title = "test", id = 1)
+    fun whenOpenReplyToPost_thenNavigatesAccordingly() =
+        runTest {
+            val post = PostModel(title = "test", id = 1)
 
-        sut.openReply(originalPost = post)
+            sut.openReply(originalPost = post)
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            lemmyItemCache.putPost(post)
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<CreateCommentScreen>(it)
-                },
-            )
+            coVerify {
+                lemmyItemCache.putPost(post)
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<CreateCommentScreen>(it)
+                    },
+                )
+            }
         }
-    }
 
     @Test
-    fun whenOpenReplyToComment_thenNavigatesAccordingly() = runTest {
-        val comment = CommentModel(text = "test", id = 1)
+    fun whenOpenReplyToComment_thenNavigatesAccordingly() =
+        runTest {
+            val comment = CommentModel(text = "test", id = 1)
 
-        sut.openReply(originalComment = comment)
+            sut.openReply(originalComment = comment)
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            lemmyItemCache.putComment(comment)
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<CreateCommentScreen>(it)
-                },
-            )
+            coVerify {
+                lemmyItemCache.putComment(comment)
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<CreateCommentScreen>(it)
+                    },
+                )
+            }
         }
-    }
 
     @Test
-    fun whenOpenCreatePost_thenNavigatesAccordingly() = runTest {
-        sut.openCreatePost()
+    fun whenOpenCreatePost_thenNavigatesAccordingly() =
+        runTest {
+            sut.openCreatePost()
+            advanceTimeBy(OPEN_DELAY)
 
-        coVerify {
-            navigationCoordinator.pushScreen(
-                withArg {
-                    assertIs<CreatePostScreen>(it)
-                },
-            )
+            coVerify {
+                navigationCoordinator.pushScreen(
+                    withArg {
+                        assertIs<CreatePostScreen>(it)
+                    },
+                )
+            }
         }
+
+    companion object {
+        private const val OPEN_DELAY = 500L
     }
 }

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
@@ -3,6 +3,9 @@ package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
 import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResult
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.UserRepository
@@ -21,176 +24,936 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class DefaultPostPaginationManagerTest {
-
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
-    private val identityRepository: IdentityRepository = mockk {
-        every { authToken } returns MutableStateFlow("fake-token")
-    }
+    private val identityRepository: IdentityRepository =
+        mockk {
+            every { authToken } returns MutableStateFlow(AUTH_TOKEN)
+        }
     private val postRepository: PostRepository = mockk(relaxUnitFun = true)
     private val communityRepository: CommunityRepository = mockk(relaxUnitFun = true)
     private val userRepository: UserRepository = mockk(relaxUnitFun = true)
     private val multiCommunityPaginator: MultiCommunityPaginator = mockk(relaxUnitFun = true)
 
-    private val sut = DefaultPostPaginationManager(
-        identityRepository = identityRepository,
-        postRepository = postRepository,
-        communityRepository = communityRepository,
-        userRepository = userRepository,
-        multiCommunityPaginator = multiCommunityPaginator,
-    )
+    private val sut =
+        DefaultPostPaginationManager(
+            identityRepository = identityRepository,
+            postRepository = postRepository,
+            communityRepository = communityRepository,
+            userRepository = userRepository,
+            multiCommunityPaginator = multiCommunityPaginator,
+        )
 
     @Test
-    fun whenReset_thenHistoryIsClearedAndCanFetchMore() = runTest {
-        val specification = PostPaginationSpecification.Listing()
-        sut.reset(specification)
+    fun whenReset_thenHistoryIsClearedAndCanFetchMore() =
+        runTest {
+            val specification = PostPaginationSpecification.Listing()
+            sut.reset(specification)
 
-        assertTrue(sut.canFetchMore)
-        assertTrue(sut.history.isEmpty())
-    }
-
-    @Test
-    fun givenNoResults_whenLoadNextPage_thenResultIsAsExpected() = runTest {
-        coEvery {
-            postRepository.getAll(
-                auth = any(),
-                page = any(),
-                pageCursor = any(),
-                limit = any(),
-                type = any(),
-                sort = any(),
-                communityId = any(),
-                communityName = any(),
-                otherInstance = any(),
-            )
-        } returns (emptyList<PostModel>() to null)
-        val specification = PostPaginationSpecification.Listing()
-        sut.reset(specification)
-
-        val items = sut.loadNextPage()
-
-        assertTrue(items.isEmpty())
-        coVerify {
-            postRepository.getAll(
-                auth = "fake-token",
-                page = 1,
-                pageCursor = null,
-                limit = 20,
-                type = specification.listingType,
-                sort = specification.sortType,
-                communityId = null,
-                communityName = null,
-                otherInstance = null,
-            )
+            assertTrue(sut.canFetchMore)
+            assertTrue(sut.history.isEmpty())
         }
-    }
 
     @Test
-    fun givenResults_whenLoadNextPage_thenResultIsAsExpected() = runTest {
-        val page = slot<Int>()
-        coEvery {
-            postRepository.getAll(
-                auth = any(),
-                page = capture(page),
-                pageCursor = any(),
-                limit = any(),
-                type = any(),
-                sort = any(),
-                communityId = any(),
-                communityName = any(),
-                otherInstance = any(),
-            )
-        } answers {
-            val pageNumber = page.captured
-            if (pageNumber == 1) {
-                (0..<20).map { idx ->
-                    PostModel(id = idx.toLong())
-                } to "page-cursor"
-            } else {
-                (emptyList<PostModel>() to null)
+    fun givenListingSpecAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = any(),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    otherInstance = any(),
+                )
+            } returns (emptyList<PostModel>() to null)
+            val specification = PostPaginationSpecification.Listing()
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = specification.listingType,
+                    sort = specification.sortType,
+                    communityId = null,
+                    communityName = null,
+                )
             }
         }
-        val specification = PostPaginationSpecification.Listing()
-        sut.reset(specification)
-
-        val items = sut.loadNextPage()
-
-        assertEquals(20, items.size)
-        assertTrue(sut.canFetchMore)
-
-        coVerify {
-            postRepository.getAll(
-                auth = "fake-token",
-                page = 1,
-                pageCursor = null,
-                limit = 20,
-                type = specification.listingType,
-                sort = specification.sortType,
-                communityId = null,
-                communityName = null,
-                otherInstance = null,
-            )
-        }
-    }
 
     @Test
-    fun givenResults_whenSecondLoadNextPage_thenResultIsAsExpected() = runTest {
-        val page = slot<Int>()
-        coEvery {
-            postRepository.getAll(
-                auth = any(),
-                page = capture(page),
-                pageCursor = any(),
-                limit = any(),
-                type = any(),
-                sort = any(),
-                communityId = any(),
-                communityName = any(),
-                otherInstance = any(),
-            )
-        } answers {
-            val pageNumber = page.captured
-            if (pageNumber == 1) {
-                (0..<20).map { idx ->
-                    PostModel(id = idx.toLong())
-                } to "page-cursor"
-            } else {
-                (emptyList<PostModel>() to null)
+    fun givenListingSpecAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = capture(page),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    otherInstance = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    (emptyList<PostModel>() to null)
+                }
+            }
+            val specification = PostPaginationSpecification.Listing()
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = specification.listingType,
+                    sort = specification.sortType,
+                    communityId = null,
+                    communityName = null,
+                )
             }
         }
-        val specification = PostPaginationSpecification.Listing()
-        sut.reset(specification)
 
-        sut.loadNextPage()
-        val items = sut.loadNextPage()
+    @Test
+    fun givenListingSpecAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = capture(page),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    otherInstance = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    (emptyList<PostModel>() to null)
+                }
+            }
+            val specification = PostPaginationSpecification.Listing()
+            sut.reset(specification)
 
-        assertEquals(20, items.size)
-        assertFalse(sut.canFetchMore)
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
 
-        coVerifySequence {
-            postRepository.getAll(
-                auth = "fake-token",
-                page = 1,
-                pageCursor = null,
-                limit = 20,
-                type = specification.listingType,
-                sort = specification.sortType,
-                communityId = null,
-                communityName = null,
-                otherInstance = null,
-            )
-            postRepository.getAll(
-                auth = "fake-token",
-                page = 2,
-                pageCursor = "page-cursor",
-                limit = 20,
-                type = specification.listingType,
-                sort = specification.sortType,
-                communityId = null,
-                communityName = null,
-                otherInstance = null,
-            )
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerifySequence {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = specification.listingType,
+                    sort = specification.sortType,
+                    communityId = null,
+                    communityName = null,
+                )
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 2,
+                    pageCursor = PAGE_CURSOR,
+                    limit = 20,
+                    type = specification.listingType,
+                    sort = specification.sortType,
+                    communityId = null,
+                    communityName = null,
+                )
+            }
         }
+
+    @Test
+    fun givenMultiCommunitySpecAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                multiCommunityPaginator.loadNextPage(any(), any())
+            } returns emptyList()
+            every { multiCommunityPaginator.canFetchMore } returns false
+            val communityIds = listOf(1L)
+            val specification = PostPaginationSpecification.MultiCommunity(communityIds = communityIds)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                multiCommunityPaginator.setCommunities(communityIds)
+                multiCommunityPaginator.loadNextPage(
+                    auth = AUTH_TOKEN,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenMultiCommunitySpecAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                multiCommunityPaginator.loadNextPage(any(), any())
+            } answers {
+                (0..<20).map { idx ->
+                    PostModel(id = idx.toLong())
+                }
+            }
+            every { multiCommunityPaginator.canFetchMore } returns true
+            val communityIds = listOf(1L)
+            val specification = PostPaginationSpecification.MultiCommunity(communityIds = communityIds)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                multiCommunityPaginator.setCommunities(communityIds)
+                multiCommunityPaginator.loadNextPage(
+                    auth = AUTH_TOKEN,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenMultiCommunitySpecAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            var invokeCount = 0
+            coEvery {
+                multiCommunityPaginator.loadNextPage(any(), any())
+            } answers {
+                val res =
+                    if (invokeCount == 0) {
+                        (0..<20).map { idx ->
+                            PostModel(id = idx.toLong())
+                        }
+                    } else {
+                        emptyList()
+                    }
+                invokeCount++
+                res
+            }
+            every { multiCommunityPaginator.canFetchMore } answers {
+                invokeCount == 0
+            }
+            val communityIds = listOf(1L)
+            val specification = PostPaginationSpecification.MultiCommunity(communityIds = communityIds)
+            sut.reset(specification)
+
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerify {
+                multiCommunityPaginator.setCommunities(communityIds)
+            }
+            coVerify(exactly = 2) {
+                multiCommunityPaginator.loadNextPage(
+                    auth = AUTH_TOKEN,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenCommunitySpecAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = any(),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    otherInstance = any(),
+                )
+            } returns (emptyList<PostModel>() to null)
+            val communityId = 1L
+            val specification = PostPaginationSpecification.Community(communityId)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    sort = specification.sortType,
+                    communityId = communityId,
+                )
+            }
+        }
+
+    @Test
+    fun givenCommunitySpecSearchingAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                communityRepository.search(
+                    auth = any(),
+                    communityId = any(),
+                    page = any(),
+                    sortType = any(),
+                    resultType = any(),
+                    query = any(),
+                )
+            } returns emptyList()
+            val communityId = 1L
+            val searchText = "query"
+            val specification = PostPaginationSpecification.Community(id = communityId, query = searchText)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                communityRepository.search(
+                    auth = AUTH_TOKEN,
+                    communityId = communityId,
+                    page = 1,
+                    sortType = specification.sortType,
+                    resultType = SearchResultType.Posts,
+                    query = searchText,
+                )
+            }
+        }
+
+    @Test
+    fun givenCommunitySpecAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = capture(page),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    otherInstance = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    emptyList<PostModel>() to null
+                }
+            }
+            val communityId = 1L
+            val specification = PostPaginationSpecification.Community(communityId)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    sort = specification.sortType,
+                    communityId = communityId,
+                )
+            }
+        }
+
+    @Test
+    fun givenCommunitySpecSearchingAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                communityRepository.search(
+                    auth = any(),
+                    communityId = any(),
+                    page = capture(page),
+                    sortType = any(),
+                    resultType = any(),
+                    query = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        SearchResult.Post(
+                            model = PostModel(id = idx.toLong()),
+                        )
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+            val communityId = 1L
+            val searchText = "query"
+            val specification = PostPaginationSpecification.Community(id = communityId, query = searchText)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                communityRepository.search(
+                    auth = AUTH_TOKEN,
+                    communityId = communityId,
+                    page = 1,
+                    sortType = specification.sortType,
+                    resultType = SearchResultType.Posts,
+                    query = searchText,
+                )
+            }
+        }
+
+    @Test
+    fun givenCommunitySpecAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = capture(page),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    otherInstance = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    emptyList<PostModel>() to null
+                }
+            }
+            val communityId = 1L
+            val specification = PostPaginationSpecification.Community(communityId)
+            sut.reset(specification)
+
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerifySequence {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    sort = specification.sortType,
+                    communityId = communityId,
+                )
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 2,
+                    pageCursor = PAGE_CURSOR,
+                    limit = 20,
+                    sort = specification.sortType,
+                    communityId = communityId,
+                )
+            }
+        }
+
+    @Test
+    fun givenCommunitySpecSearchingAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                communityRepository.search(
+                    auth = any(),
+                    communityId = any(),
+                    page = capture(page),
+                    sortType = any(),
+                    resultType = any(),
+                    query = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        SearchResult.Post(
+                            model = PostModel(id = idx.toLong()),
+                        )
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+            val communityId = 1L
+            val searchText = "query"
+            val specification = PostPaginationSpecification.Community(id = communityId, query = searchText)
+            sut.reset(specification)
+
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerifySequence {
+                communityRepository.search(
+                    auth = AUTH_TOKEN,
+                    communityId = communityId,
+                    page = 1,
+                    sortType = specification.sortType,
+                    resultType = SearchResultType.Posts,
+                    query = searchText,
+                )
+                communityRepository.search(
+                    auth = AUTH_TOKEN,
+                    communityId = communityId,
+                    page = 2,
+                    sortType = specification.sortType,
+                    resultType = SearchResultType.Posts,
+                    query = searchText,
+                )
+            }
+        }
+
+    @Test
+    fun givenUserSpecAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val userId = 1L
+            coEvery {
+                userRepository.getPosts(
+                    id = userId,
+                    auth = any(),
+                    page = any(),
+                    limit = any(),
+                    sort = any(),
+                    otherInstance = any(),
+                )
+            } returns emptyList()
+            val specification = PostPaginationSpecification.User(userId)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                userRepository.getPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenUserSpecAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val userId = 1L
+            val page = slot<Int>()
+            coEvery {
+                userRepository.getPosts(
+                    id = userId,
+                    auth = any(),
+                    page = capture(page),
+                    limit = any(),
+                    sort = any(),
+                    otherInstance = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+            val specification = PostPaginationSpecification.User(userId)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                userRepository.getPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenUserSpecAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val userId = 1L
+            val page = slot<Int>()
+            coEvery {
+                userRepository.getPosts(
+                    id = userId,
+                    auth = any(),
+                    page = capture(page),
+                    limit = any(),
+                    sort = any(),
+                    otherInstance = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+            val specification = PostPaginationSpecification.User(userId)
+            sut.reset(specification)
+
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerifySequence {
+                userRepository.getPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+                userRepository.getPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 2,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenVotesSpecAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                userRepository.getLikedPosts(
+                    auth = any(),
+                    page = any(),
+                    limit = any(),
+                    sort = any(),
+                    liked = any(),
+                    pageCursor = any(),
+                )
+            } returns (emptyList<PostModel>() to null)
+            val specification = PostPaginationSpecification.Votes(liked = true)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                userRepository.getLikedPosts(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    liked = specification.liked,
+                    sort = specification.sortType,
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun givenVotesSpecAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                userRepository.getLikedPosts(
+                    auth = any(),
+                    page = capture(page),
+                    limit = any(),
+                    sort = any(),
+                    liked = any(),
+                    pageCursor = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    emptyList<PostModel>() to null
+                }
+            }
+            val specification = PostPaginationSpecification.Votes(liked = true)
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                userRepository.getLikedPosts(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    liked = specification.liked,
+                    sort = specification.sortType,
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun givenVotesSpecAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                userRepository.getLikedPosts(
+                    auth = any(),
+                    page = capture(page),
+                    limit = any(),
+                    sort = any(),
+                    liked = any(),
+                    pageCursor = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    emptyList<PostModel>() to null
+                }
+            }
+            val specification = PostPaginationSpecification.Votes(liked = true)
+            sut.reset(specification)
+
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerifySequence {
+                userRepository.getLikedPosts(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    liked = specification.liked,
+                    sort = specification.sortType,
+                    pageCursor = null,
+                )
+                userRepository.getLikedPosts(
+                    auth = AUTH_TOKEN,
+                    page = 2,
+                    limit = 20,
+                    liked = specification.liked,
+                    sort = specification.sortType,
+                    pageCursor = PAGE_CURSOR,
+                )
+            }
+        }
+
+    @Test
+    fun givenSavedSpecAndNoPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val userId = 1L
+            coEvery { identityRepository.cachedUser } returns UserModel(id = userId)
+            coEvery {
+                userRepository.getSavedPosts(
+                    id = any(),
+                    auth = any(),
+                    page = any(),
+                    limit = any(),
+                    sort = any(),
+                )
+            } returns emptyList()
+            val specification = PostPaginationSpecification.Saved()
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertTrue(items.isEmpty())
+            coVerify {
+                userRepository.getSavedPosts(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    id = userId,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenSavedSpecAndPosts_whenLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val userId = 1L
+            coEvery { identityRepository.cachedUser } returns UserModel(id = userId)
+            val page = slot<Int>()
+            coEvery {
+                userRepository.getSavedPosts(
+                    id = any(),
+                    auth = any(),
+                    page = capture(page),
+                    limit = any(),
+                    sort = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+            val specification = PostPaginationSpecification.Saved()
+            sut.reset(specification)
+
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                userRepository.getSavedPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun givenSavedSpecAndPosts_whenSecondLoadNextPage_thenResultIsAsExpected() =
+        runTest {
+            val userId = 1L
+            coEvery { identityRepository.cachedUser } returns UserModel(id = userId)
+            val page = slot<Int>()
+            coEvery {
+                userRepository.getSavedPosts(
+                    id = any(),
+                    auth = any(),
+                    page = capture(page),
+                    limit = any(),
+                    sort = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    }
+                } else {
+                    emptyList()
+                }
+            }
+            val specification = PostPaginationSpecification.Saved()
+            sut.reset(specification)
+
+            sut.loadNextPage()
+            val items = sut.loadNextPage()
+
+            assertEquals(20, items.size)
+            assertFalse(sut.canFetchMore)
+
+            coVerifySequence {
+                userRepository.getSavedPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+                userRepository.getSavedPosts(
+                    id = userId,
+                    auth = AUTH_TOKEN,
+                    page = 2,
+                    limit = 20,
+                    sort = specification.sortType,
+                )
+            }
+        }
+
+    @Test
+    fun whenExtractAndRestoreState_thenResultIsAsExpected() {
+        val state = sut.extractState()
+
+        sut.restoreState(state)
+
+        val res = sut.extractState()
+        assertEquals(state, res)
+    }
+
+    companion object {
+        private const val AUTH_TOKEN = "fake-token"
+        private const val PAGE_CURSOR = "fake-page-cursor"
     }
 }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
@@ -19,7 +19,6 @@ internal class DefaultPostPaginationManager(
     private val userRepository: UserRepository,
     private val multiCommunityPaginator: MultiCommunityPaginator,
 ) : PostPaginationManager {
-
     override var canFetchMore: Boolean = true
         private set
 
@@ -40,151 +39,161 @@ internal class DefaultPostPaginationManager(
         }
     }
 
-    override suspend fun loadNextPage(): List<PostModel> = withContext(Dispatchers.IO) {
-        val specification = specification ?: return@withContext emptyList()
-        val auth = identityRepository.authToken.value.orEmpty()
+    override suspend fun loadNextPage(): List<PostModel> =
+        withContext(Dispatchers.IO) {
+            val specification = specification ?: return@withContext emptyList()
+            val auth = identityRepository.authToken.value.orEmpty()
 
-        val result = when (specification) {
-            is PostPaginationSpecification.Listing -> {
-                val (itemList, nextPage) = postRepository.getAll(
-                    auth = auth,
-                    page = currentPage,
-                    pageCursor = pageCursor,
-                    type = specification.listingType,
-                    sort = specification.sortType,
-                ) ?: (null to null)
-                if (!itemList.isNullOrEmpty()) {
-                    currentPage++
-                }
-                if (nextPage != null) {
-                    pageCursor = nextPage
-                }
-                canFetchMore = itemList?.isEmpty() != true
-                itemList
-                    .orEmpty()
-                    .deduplicate()
-                    .filterNsfw(specification.includeNsfw)
-                    .filterDeleted()
-            }
+            val result =
+                when (specification) {
+                    is PostPaginationSpecification.Listing -> {
+                        val (itemList, nextPage) =
+                            postRepository.getAll(
+                                auth = auth,
+                                page = currentPage,
+                                pageCursor = pageCursor,
+                                type = specification.listingType,
+                                sort = specification.sortType,
+                            ) ?: (null to null)
+                        if (!itemList.isNullOrEmpty()) {
+                            currentPage++
+                        }
+                        if (nextPage != null) {
+                            pageCursor = nextPage
+                        }
+                        canFetchMore = itemList?.isEmpty() != true
+                        itemList
+                            .orEmpty()
+                            .deduplicate()
+                            .filterNsfw(specification.includeNsfw)
+                            .filterDeleted()
+                    }
 
-            is PostPaginationSpecification.Community -> {
-                val searching = !specification.query.isNullOrEmpty()
-                val (itemList, nextPage) = if (searching) {
-                    communityRepository.search(
-                        auth = auth,
-                        communityId = specification.id,
-                        page = currentPage,
-                        sortType = specification.sortType,
-                        resultType = SearchResultType.Posts,
-                        query = specification.query.orEmpty(),
-                    ).mapNotNull {
-                        (it as? SearchResult.Post)?.model
-                    } to null
-                } else {
-                    postRepository.getAll(
-                        auth = auth,
-                        otherInstance = specification.otherInstance,
-                        communityId = specification.id,
-                        communityName = specification.name,
-                        page = currentPage,
-                        pageCursor = pageCursor,
-                        sort = specification.sortType,
-                    ) ?: (null to null)
-                }
-                if (!itemList.isNullOrEmpty()) {
-                    currentPage++
-                }
-                if (nextPage != null) {
-                    pageCursor = nextPage
-                }
-                canFetchMore = itemList?.isEmpty() != true
-                itemList
-                    .orEmpty()
-                    .deduplicate()
-                    .filterNsfw(specification.includeNsfw)
-                    .filterDeleted()
-            }
+                    is PostPaginationSpecification.Community -> {
+                        val searching = !specification.query.isNullOrEmpty()
+                        val (itemList, nextPage) =
+                            if (searching) {
+                                communityRepository.search(
+                                    auth = auth,
+                                    communityId = specification.id,
+                                    page = currentPage,
+                                    sortType = specification.sortType,
+                                    resultType = SearchResultType.Posts,
+                                    query = specification.query.orEmpty(),
+                                ).mapNotNull {
+                                    (it as? SearchResult.Post)?.model
+                                } to null
+                            } else {
+                                postRepository.getAll(
+                                    auth = auth,
+                                    otherInstance = specification.otherInstance,
+                                    communityId = specification.id,
+                                    communityName = specification.name,
+                                    page = currentPage,
+                                    pageCursor = pageCursor,
+                                    sort = specification.sortType,
+                                ) ?: (null to null)
+                            }
+                        if (!itemList.isNullOrEmpty()) {
+                            currentPage++
+                        }
+                        if (nextPage != null) {
+                            pageCursor = nextPage
+                        }
+                        canFetchMore = itemList?.isEmpty() != true
+                        itemList
+                            .orEmpty()
+                            .deduplicate()
+                            .filterNsfw(specification.includeNsfw)
+                            .filterDeleted()
+                    }
 
-            is PostPaginationSpecification.MultiCommunity -> {
-                val itemList = multiCommunityPaginator.loadNextPage(
-                    auth = auth,
-                    sort = specification.sortType,
-                )
-                canFetchMore = multiCommunityPaginator.canFetchMore
-                itemList
-                    .deduplicate()
-                    .filterNsfw(specification.includeNsfw)
-                    .filterDeleted()
-            }
+                    is PostPaginationSpecification.MultiCommunity -> {
+                        val itemList =
+                            multiCommunityPaginator.loadNextPage(
+                                auth = auth,
+                                sort = specification.sortType,
+                            )
+                        canFetchMore = multiCommunityPaginator.canFetchMore
+                        itemList
+                            .deduplicate()
+                            .filterNsfw(specification.includeNsfw)
+                            .filterDeleted()
+                    }
 
-            is PostPaginationSpecification.User -> {
-                val itemList = userRepository.getPosts(
-                    auth = auth,
-                    id = specification.id,
-                    username = specification.name,
-                    otherInstance = specification.otherInstance,
-                    page = currentPage,
-                    sort = SortType.New,
-                )
-                if (!itemList.isNullOrEmpty()) {
-                    currentPage++
-                }
-                canFetchMore = itemList?.isEmpty() != true
-                itemList
-                    .orEmpty()
-                    .deduplicate()
-                    .filterNsfw(specification.includeNsfw)
-                    .filterDeleted()
-            }
+                    is PostPaginationSpecification.User -> {
+                        val itemList =
+                            userRepository.getPosts(
+                                auth = auth,
+                                id = specification.id,
+                                username = specification.name,
+                                otherInstance = specification.otherInstance,
+                                page = currentPage,
+                                sort = SortType.New,
+                            )
+                        if (!itemList.isNullOrEmpty()) {
+                            currentPage++
+                        }
+                        canFetchMore = itemList?.isEmpty() != true
+                        itemList
+                            .orEmpty()
+                            .deduplicate()
+                            .filterNsfw(specification.includeNsfw)
+                            .filterDeleted()
+                    }
 
-            is PostPaginationSpecification.Votes -> {
-                val (itemList, nextPage) = userRepository.getLikedPosts(
-                    auth = auth,
-                    page = currentPage,
-                    pageCursor = pageCursor,
-                    liked = specification.liked,
-                    sort = SortType.New,
-                ) ?: (null to null)
-                if (!itemList.isNullOrEmpty()) {
-                    currentPage++
-                }
-                if (nextPage != null) {
-                    pageCursor = nextPage
-                }
-                itemList
-                    .orEmpty()
-                    .deduplicate()
-            }
+                    is PostPaginationSpecification.Votes -> {
+                        val (itemList, nextPage) =
+                            userRepository.getLikedPosts(
+                                auth = auth,
+                                page = currentPage,
+                                pageCursor = pageCursor,
+                                liked = specification.liked,
+                                sort = SortType.New,
+                            ) ?: (null to null)
+                        if (!itemList.isNullOrEmpty()) {
+                            currentPage++
+                        }
+                        if (nextPage != null) {
+                            pageCursor = nextPage
+                        }
+                        canFetchMore = itemList?.isEmpty() != true
+                        itemList
+                            .orEmpty()
+                            .deduplicate()
+                    }
 
-            is PostPaginationSpecification.Saved -> {
-                val itemList = userRepository.getSavedPosts(
-                    auth = auth,
-                    page = currentPage,
-                    sort = specification.sortType,
-                    id = identityRepository.cachedUser?.id ?: 0,
-                )
-                if (!itemList.isNullOrEmpty()) {
-                    currentPage++
+                    is PostPaginationSpecification.Saved -> {
+                        val itemList =
+                            userRepository.getSavedPosts(
+                                auth = auth,
+                                page = currentPage,
+                                sort = specification.sortType,
+                                id = identityRepository.cachedUser?.id ?: 0,
+                            )
+                        if (!itemList.isNullOrEmpty()) {
+                            currentPage++
+                        }
+                        canFetchMore = itemList?.isEmpty() != true
+                        itemList
+                            .orEmpty()
+                            .deduplicate()
+                            .filterDeleted()
+                    }
                 }
-                canFetchMore = itemList?.isEmpty() != true
-                itemList
-                    .orEmpty()
-                    .deduplicate()
-                    .filterDeleted()
-            }
+
+            history.addAll(result)
+            // returns whole history
+            history
         }
 
-        history.addAll(result)
-        // returns whole history
-        history
-    }
-
-    override fun extractState(): PostPaginationManagerState = DefaultPostPaginationManagerState(
-        specification = specification,
-        currentPage = currentPage,
-        pageCursor = pageCursor,
-        history = history,
-    )
+    override fun extractState(): PostPaginationManagerState =
+        DefaultPostPaginationManagerState(
+            specification = specification,
+            currentPage = currentPage,
+            pageCursor = pageCursor,
+            history = history,
+        )
 
     override fun restoreState(state: PostPaginationManagerState) {
         (state as? DefaultPostPaginationManagerState)?.also {
@@ -196,18 +205,21 @@ internal class DefaultPostPaginationManager(
         }
     }
 
-    private fun List<PostModel>.deduplicate(): List<PostModel> = filter { p1 ->
-        // prevents accidental duplication
-        history.none { p2 -> p2.id == p1.id }
-    }
+    private fun List<PostModel>.deduplicate(): List<PostModel> =
+        filter { p1 ->
+            // prevents accidental duplication
+            history.none { p2 -> p2.id == p1.id }
+        }
 
-    private fun List<PostModel>.filterNsfw(includeNsfw: Boolean): List<PostModel> = if (includeNsfw) {
-        this
-    } else {
-        filter { post -> !post.nsfw }
-    }
+    private fun List<PostModel>.filterNsfw(includeNsfw: Boolean): List<PostModel> =
+        if (includeNsfw) {
+            this
+        } else {
+            filter { post -> !post.nsfw }
+        }
 
-    private fun List<PostModel>.filterDeleted(): List<PostModel> = filterNot { post ->
-        post.deleted
-    }
+    private fun List<PostModel>.filterDeleted(): List<PostModel> =
+        filterNot { post ->
+            post.deleted
+        }
 }


### PR DESCRIPTION
Add some missing test for `DefaultPostPaginationManager` and fixes a bug concerning liked posts pagination.