### PR TITLE
fix: revert open custom tabs without history

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -45,13 +45,11 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallb
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAVideo
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAnImage
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.showInEmbeddedWebView
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.url.getCustomTabsHelper
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
-import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.embeddedUrl
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.imageUrl
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.videoUrl
 
@@ -439,8 +437,7 @@ private fun ExtendedPost(
             it != post.imageUrl &&
                 it != post.videoUrl &&
                 !it.looksLikeAnImage &&
-                !it.looksLikeAVideo &&
-                !it.showInEmbeddedWebView
+                !it.looksLikeAVideo
         }.orEmpty()
 
     Column(
@@ -509,35 +506,7 @@ private fun ExtendedPost(
             )
         }
 
-        if (post.embeddedUrl.isNotEmpty()) {
-            PostCardEmbeddedWebView(
-                modifier =
-                    Modifier
-                        .padding(
-                            vertical = Spacing.xxs,
-                            horizontal = if (fullWidthImage) 0.dp else Spacing.s,
-                        ),
-                blurred = blurNsfw && post.nsfw,
-                autoLoadImages = autoLoadImages,
-                url = post.embeddedUrl,
-                onOpen = {
-                    if (postLinkUrl.isNotEmpty()) {
-                        navigationCoordinator.handleUrl(
-                            url = postLinkUrl,
-                            openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                            uriHandler = uriHandler,
-                            customTabsHelper = customTabsHelper,
-                            onOpenWeb = onOpenWeb,
-                            onOpenCommunity = onOpenCommunity,
-                            onOpenPost = onOpenPost,
-                            onOpenUser = onOpenCreator,
-                        )
-                    } else {
-                        onClick?.invoke()
-                    }
-                },
-            )
-        } else if (post.videoUrl.isNotEmpty()) {
+        if (post.videoUrl.isNotEmpty()) {
             PostCardVideo(
                 modifier =
                     Modifier

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -45,11 +45,13 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallb
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAVideo
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAnImage
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.showInEmbeddedWebView
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.url.getCustomTabsHelper
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.embeddedUrl
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.imageUrl
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.videoUrl
 
@@ -437,7 +439,8 @@ private fun ExtendedPost(
             it != post.imageUrl &&
                 it != post.videoUrl &&
                 !it.looksLikeAnImage &&
-                !it.looksLikeAVideo
+                !it.looksLikeAVideo &&
+                !it.showInEmbeddedWebView
         }.orEmpty()
 
     Column(
@@ -506,7 +509,35 @@ private fun ExtendedPost(
             )
         }
 
-        if (post.videoUrl.isNotEmpty()) {
+        if (post.embeddedUrl.isNotEmpty()) {
+            PostCardEmbeddedWebView(
+                modifier =
+                    Modifier
+                        .padding(
+                            vertical = Spacing.xxs,
+                            horizontal = if (fullWidthImage) 0.dp else Spacing.s,
+                        ),
+                blurred = blurNsfw && post.nsfw,
+                autoLoadImages = autoLoadImages,
+                url = post.embeddedUrl,
+                onOpen = {
+                    if (postLinkUrl.isNotEmpty()) {
+                        navigationCoordinator.handleUrl(
+                            url = postLinkUrl,
+                            openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
+                            uriHandler = uriHandler,
+                            customTabsHelper = customTabsHelper,
+                            onOpenWeb = onOpenWeb,
+                            onOpenCommunity = onOpenCommunity,
+                            onOpenPost = onOpenPost,
+                            onOpenUser = onOpenCreator,
+                        )
+                    } else {
+                        onClick?.invoke()
+                    }
+                },
+            )
+        } else if (post.videoUrl.isNotEmpty()) {
             PostCardVideo(
                 modifier =
                     Modifier

--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">عرض المسافة البادئة للتعليقات</string>
     <string name="post_action_unhide">إرجاع الإخفاء</string>
     <string name="admin_action_purge">تطهير</string>
-    <string name="settings_url_opening_mode_no_history">لا تاريخ</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Ширина на отстъпа на коментарите</string>
     <string name="post_action_unhide">Връщане на скриването</string>
     <string name="admin_action_purge">Прочистване</string>
-    <string name="settings_url_opening_mode_no_history">няма история</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Šířka odsazení komentářů</string>
     <string name="post_action_unhide">Vrátit skrýt</string>
     <string name="admin_action_purge">Očistit</string>
-    <string name="settings_url_opening_mode_no_history">žádná historie</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Bredde på indrykning af kommentarer</string>
     <string name="post_action_unhide">Vend skjul tilbage</string>
     <string name="admin_action_purge">Udrensning</string>
-    <string name="settings_url_opening_mode_no_history">ingen historie</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Breite der Einrückung von Kommentaren</string>
     <string name="post_action_unhide">Ausblenden wiederherstellen</string>
     <string name="admin_action_purge">Säubern</string>
-    <string name="settings_url_opening_mode_no_history">keine Geschichte</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Πλάτος εσοχής σχολίων</string>
     <string name="post_action_unhide">Επαναφορά απόκρυψης</string>
     <string name="admin_action_purge">Καθάρισε</string>
-    <string name="settings_url_opening_mode_no_history">καμία ιστορία</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Larĝeco de indentaĵo de komentoj</string>
     <string name="post_action_unhide">Reverti kaŝon</string>
     <string name="admin_action_purge">Elpurigi</string>
-    <string name="settings_url_opening_mode_no_history">neniu historio</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Ancho de indentación de los comentarios</string>
     <string name="post_action_unhide">Revertir ocultar</string>
     <string name="admin_action_purge">Purgar</string>
-    <string name="settings_url_opening_mode_no_history">no historia</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Kommentaaride taande laius</string>
     <string name="post_action_unhide">Taasta peitmine</string>
     <string name="admin_action_purge">Puhastamine</string>
-    <string name="settings_url_opening_mode_no_history">ajalugu pole</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Kommenttien sisennyksen leveys</string>
     <string name="post_action_unhide">Palauta piilotus</string>
     <string name="admin_action_purge">Puhdistaa</string>
-    <string name="settings_url_opening_mode_no_history">ei historiaa</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Largeur d\'indentation des commentaires</string>
     <string name="post_action_unhide">Rétablir le masquage</string>
     <string name="admin_action_purge">Purger</string>
-    <string name="settings_url_opening_mode_no_history">pas d\'histoire</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Leithead eangú na dtuairimí</string>
     <string name="post_action_unhide">Cuir ceilt ar ais</string>
     <string name="admin_action_purge">Glanadh</string>
-    <string name="settings_url_opening_mode_no_history">gan stair</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Širina uvlačenja komentara</string>
     <string name="post_action_unhide">Vrati skrivanje</string>
     <string name="admin_action_purge">Čišćenje</string>
-    <string name="settings_url_opening_mode_no_history">nema povijesti</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">A megjegyzések behúzásának szélessége</string>
     <string name="post_action_unhide">Elrejtés visszaállítása</string>
     <string name="admin_action_purge">Tisztítás</string>
-    <string name="settings_url_opening_mode_no_history">nincs történelem</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Larghezza rientro dei commenti</string>
     <string name="post_action_unhide">Annulla nascondi</string>
     <string name="admin_action_purge">Epura</string>
-    <string name="settings_url_opening_mode_no_history">no cronologia</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Komentarų įtraukos plotis</string>
     <string name="post_action_unhide">Grąžinti slėpimą</string>
     <string name="admin_action_purge">Valymas</string>
-    <string name="settings_url_opening_mode_no_history">jokios istorijos</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Komentāru atkāpes platums</string>
     <string name="post_action_unhide">Atgriezt slēpšanu</string>
     <string name="admin_action_purge">Iztīrīšana</string>
-    <string name="settings_url_opening_mode_no_history">nav vēstures</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Wisa\' ta\' indentazzjoni tal-kummenti</string>
     <string name="post_action_unhide">Aqleb ħabi</string>
     <string name="admin_action_purge">Tnaddaf</string>
-    <string name="settings_url_opening_mode_no_history">ebda storja</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Breedte van de inspringing van opmerkingen</string>
     <string name="post_action_unhide">Verberg terug</string>
     <string name="admin_action_purge">Zuiveren</string>
-    <string name="settings_url_opening_mode_no_history">geen geschiedenis</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Bredde på innrykk av kommentarer</string>
     <string name="post_action_unhide">Tilbakestill skjul</string>
     <string name="admin_action_purge">Rensing</string>
-    <string name="settings_url_opening_mode_no_history">ingen historie</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Szerokość wcięcia komentarzy</string>
     <string name="post_action_unhide">Przywróć ukrycie</string>
     <string name="admin_action_purge">Oczyszczać</string>
-    <string name="settings_url_opening_mode_no_history">żadnej historii</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Largura de recuo dos comentários</string>
     <string name="post_action_unhide">Reverter ocultar</string>
     <string name="admin_action_purge">Purgar</string>
-    <string name="settings_url_opening_mode_no_history">sem história</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Largura de recuo dos comentários</string>
     <string name="post_action_unhide">Reverter ocultar</string>
     <string name="admin_action_purge">Purgar</string>
-    <string name="settings_url_opening_mode_no_history">sem história</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Lățimea indentării comentariilor</string>
     <string name="post_action_unhide">Revino ascunderea</string>
     <string name="admin_action_purge">Epurează</string>
-    <string name="settings_url_opening_mode_no_history">fără istorie</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -395,5 +395,4 @@
     <string name="settings_comment_indent_amount">Ширина отступа комментариев</string>
     <string name="post_action_unhide">Вернуть скрытие</string>
     <string name="admin_action_purge">Удалять</string>
-    <string name="settings_url_opening_mode_no_history">нет истории</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Bredd på indrag av kommentarer</string>
     <string name="post_action_unhide">Återställ göm</string>
     <string name="admin_action_purge">Rena</string>
-    <string name="settings_url_opening_mode_no_history">ingen historia</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Šírka odsadenia komentárov</string>
     <string name="post_action_unhide">Vrátiť skryť</string>
     <string name="admin_action_purge">Vyčistiť</string>
-    <string name="settings_url_opening_mode_no_history">žiadna história</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Širina zamika komentarjev</string>
     <string name="post_action_unhide">Povrni skrivanje</string>
     <string name="admin_action_purge">Čiščenje</string>
-    <string name="settings_url_opening_mode_no_history">brez zgodovine</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Gjerësia e dhëmbëzimit të komenteve</string>
     <string name="post_action_unhide">Rikthe fshehjen</string>
     <string name="admin_action_purge">Pastrim</string>
-    <string name="settings_url_opening_mode_no_history">asnjë histori</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sr/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Ширина увлачења коментара</string>
     <string name="post_action_unhide">Врати сакрити</string>
     <string name="admin_action_purge">Чистка</string>
-    <string name="settings_url_opening_mode_no_history">нема историје</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">suli poka pi toki lili</string>
     <string name="post_action_unhide">o lukin</string>
     <string name="admin_action_purge">o weka kin</string>
-    <string name="settings_url_opening_mode_no_history">sona ala pi tenpo pini</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -396,5 +396,4 @@
     <string name="settings_comment_indent_amount">Yorum girintisinin genişliği</string>
     <string name="post_action_unhide">Gizlemeyi geri al</string>
     <string name="admin_action_purge">Tasfiye</string>
-    <string name="settings_url_opening_mode_no_history">tarih yok</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -395,5 +395,4 @@
     <string name="settings_comment_indent_amount">Ширина відступу коментарів</string>
     <string name="post_action_unhide">Повернути приховування</string>
     <string name="admin_action_purge">Чистка</string>
-    <string name="settings_url_opening_mode_no_history">немає історії</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -404,5 +404,4 @@
     <string name="settings_comment_indent_amount">Comment indentation amount</string>
     <string name="post_action_unhide">Revert hide</string>
     <string name="admin_action_purge">Purge</string>
-    <string name="settings_url_opening_mode_no_history">no history</string>
 </resources>

--- a/core/utils/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/DefaultCustomTabsHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/DefaultCustomTabsHelper.kt
@@ -17,10 +17,7 @@ class DefaultCustomTabsHelper(
         !packageName.isNullOrEmpty()
     }
 
-    override fun handle(
-        url: String,
-        noHistory: Boolean,
-    ) {
+    override fun handle(url: String) {
         val uri = Uri.parse(url)
         CustomTabsIntent.Builder()
             .apply {
@@ -31,18 +28,10 @@ class DefaultCustomTabsHelper(
             .run {
                 intent.apply {
                     `package` = packageName
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    if (noHistory) {
-                        flags = flags or Intent.FLAG_ACTIVITY_NO_HISTORY
-                        putExtra(EXTRA_CHROME_INCOGNITO, true)
-                    }
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 }
                 launchUrl(context, uri)
             }
-    }
-
-    companion object {
-        private const val EXTRA_CHROME_INCOGNITO = "com.google.android.apps.chrome.EXTRA_OPEN_NEW_INCOGNITO_TAB"
     }
 }
 

--- a/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/Extensions.kt
+++ b/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/Extensions.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:no-wildcard-imports")
-
 package com.github.diegoberaldin.raccoonforlemmy.core.utils
 
 import androidx.compose.runtime.Composable
@@ -10,7 +8,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.Locales
-import io.ktor.utils.io.core.toByteArray
+import io.ktor.utils.io.core.*
 import org.kotlincrypto.hash.md.MD5
 import kotlin.math.round
 
@@ -176,8 +174,14 @@ val String.looksLikeAVideo: Boolean
         return extensions.any { this.endsWith(it) }
     }
 
-val String.isRedGifs: Boolean
-    get() = this.contains("redgifs.com")
+val String.showInEmbeddedWebView: Boolean
+    get() {
+        val patterns =
+            listOf(
+                ".redgifs.com/",
+            )
+        return patterns.any { this.contains(it) }
+    }
 
 fun String?.ellipsize(
     length: Int = 100,

--- a/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/Extensions.kt
+++ b/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/Extensions.kt
@@ -174,14 +174,8 @@ val String.looksLikeAVideo: Boolean
         return extensions.any { this.endsWith(it) }
     }
 
-val String.showInEmbeddedWebView: Boolean
-    get() {
-        val patterns =
-            listOf(
-                ".redgifs.com/",
-            )
-        return patterns.any { this.contains(it) }
-    }
+val String.isRedGifs: Boolean
+    get() = contains("redgifs.com")
 
 fun String?.ellipsize(
     length: Int = 100,

--- a/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/CustomTabsHelper.kt
+++ b/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/CustomTabsHelper.kt
@@ -3,10 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.core.utils.url
 interface CustomTabsHelper {
     val isSupported: Boolean
 
-    fun handle(
-        url: String,
-        noHistory: Boolean = false,
-    )
+    fun handle(url: String)
 }
 
 expect fun getCustomTabsHelper(): CustomTabsHelper

--- a/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/UrlOpeningMode.kt
+++ b/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/UrlOpeningMode.kt
@@ -6,8 +6,6 @@ import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 sealed interface UrlOpeningMode {
     data object CustomTabs : UrlOpeningMode
 
-    data object CustomTabsNoHistory : UrlOpeningMode
-
     data object External : UrlOpeningMode
 
     data object Internal : UrlOpeningMode
@@ -15,7 +13,6 @@ sealed interface UrlOpeningMode {
 
 fun UrlOpeningMode.toInt(): Int =
     when (this) {
-        UrlOpeningMode.CustomTabsNoHistory -> 3
         UrlOpeningMode.CustomTabs -> 2
         UrlOpeningMode.External -> 1
         else -> 0
@@ -23,7 +20,6 @@ fun UrlOpeningMode.toInt(): Int =
 
 fun Int.toUrlOpeningMode(): UrlOpeningMode =
     when (this) {
-        3 -> UrlOpeningMode.CustomTabsNoHistory
         2 -> UrlOpeningMode.CustomTabs
         1 -> UrlOpeningMode.External
         else -> UrlOpeningMode.Internal
@@ -32,13 +28,6 @@ fun Int.toUrlOpeningMode(): UrlOpeningMode =
 @Composable
 fun UrlOpeningMode.toReadableName(): String =
     when (this) {
-        UrlOpeningMode.CustomTabsNoHistory ->
-            buildString {
-                append(LocalXmlStrings.current.settingsUrlOpeningModeCustomTabs)
-                append(" (")
-                append(LocalXmlStrings.current.settingsUrlOpeningModeNoHistory)
-                append(")")
-            }
         UrlOpeningMode.CustomTabs -> LocalXmlStrings.current.settingsUrlOpeningModeCustomTabs
         UrlOpeningMode.External -> LocalXmlStrings.current.settingsUrlOpeningModeExternal
         UrlOpeningMode.Internal -> LocalXmlStrings.current.settingsUrlOpeningModeInternal

--- a/core/utils/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/DefaultCustomTabsHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/url/DefaultCustomTabsHelper.kt
@@ -6,10 +6,7 @@ import org.koin.core.component.inject
 class DefaultCustomTabsHelper : CustomTabsHelper {
     override val isSupported = false
 
-    override fun handle(
-        url: String,
-        noHistory: Boolean,
-    ) {
+    override fun handle(url: String) {
         // no-op
     }
 }

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/PostModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/PostModel.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data
 
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAVideo
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAnImage
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.showInEmbeddedWebView
 
 data class PostModel(
     val id: Long = 0,
@@ -41,3 +42,6 @@ val PostModel.imageUrl: String
 
 val PostModel.videoUrl: String
     get() = url?.takeIf { it.looksLikeAVideo }?.takeIf { it.isNotEmpty() }.orEmpty()
+
+val PostModel.embeddedUrl: String
+    get() = url?.takeIf { it.showInEmbeddedWebView }?.takeIf { it.isNotEmpty() }.orEmpty()

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/PostModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/PostModel.kt
@@ -2,7 +2,6 @@ package com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data
 
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAVideo
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.looksLikeAnImage
-import com.github.diegoberaldin.raccoonforlemmy.core.utils.showInEmbeddedWebView
 
 data class PostModel(
     val id: Long = 0,
@@ -35,13 +34,8 @@ data class PostModel(
 
 val PostModel.imageUrl: String
     get() =
-        (
-            thumbnailUrl?.takeIf { it.isNotEmpty() }
-                ?: url?.takeIf { it.looksLikeAnImage }
-        ).orEmpty()
+        thumbnailUrl?.takeIf { it.isNotEmpty() }
+            ?: url?.takeIf { it.looksLikeAnImage }.orEmpty()
 
 val PostModel.videoUrl: String
     get() = url?.takeIf { it.looksLikeAVideo }?.takeIf { it.isNotEmpty() }.orEmpty()
-
-val PostModel.embeddedUrl: String
-    get() = url?.takeIf { it.showInEmbeddedWebView }?.takeIf { it.isNotEmpty() }.orEmpty()

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -294,7 +294,6 @@ class SettingsScreen : Screen {
                                                 this += UrlOpeningMode.Internal
                                                 if (uiState.customTabsEnabled) {
                                                     this += UrlOpeningMode.CustomTabs
-                                                    this += UrlOpeningMode.CustomTabsNoHistory
                                                 }
                                                 this += UrlOpeningMode.External
                                             },


### PR DESCRIPTION
Apparently, it is simply not possible to implement what was intended in #857, so I'm reverting it. Sorry for the inconvenience.

I am also removing the `emdeddedUrl` property from posts and `showInEmbeddedWebView` for URL processing, because RedGifs will be dealt with in a separate PR.