### PR TITLE
fix: post and comment pagination cache

### DIFF
--- a/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
+++ b/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
@@ -24,6 +24,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -57,7 +58,9 @@ class DefaultDetailOpenerTest {
         runTest {
             val community = CommunityModel(name = "test", id = 1)
 
-            sut.openCommunityDetail(community)
+            launch {
+                sut.openCommunityDetail(community)
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {
@@ -92,7 +95,9 @@ class DefaultDetailOpenerTest {
                 )
             } returns listOf(SearchResult.Community(community))
 
-            sut.openCommunityDetail(community, otherInstance)
+            launch {
+                sut.openCommunityDetail(community, otherInstance)
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {
@@ -119,7 +124,9 @@ class DefaultDetailOpenerTest {
         runTest {
             val user = UserModel(name = "test", id = 1)
 
-            sut.openUserDetail(user)
+            launch {
+                sut.openUserDetail(user)
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {
@@ -137,7 +144,9 @@ class DefaultDetailOpenerTest {
         runTest {
             val post = PostModel(title = "test", id = 1)
 
-            sut.openPostDetail(post)
+            launch {
+                sut.openPostDetail(post)
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {
@@ -155,7 +164,9 @@ class DefaultDetailOpenerTest {
         runTest {
             val post = PostModel(title = "test", id = 1)
 
-            sut.openReply(originalPost = post)
+            launch {
+                sut.openReply(originalPost = post)
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {
@@ -173,7 +184,9 @@ class DefaultDetailOpenerTest {
         runTest {
             val comment = CommentModel(text = "test", id = 1)
 
-            sut.openReply(originalComment = comment)
+            launch {
+                sut.openReply(originalComment = comment)
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {
@@ -189,7 +202,9 @@ class DefaultDetailOpenerTest {
     @Test
     fun whenOpenCreatePost_thenNavigatesAccordingly() =
         runTest {
-            sut.openCreatePost()
+            launch {
+                sut.openCreatePost()
+            }
             advanceTimeBy(OPEN_DELAY)
 
             coVerify {

--- a/core/navigation/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -53,7 +53,7 @@ class DefaultNavigationCoordinatorTest {
         runTest {
             sut.setCurrentSection(TabNavigationSection.Profile)
             launch {
-                delay(250)
+                delay(DELAY)
                 sut.setCurrentSection(TabNavigationSection.Profile)
             }
             sut.onDoubleTabSelection.test {
@@ -163,8 +163,10 @@ class DefaultNavigationCoordinatorTest {
                 }
             sut.setRootNavigator(navigator)
 
-            sut.pushScreen(screen)
-            advanceTimeBy(500)
+            launch {
+                sut.pushScreen(screen)
+            }
+            delay(DELAY)
 
             val canPop = sut.canPop.value
             assertTrue(canPop)
@@ -192,7 +194,10 @@ class DefaultNavigationCoordinatorTest {
                 }
             sut.setRootNavigator(navigator)
 
-            sut.pushScreen(screen)
+            launch {
+                sut.pushScreen(screen)
+            }
+            advanceTimeBy(DELAY)
 
             val canPop = sut.canPop.value
             assertTrue(canPop)
@@ -211,7 +216,10 @@ class DefaultNavigationCoordinatorTest {
                 }
             sut.setRootNavigator(navigator)
 
-            sut.popScreen()
+            launch {
+                sut.popScreen()
+            }
+            advanceTimeBy(DELAY)
 
             val canPop = sut.canPop.value
             assertFalse(canPop)
@@ -233,8 +241,10 @@ class DefaultNavigationCoordinatorTest {
             val navigator = mockk<BottomSheetNavigator>(relaxUnitFun = true)
             sut.setBottomNavigator(navigator)
 
-            sut.showBottomSheet(screen)
-            advanceTimeBy(500)
+            launch {
+                sut.showBottomSheet(screen)
+            }
+            advanceTimeBy(DELAY)
 
             verify {
                 navigator.show(screen)
@@ -250,8 +260,10 @@ class DefaultNavigationCoordinatorTest {
                 }
             sut.setBottomNavigator(navigator)
 
-            sut.hideBottomSheet()
-            advanceTimeBy(500)
+            launch {
+                sut.hideBottomSheet()
+            }
+            advanceTimeBy(DELAY)
 
             verify {
                 navigator.hide()
@@ -269,6 +281,7 @@ class DefaultNavigationCoordinatorTest {
                     }
                 }
             launch {
+                delay(DELAY)
                 sut.openSideMenu(screen)
             }
 
@@ -282,6 +295,7 @@ class DefaultNavigationCoordinatorTest {
     fun whenCloseSideMenu_thenInteractionsAreAsExpected() =
         runTest {
             launch {
+                delay(DELAY)
                 sut.closeSideMenu()
             }
 
@@ -292,10 +306,11 @@ class DefaultNavigationCoordinatorTest {
         }
 
     @Test
-    fun whenShowGlobalMEssagethenInteractionsAreAsExpected() =
+    fun whenShowGlobalMessage_thenInteractionsAreAsExpected() =
         runTest {
             val message = "test message"
             launch {
+                delay(DELAY)
                 sut.showGlobalMessage(message)
             }
 
@@ -304,4 +319,8 @@ class DefaultNavigationCoordinatorTest {
                 assertEquals(message, item)
             }
         }
+
+    companion object {
+        private const val DELAY = 250L
+    }
 }

--- a/domain/lemmy/pagination/build.gradle.kts
+++ b/domain/lemmy/pagination/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
 
                 implementation(libs.koin.core)
 
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.identity)

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManagerTest.kt
@@ -1,5 +1,7 @@
 package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
 
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenter
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
@@ -13,11 +15,13 @@ import io.mockk.coVerifySequence
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
@@ -31,12 +35,17 @@ class DefaultCommentPaginationManagerTest {
         }
     private val commentRepository: CommentRepository = mockk(relaxUnitFun = true)
     private val userRepository: UserRepository = mockk(relaxUnitFun = true)
+    private val notificationCenter: NotificationCenter = mockk(relaxUnitFun = true) {
+        val slot = slot<KClass<NotificationCenterEvent>>()
+        every { subscribe(capture(slot)) } answers { MutableSharedFlow() }
+    }
 
     private val sut =
         DefaultCommentPaginationManager(
             identityRepository = identityRepository,
             commentRepository = commentRepository,
             userRepository = userRepository,
+            notificationCenter = notificationCenter,
         )
 
     @Test

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
@@ -1,5 +1,7 @@
 package com.diegoberaldin.raccoonforlemmy.domain.lemmy.pagination
 
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenter
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -15,11 +17,13 @@ import io.mockk.coVerifySequence
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
@@ -35,6 +39,10 @@ class DefaultPostPaginationManagerTest {
     private val communityRepository: CommunityRepository = mockk(relaxUnitFun = true)
     private val userRepository: UserRepository = mockk(relaxUnitFun = true)
     private val multiCommunityPaginator: MultiCommunityPaginator = mockk(relaxUnitFun = true)
+    private val notificationCenter: NotificationCenter = mockk(relaxUnitFun = true) {
+        val slot = slot<KClass<NotificationCenterEvent>>()
+        every { subscribe(capture(slot)) } answers { MutableSharedFlow() }
+    }
 
     private val sut =
         DefaultPostPaginationManager(
@@ -43,6 +51,7 @@ class DefaultPostPaginationManagerTest {
             communityRepository = communityRepository,
             userRepository = userRepository,
             multiCommunityPaginator = multiCommunityPaginator,
+            notificationCenter = notificationCenter,
         )
 
     @Test

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
@@ -24,6 +24,7 @@ val paginationModule =
                 communityRepository = get(),
                 userRepository = get(),
                 multiCommunityPaginator = get(),
+                notificationCenter = get(),
             )
         }
         factory<CommentPaginationManager> {

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
@@ -32,6 +32,7 @@ val paginationModule =
                 identityRepository = get(),
                 userRepository = get(),
                 commentRepository = get(),
+                notificationCenter = get(),
             )
         }
         single<PostNavigationManager> {


### PR DESCRIPTION
With post and comment pagination introduced in, a cache is created for posts and comments that are fetched while scrolling. If a post/comment gets modified due to user interaction (e.g. voting) the change was not reflected in this cache, which might lead to item state being "lost" when the content is fetched again from this cache, e.g. after navigating back to a post list or post detail screen.

This PR fixes this issue and ensures the cache is updated.