### PR TITLE
fix: improve appearance on iOS

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
-		892175CB2C05B940001B28DB /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7555FF8C242A565B00829871 /* Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -299,6 +298,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -430,6 +430,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -454,6 +455,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = "$(SRCROOT)/iosApp/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Raccoon;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_NAME = iosApp;
 			};
@@ -468,6 +470,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/iosApp/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Raccoon;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_NAME = iosApp;
 			};

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -13,6 +13,6 @@ struct ComposeView: UIViewControllerRepresentable {
 struct ContentView: View {
     var body: some View {
         // Compose has own keyboard handler
-        ComposeView().ignoresSafeArea(.keyboard)
+        ComposeView().ignoresSafeArea(.all)
     }
 }


### PR DESCRIPTION
This PR contains another couple of fixes for the iOS version of the app, e.g. insets for the safe area applied multiple times (due to Compose-SwiftUI interop).

Moreover, there was an error in the project.pbxproj which prevented the project from building in Xcode.

![Simulator_Screenshot_iPhone_15_Pro_2024_05_28_at_18_18_33](https://github.com/diegoberaldin/RaccoonForLemmy/assets/2738294/e21bffd9-adde-4521-b9c4-aff9eba508ae)

