### PR TITLE
fix: duplicate inter-item spacing

### DIFF
--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -161,9 +161,7 @@ class DraftsScreen : Screen {
                 ) {
                     LazyColumn(
                         modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = Spacing.xs),
+                            Modifier.fillMaxSize(),
                         state = lazyListState,
                     ) {
                         if (uiState.section == DraftsSection.Posts) {

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -165,7 +165,6 @@ class DraftsScreen : Screen {
                                 .fillMaxSize()
                                 .padding(horizontal = Spacing.xs),
                         state = lazyListState,
-                        verticalArrangement = Arrangement.spacedBy(Spacing.interItem),
                     ) {
                         if (uiState.section == DraftsSection.Posts) {
                             if (uiState.postDrafts.isEmpty() && uiState.loading && uiState.initial) {

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/components/DraftCard.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/components/DraftCard.kt
@@ -73,7 +73,7 @@ fun DraftCard(
                             color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
                             shape = RoundedCornerShape(CornerSize.l),
                         )
-                        .padding(vertical = Spacing.xs)
+                        .padding(vertical = Spacing.s)
                 } else {
                     Modifier.background(MaterialTheme.colorScheme.background)
                 },
@@ -85,7 +85,7 @@ fun DraftCard(
             draft.reference?.also { reference ->
                 CustomizedContent(ContentFontClass.AncillaryText) {
                     Row(
-                        modifier = Modifier.padding(horizontal = Spacing.xs),
+                        modifier = Modifier.padding(horizontal = Spacing.s),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                     ) {
@@ -113,9 +113,7 @@ fun DraftCard(
                 CustomizedContent(ContentFontClass.Title) {
                     PostCardTitle(
                         modifier =
-                            Modifier.padding(
-                                horizontal = Spacing.xs,
-                            ),
+                            Modifier.padding(horizontal = Spacing.s),
                         text = title,
                         onClick = onOpen,
                     )
@@ -124,16 +122,14 @@ fun DraftCard(
 
             CustomizedContent(ContentFontClass.Body) {
                 PostCardBody(
-                    modifier =
-                        Modifier.padding(
-                            horizontal = Spacing.xs,
-                        ),
+                    modifier = Modifier.padding(horizontal = Spacing.s),
                     text = draft.body,
                     maxLines = 40,
                     onClick = onOpen,
                 )
             }
             DraftFooter(
+                modifier = Modifier.padding(horizontal = Spacing.s),
                 date = draft.date?.toIso8601Timestamp(),
                 options = options,
                 onOptionSelected = onOptionSelected,
@@ -144,6 +140,7 @@ fun DraftCard(
 
 @Composable
 private fun DraftFooter(
+    modifier: Modifier = Modifier,
     date: String? = null,
     options: List<Option> = emptyList(),
     onOptionSelected: ((OptionId) -> Unit)? = null,
@@ -152,7 +149,7 @@ private fun DraftFooter(
     var optionsOffset by remember { mutableStateOf(Offset.Zero) }
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha)
 
-    Box {
+    Box(modifier = modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -302,7 +302,6 @@ class FilteredContentsScreen(
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
-                        verticalArrangement = Arrangement.spacedBy(Spacing.interItem),
                     ) {
                         if (uiState.section == FilteredContentsSection.Posts) {
                             if (uiState.posts.isEmpty() && uiState.loading && uiState.initial) {
@@ -633,6 +632,12 @@ class FilteredContentsScreen(
                                         )
                                     },
                                 )
+
+                                if (uiState.postLayout != PostLayout.Card) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.interItem))
+                                } else {
+                                    Spacer(modifier = Modifier.height(Spacing.interItem))
+                                }
                             }
                         } else {
                             if (uiState.comments.isEmpty() && uiState.loading && uiState.initial) {
@@ -920,6 +925,12 @@ class FilteredContentsScreen(
                                         )
                                     },
                                 )
+
+                                if (uiState.postLayout != PostLayout.Card) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.interItem))
+                                } else {
+                                    Spacer(modifier = Modifier.height(Spacing.interItem))
+                                }
                             }
                         }
 

--- a/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -209,7 +209,6 @@ class ReportListScreen(
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
-                        verticalArrangement = Arrangement.spacedBy(Spacing.interItem),
                     ) {
                         if (uiState.section == ReportListSection.Posts) {
                             if (uiState.postReports.isEmpty() && uiState.loading && uiState.initial) {


### PR DESCRIPTION
This PR aims to fix a couple of layout issues with spacing in filtered contents (votes, moderated contents and saved items) and drafts screens.