### PR TITLE
enhancement: inbox read replies and mentions

### DIFF
--- a/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsScreen.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsScreen.kt
@@ -46,8 +46,6 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.detailopener.api.g
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.InboxCard
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.InboxCardPlaceholder
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.InboxCardType
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.Option
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.TabNavigationSection
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -185,9 +183,7 @@ class InboxMentionsScreen : Tab {
                                         onTriggered =
                                             rememberCallback {
                                                 model.reduce(
-                                                    InboxMentionsMviModel.Intent.DownVoteComment(
-                                                        mention.id,
-                                                    ),
+                                                    InboxMentionsMviModel.Intent.DownVoteComment(mention.id),
                                                 )
                                             },
                                     )
@@ -242,6 +238,14 @@ class InboxMentionsScreen : Tab {
                                 voteFormat = uiState.voteFormat,
                                 onOpenPost =
                                     rememberCallbackArgs { post ->
+                                        if (!mention.read) {
+                                            model.reduce(
+                                                InboxMentionsMviModel.Intent.MarkAsRead(
+                                                    read = true,
+                                                    id = mention.id,
+                                                ),
+                                            )
+                                        }
                                         detailOpener.openPostDetail(
                                             post = post,
                                             highlightCommentId = mention.comment.id,
@@ -281,33 +285,6 @@ class InboxMentionsScreen : Tab {
                                             originalPost = mention.post,
                                             originalComment = mention.comment,
                                         )
-                                    },
-                                options =
-                                    buildList {
-                                        add(
-                                            Option(
-                                                OptionId.ToggleRead,
-                                                if (mention.read) {
-                                                    LocalXmlStrings.current.inboxActionMarkUnread
-                                                } else {
-                                                    LocalXmlStrings.current.inboxActionMarkRead
-                                                },
-                                            ),
-                                        )
-                                    },
-                                onOptionSelected =
-                                    rememberCallbackArgs(model) { optionId ->
-                                        when (optionId) {
-                                            OptionId.ToggleRead ->
-                                                model.reduce(
-                                                    InboxMentionsMviModel.Intent.MarkAsRead(
-                                                        read = !mention.read,
-                                                        id = mention.id,
-                                                    ),
-                                                )
-
-                                            else -> Unit
-                                        }
                                     },
                             )
                         },

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesScreen.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/InboxMessagesScreen.kt
@@ -100,7 +100,7 @@ class InboxMessagesScreen : Tab {
             ) {
                 if (uiState.chats.isEmpty() && uiState.initial) {
                     items(3) {
-                        ChatCardPlaceholder()
+                        ChatCardPlaceholder(modifier = Modifier.padding(top = Spacing.interItem))
                     }
                 }
                 if (uiState.chats.isEmpty() && !uiState.initial) {

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCard.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCard.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreHoriz
-import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -29,7 +28,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ContentFontClass
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -71,7 +69,7 @@ internal fun ChatCard(
     Row(
         modifier =
             modifier
-                .padding(horizontal = Spacing.xs, vertical = Spacing.s)
+                .padding(horizontal = Spacing.xs)
                 .onClick(
                     onClick = {
                         onOpen?.invoke()
@@ -116,7 +114,7 @@ internal fun ChatCard(
 
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
             Row(
                 modifier = Modifier.padding(end = Spacing.m),
@@ -129,6 +127,15 @@ internal fun ChatCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = ancillaryColor,
                 )
+                // last message date
+                if (lastMessageDate != null) {
+                    Text(
+                        modifier = Modifier.padding(start = Spacing.xxs),
+                        text = lastMessageDate.prettifyDate(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = ancillaryColor,
+                    )
+                }
             }
             CustomizedContent(ContentFontClass.Body) {
                 // last message text
@@ -140,30 +147,15 @@ internal fun ChatCard(
                     },
                 )
             }
-
-            // last message date
-            if (lastMessageDate != null) {
-                Box {
+            Box {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                modifier = Modifier.size(IconSize.s).padding(0.5.dp),
-                                imageVector = Icons.Default.Schedule,
-                                contentDescription = null,
-                                tint = ancillaryColor,
-                            )
-                            Text(
-                                modifier = Modifier.padding(start = Spacing.xxs),
-                                text = lastMessageDate.prettifyDate(),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = ancillaryColor,
-                            )
-                        }
+                        Spacer(modifier = Modifier.size(IconSize.m))
                         Spacer(modifier = Modifier.weight(1f))
                         if (options.isNotEmpty()) {
                             Icon(

--- a/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCardPlaceholder.kt
+++ b/unit/messages/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/messages/components/ChatCardPlaceholder.kt
@@ -16,14 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.CornerSize
-import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.shimmerEffect
 
 @Composable
-internal fun ChatCardPlaceholder() {
+internal fun ChatCardPlaceholder(modifier: Modifier = Modifier) {
     Row(
-        modifier = Modifier.padding(horizontal = Spacing.xs, vertical = Spacing.s),
+        modifier = modifier.padding(horizontal = Spacing.xs),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.m),
     ) {
@@ -41,14 +40,6 @@ internal fun ChatCardPlaceholder() {
                 modifier =
                     Modifier
                         .height(50.dp)
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(CornerSize.s))
-                        .shimmerEffect(),
-            )
-            Box(
-                modifier =
-                    Modifier
-                        .height(IconSize.m)
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(CornerSize.s))
                         .shimmerEffect(),

--- a/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesScreen.kt
+++ b/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesScreen.kt
@@ -47,8 +47,6 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.detailopener.api.g
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.InboxCard
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.InboxCardPlaceholder
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.InboxCardType
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.Option
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.TabNavigationSection
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -182,11 +180,7 @@ class InboxRepliesScreen : Tab {
                                         backgroundColor = downVoteColor ?: defaultDownVoteColor,
                                         onTriggered =
                                             rememberCallback {
-                                                model.reduce(
-                                                    InboxRepliesMviModel.Intent.DownVoteComment(
-                                                        reply.id,
-                                                    ),
-                                                )
+                                                model.reduce(InboxRepliesMviModel.Intent.DownVoteComment(reply.id))
                                             },
                                     )
 
@@ -240,6 +234,14 @@ class InboxRepliesScreen : Tab {
                                 voteFormat = uiState.voteFormat,
                                 onOpenPost =
                                     rememberCallbackArgs { post ->
+                                        if (!reply.read) {
+                                            model.reduce(
+                                                InboxRepliesMviModel.Intent.MarkAsRead(
+                                                    read = true,
+                                                    id = reply.id,
+                                                ),
+                                            )
+                                        }
                                         detailOpener.openPostDetail(
                                             post = post,
                                             highlightCommentId = reply.comment.id,
@@ -276,33 +278,6 @@ class InboxRepliesScreen : Tab {
                                             originalPost = reply.post,
                                             originalComment = reply.comment,
                                         )
-                                    },
-                                options =
-                                    buildList {
-                                        add(
-                                            Option(
-                                                OptionId.ToggleRead,
-                                                if (reply.read) {
-                                                    LocalXmlStrings.current.inboxActionMarkUnread
-                                                } else {
-                                                    LocalXmlStrings.current.inboxActionMarkRead
-                                                },
-                                            ),
-                                        )
-                                    },
-                                onOptionSelected =
-                                    rememberCallbackArgs(model) { optionId ->
-                                        when (optionId) {
-                                            OptionId.ToggleRead ->
-                                                model.reduce(
-                                                    InboxRepliesMviModel.Intent.MarkAsRead(
-                                                        read = !reply.read,
-                                                        id = reply.id,
-                                                    ),
-                                                )
-
-                                            else -> Unit
-                                        }
                                     },
                             )
                         },

--- a/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
+++ b/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
@@ -90,23 +90,19 @@ class InboxRepliesViewModel(
                 }
 
             is InboxRepliesMviModel.Intent.MarkAsRead -> {
-                markAsRead(
-                    read = intent.read,
-                    reply = uiState.value.replies.first { it.id == intent.id },
-                )
+                val reply = uiState.value.replies.first { it.id == intent.id }
+                markAsRead(read = intent.read, reply = reply)
             }
 
             InboxRepliesMviModel.Intent.HapticIndication -> hapticFeedback.vibrate()
             is InboxRepliesMviModel.Intent.DownVoteComment -> {
-                toggleDownVoteComment(
-                    mention = uiState.value.replies.first { it.id == intent.id },
-                )
+                val reply = uiState.value.replies.first { it.id == intent.id }
+                toggleDownVoteComment(reply)
             }
 
             is InboxRepliesMviModel.Intent.UpVoteComment -> {
-                toggleUpVoteComment(
-                    mention = uiState.value.replies.first { it.id == intent.id },
-                )
+                val reply = uiState.value.replies.first { it.id == intent.id }
+                toggleUpVoteComment(reply)
             }
         }
     }
@@ -237,6 +233,15 @@ class InboxRepliesViewModel(
                     comment = mention.comment,
                     voted = newValue,
                 )
+                if (!mention.read) {
+                    userRepository.setReplyRead(
+                        read = true,
+                        replyId = mention.id,
+                        auth = auth,
+                    )
+                    handleItemUpdate(newMention.copy(read = true))
+                    updateUnreadItems()
+                }
             } catch (e: Throwable) {
                 handleItemUpdate(mention)
             }
@@ -259,6 +264,15 @@ class InboxRepliesViewModel(
                     comment = mention.comment,
                     downVoted = newValue,
                 )
+                if (!mention.read) {
+                    userRepository.setReplyRead(
+                        read = true,
+                        replyId = mention.id,
+                        auth = auth,
+                    )
+                    handleItemUpdate(newMention.copy(read = true))
+                    updateUnreadItems()
+                }
             } catch (e: Throwable) {
                 handleItemUpdate(mention)
             }


### PR DESCRIPTION
It is useless to have to use different actions to mark replies and mentions as read after you have voted, downvoted or even opened the corresponding thread. It will now be possible to mark them as read while voting altogether.

Moreover, since there is a swipe action for it, it is no longer needed to have an options menu in mention/reply cards.

Finally, this PR also improves the messages layout by reducing the amount of wasted space to display the user name and the date on two separate lines.