### PR TITLE
chore: add more pagination tests

### DIFF
--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultMultiCommunityPaginatorTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultMultiCommunityPaginatorTest.kt
@@ -1,0 +1,160 @@
+package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
+
+import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.PostRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DefaultMultiCommunityPaginatorTest {
+    @get:Rule
+    val dispatcherTestRule = DispatcherTestRule()
+
+    private val postRepository: PostRepository = mockk()
+
+    private val sut =
+        DefaultMultiCommunityPaginator(
+            postRepository = postRepository,
+        )
+
+    @Test
+    fun whenLoadNextPage_thenResultAndInteractionsAreAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = capture(page),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    emptyList<PostModel>() to null
+                }
+            }
+            val communityIds = listOf(1L, 2L)
+            sut.setCommunities(communityIds)
+
+            val sort = SortType.Active
+            val items =
+                sut.loadNextPage(
+                    auth = AUTH_TOKEN,
+                    sort = sort,
+                )
+
+            assertEquals(40, items.size)
+            assertTrue(sut.canFetchMore)
+
+            coVerify {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = ListingType.All,
+                    sort = sort,
+                    communityId = 1L,
+                    communityName = null,
+                )
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = ListingType.All,
+                    sort = sort,
+                    communityId = 2L,
+                    communityName = null,
+                )
+            }
+        }
+
+    @Test
+    fun whenLoadNextPageAndNoMoreResults_thenResultAndInteractionsAreAsExpected() =
+        runTest {
+            val page = slot<Int>()
+            coEvery {
+                postRepository.getAll(
+                    auth = any(),
+                    page = capture(page),
+                    pageCursor = any(),
+                    limit = any(),
+                    type = any(),
+                    sort = any(),
+                    communityId = any(),
+                )
+            } answers {
+                val pageNumber = page.captured
+                if (pageNumber == 1) {
+                    (0..<20).map { idx ->
+                        PostModel(id = idx.toLong())
+                    } to PAGE_CURSOR
+                } else {
+                    emptyList<PostModel>() to null
+                }
+            }
+            val communityIds = listOf(1L, 2L)
+            sut.setCommunities(communityIds)
+
+            val sort = SortType.Active
+            sut.loadNextPage(
+                auth = AUTH_TOKEN,
+                sort = sort,
+            )
+            val items =
+                sut.loadNextPage(
+                    auth = AUTH_TOKEN,
+                    sort = sort,
+                )
+
+            assertTrue(items.isEmpty())
+            assertFalse(sut.canFetchMore)
+
+            coVerify {
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = ListingType.All,
+                    sort = sort,
+                    communityId = 1L,
+                    communityName = null,
+                )
+                postRepository.getAll(
+                    auth = AUTH_TOKEN,
+                    page = 1,
+                    pageCursor = null,
+                    limit = 20,
+                    type = ListingType.All,
+                    sort = sort,
+                    communityId = 2L,
+                    communityName = null,
+                )
+            }
+        }
+
+    companion object {
+        private const val AUTH_TOKEN = "fake-token"
+        private const val PAGE_CURSOR = "fake-page-cursor"
+    }
+}

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostNavigationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostNavigationManagerTest.kt
@@ -1,0 +1,185 @@
+package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
+
+import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DefaultPostNavigationManagerTest {
+    @get:Rule
+    val dispatcherTestRule = DispatcherTestRule()
+
+    private val postPaginationManager: PostPaginationManager = mockk(relaxUnitFun = true)
+
+    private val sut =
+        DefaultPostNavigationManager(
+            postPaginationManager = postPaginationManager,
+        )
+
+    @Test
+    fun whenInitial_thenCanNotNavigate() =
+        runTest {
+            val res = sut.canNavigate.value
+            assertFalse(res)
+        }
+
+    @Test
+    fun whenPush_thenCanNavigate() =
+        runTest {
+            val mockState = mockk<PostPaginationManagerState>()
+            sut.push(mockState)
+
+            val res = sut.canNavigate.value
+            assertTrue(res)
+
+            verify {
+                postPaginationManager.restoreState(mockState)
+            }
+        }
+
+    @Test
+    fun whenPopWithMoreThanOneState_thenCanNavigate() =
+        runTest {
+            val mockState1 = mockk<PostPaginationManagerState>()
+            sut.push(mockState1)
+            val mockState2 = mockk<PostPaginationManagerState>()
+            sut.push(mockState2)
+
+            sut.pop()
+            val res = sut.canNavigate.value
+            assertTrue(res)
+
+            verifySequence {
+                postPaginationManager.restoreState(mockState1)
+                postPaginationManager.restoreState(mockState2)
+                postPaginationManager.restoreState(mockState1)
+            }
+        }
+
+    @Test
+    fun whenPopWithOneState_thenCanNotNavigate() =
+        runTest {
+            val mockState = mockk<PostPaginationManagerState>()
+            sut.push(mockState)
+
+            sut.pop()
+            val res = sut.canNavigate.value
+            assertFalse(res)
+
+            verifySequence {
+                postPaginationManager.restoreState(mockState)
+                postPaginationManager.reset()
+            }
+        }
+
+    @Test
+    fun givenEmptyHistory_whenGetPrevious_thenResultIsAsExpected() =
+        runTest {
+            every { postPaginationManager.history } returns emptyList()
+
+            val res = sut.getPrevious(1)
+
+            assertNull(res)
+        }
+
+    @Test
+    fun givenHistory_whenGetPreviousWithFirstId_thenResultIsAsExpected() =
+        runTest {
+            val postId = 1L
+            every { postPaginationManager.history } returns listOf(PostModel(id = postId))
+
+            val res = sut.getPrevious(postId)
+
+            assertNull(res)
+        }
+
+    @Test
+    fun givenHistory_whenGetPreviousWithNotFirstId_thenResultIsAsExpected() =
+        runTest {
+            val otherPostId = 1L
+            val postId = 2L
+            every { postPaginationManager.history } returns
+                listOf(
+                    PostModel(id = otherPostId),
+                    PostModel(id = postId),
+                )
+
+            val res = sut.getPrevious(postId)
+
+            assertNotNull(res)
+            assertEquals(otherPostId, res.id)
+        }
+
+    @Test
+    fun givenEmptyHistory_whenGetNext_thenResultIsAsExpected() =
+        runTest {
+            every { postPaginationManager.history } returns emptyList()
+
+            val res = sut.getNext(1)
+
+            assertNull(res)
+        }
+
+    @Test
+    fun givenHistoryAndCanNotFetchMore_whenGetNextWithLastId_thenResultIsAsExpected() =
+        runTest {
+            val postId = 1L
+            every { postPaginationManager.history } returns listOf(PostModel(id = postId))
+            every { postPaginationManager.canFetchMore } returns false
+
+            val res = sut.getNext(postId)
+
+            assertNull(res)
+            coVerify(inverse = true) {
+                postPaginationManager.loadNextPage()
+            }
+        }
+
+    @Test
+    fun givenHistoryAndCanFetchMore_whenGetNextWithLastId_thenResultIsAsExpected() =
+        runTest {
+            val postId = 1L
+            val otherPostId = 2L
+            every { postPaginationManager.history } returns listOf(PostModel(id = postId))
+            every { postPaginationManager.canFetchMore } returns true
+            coEvery { postPaginationManager.loadNextPage() } returns listOf(PostModel(id = otherPostId))
+
+            val res = sut.getNext(postId)
+
+            assertNotNull(res)
+            assertEquals(otherPostId, res.id)
+
+            coVerify {
+                postPaginationManager.loadNextPage()
+            }
+        }
+
+    @Test
+    fun givenHistory_whenGetPreviousWithNotLastId_thenResultIsAsExpected() =
+        runTest {
+            val otherPostId = 1L
+            val postId = 2L
+            every { postPaginationManager.history } returns
+                listOf(
+                    PostModel(id = postId),
+                    PostModel(id = otherPostId),
+                )
+
+            val res = sut.getNext(postId)
+
+            assertNotNull(res)
+            assertEquals(otherPostId, res.id)
+        }
+}


### PR DESCRIPTION
This PR adds the last tests that were missing for the `:domain:lemmy:pagination` module.