### PR TITLE
feat: specific language on a per-community basis

### DIFF
--- a/core/commonui/detailopener-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
+++ b/core/commonui/detailopener-api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
@@ -27,7 +27,7 @@ interface DetailOpener {
 
     fun openReply(
         draftId: Long? = null,
-        originalPost: PostModel? = null,
+        originalPost: PostModel,
         originalComment: CommentModel? = null,
         editedComment: CommentModel? = null,
         initialText: String? = null,

--- a/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
+++ b/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
@@ -185,7 +185,7 @@ class DefaultDetailOpenerTest {
             val comment = CommentModel(text = "test", id = 1)
 
             launch {
-                sut.openReply(originalComment = comment)
+                sut.openReply(originalComment = comment, originalPost = PostModel(id = 0))
             }
             advanceTimeBy(OPEN_DELAY)
 

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -102,16 +102,14 @@ class DefaultDetailOpener(
 
     override fun openReply(
         draftId: Long?,
-        originalPost: PostModel?,
+        originalPost: PostModel,
         originalComment: CommentModel?,
         editedComment: CommentModel?,
         initialText: String?,
     ) {
         scope.launch {
             withContext(Dispatchers.IO) {
-                if (originalPost != null) {
-                    itemCache.putPost(originalPost)
-                }
+                itemCache.putPost(originalPost)
                 if (originalComment != null) {
                     itemCache.putComment(originalComment)
                 }
@@ -122,7 +120,7 @@ class DefaultDetailOpener(
             val screen =
                 CreateCommentScreen(
                     draftId = draftId,
-                    originalPostId = originalPost?.id,
+                    originalPostId = originalPost.id,
                     originalCommentId = originalComment?.id,
                     editedCommentId = editedComment?.id,
                     initialText = initialText,

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/Options.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/Options.kt
@@ -30,6 +30,8 @@ sealed class OptionId(val value: Int) {
 
     data object AdminFeaturePost : OptionId(11)
 
+    data object SetPreferredLanguage : OptionId(12)
+
     data object FeaturePost : OptionId(13)
 
     data object LockPost : OptionId(14)

--- a/core/l10n/src/androidMain/res/values-ar/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ar/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">تطهير</string>
     <string name="admin_action_mark_as_featured">وضع علامة مميزة (مثال)</string>
     <string name="admin_action_unmark_as_featured">إلغاء تحديد علامة مميزة (مثال)</string>
+    <string name="community_set_preferred_language">تعيين اللغة المفضلة</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-bg/strings.xml
+++ b/core/l10n/src/androidMain/res/values-bg/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Прочистване</string>
     <string name="admin_action_mark_as_featured">Маркиране като представено (екземпляр)</string>
     <string name="admin_action_unmark_as_featured">Демаркиране като представено (екземпляр)</string>
+    <string name="community_set_preferred_language">Задаване на предпочитанияезик</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-cs/strings.xml
+++ b/core/l10n/src/androidMain/res/values-cs/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Očistit</string>
     <string name="admin_action_mark_as_featured">Označit jako doporučené (instance)</string>
     <string name="admin_action_unmark_as_featured">Zrušit označení jako doporučené (instance)</string>
+    <string name="community_set_preferred_language">Nastavení preferovaného jazyka</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-da/strings.xml
+++ b/core/l10n/src/androidMain/res/values-da/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Udrensning</string>
     <string name="admin_action_mark_as_featured">Markér som fremhævet (forekomst)</string>
     <string name="admin_action_unmark_as_featured">Fjern markering som fremhævet (forekomst)</string>
+    <string name="community_set_preferred_language">Indstil foretrukket sprog</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-de/strings.xml
+++ b/core/l10n/src/androidMain/res/values-de/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Säubern</string>
     <string name="admin_action_mark_as_featured">Als vorgestellt markieren (Instanz)</string>
     <string name="admin_action_unmark_as_featured">Markierung als vorgestellt aufheben (Instanz)</string>
+    <string name="community_set_preferred_language">Bevorzugte Sprache festlegen</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-el/strings.xml
+++ b/core/l10n/src/androidMain/res/values-el/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Καθάρισε</string>
     <string name="admin_action_mark_as_featured">Επισήμανση ως χαρακτηρισμένου (παράδειγμα)</string>
     <string name="admin_action_unmark_as_featured">Κατάργηση επισήμανσης ως επιλεγμένου (παράδειγμα)</string>
+    <string name="community_set_preferred_language">Ορισμός προτιμώμενης γλώσσας</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-eo/strings.xml
+++ b/core/l10n/src/androidMain/res/values-eo/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Elpurigi</string>
     <string name="admin_action_mark_as_featured">Marki kiel elstara (nodo)</string>
     <string name="admin_action_unmark_as_featured">Malmarki kiel elstara (nodo)</string>
+    <string name="community_set_preferred_language">Agordi preferatan lingvon</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-es/strings.xml
+++ b/core/l10n/src/androidMain/res/values-es/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Purgar</string>
     <string name="admin_action_mark_as_featured">Marcar como destacado (instancia)</string>
     <string name="admin_action_unmark_as_featured">Desmarcar como destacado (instancia)</string>
+    <string name="community_set_preferred_language">Elegir idioma preferido</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-et/strings.xml
+++ b/core/l10n/src/androidMain/res/values-et/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Puhastamine</string>
     <string name="admin_action_mark_as_featured">Märgi esiletõstetuks (näide)</string>
     <string name="admin_action_unmark_as_featured">Tühista esiletõstetud märgistus (näide)</string>
+    <string name="community_set_preferred_language">Eelistatud keele määramine</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fi/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fi/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Puhdistaa</string>
     <string name="admin_action_mark_as_featured">Merkitse esittelyyn (esim.)</string>
     <string name="admin_action_unmark_as_featured">Poista suositellun merkintä (esim.)</string>
+    <string name="community_set_preferred_language">Aseta ensisijainen kieli</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-fr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-fr/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Purger</string>
     <string name="admin_action_mark_as_featured">Marquer comme présenté (instance)</string>
     <string name="admin_action_unmark_as_featured">Démarquer comme présenté (instance)</string>
+    <string name="community_set_preferred_language">Définir la langue préférée</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ga/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ga/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Glanadh</string>
     <string name="admin_action_mark_as_featured">Marcáil mar atá léirithe (cás)</string>
     <string name="admin_action_unmark_as_featured">Dímharcáil mar atá i gceist (cás)</string>
+    <string name="community_set_preferred_language">An teanga rogha a shocrú</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hr/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Čišćenje</string>
     <string name="admin_action_mark_as_featured">Označi kao istaknuto (instanca)</string>
     <string name="admin_action_unmark_as_featured">Ukloni oznaku kao istaknuto (instanca)</string>
+    <string name="community_set_preferred_language">Postavljanje preferiranog jezik</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-hu/strings.xml
+++ b/core/l10n/src/androidMain/res/values-hu/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Tisztítás</string>
     <string name="admin_action_mark_as_featured">Megjelölés kiemeltként (példány)</string>
     <string name="admin_action_unmark_as_featured">Kiemeltként való megjelölés visszavonása (példány)</string>
+    <string name="community_set_preferred_language">Előnyben részesítettnyelv beállítása</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-it/strings.xml
+++ b/core/l10n/src/androidMain/res/values-it/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Epura</string>
     <string name="admin_action_mark_as_featured">Contrassegna come fissato (istanza)</string>
     <string name="admin_action_unmark_as_featured">Contrassegna come non fisasto (istanza)</string>
+    <string name="community_set_preferred_language">Imposta lingua preferita</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lt/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Valymas</string>
     <string name="admin_action_mark_as_featured">Pažymėti kaip siūlomą (pavyzdys)</string>
     <string name="admin_action_unmark_as_featured">Panaikinkite žymėjimą kaip panašų (pavyzdys)</string>
+    <string name="community_set_preferred_language">Nustatyti pageidaujamą kalbą</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-lv/strings.xml
+++ b/core/l10n/src/androidMain/res/values-lv/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Iztīrīšana</string>
     <string name="admin_action_mark_as_featured">Atzīmēt kā piedāvātu (piemērs)</string>
     <string name="admin_action_unmark_as_featured">Noņemt atzīmēto kā piedāvāto (piemērs)</string>
+    <string name="community_set_preferred_language">Iestatīt vēlamo valodu</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-mt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-mt/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Tnaddaf</string>
     <string name="admin_action_mark_as_featured">Immarka bħala dehru (istanza)</string>
     <string name="admin_action_unmark_as_featured">Neħħi l-immarka bħala dehru (istanza)</string>
+    <string name="community_set_preferred_language">Issettja l-lingwa preferuta</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-nl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-nl/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Zuiveren</string>
     <string name="admin_action_mark_as_featured">Markeren als aanbevolen (instantie)</string>
     <string name="admin_action_unmark_as_featured">Markering als aanbevolen opheffen (instantie)</string>
+    <string name="community_set_preferred_language">Voorkeurstaal instellen</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-no/strings.xml
+++ b/core/l10n/src/androidMain/res/values-no/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Rensing</string>
     <string name="admin_action_mark_as_featured">Merk som fremhevet (forekomst)</string>
     <string name="admin_action_unmark_as_featured">Fjern merking som fremhevet (forekomst)</string>
+    <string name="community_set_preferred_language">Sett foretrukket språk</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pl/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Oczyszczać</string>
     <string name="admin_action_mark_as_featured">Oznacz jako polecane (instancja)</string>
     <string name="admin_action_unmark_as_featured">Usuń oznaczenie jako polecane (instancja)</string>
+    <string name="community_set_preferred_language">Ustaw preferowany język</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt-rBR/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Purgar</string>
     <string name="admin_action_mark_as_featured">Marcar como destaque (instância)</string>
     <string name="admin_action_unmark_as_featured">Desmarcar como destaque (instância)</string>
+    <string name="community_set_preferred_language">Definir idioma preferido</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-pt/strings.xml
+++ b/core/l10n/src/androidMain/res/values-pt/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Purgar</string>
     <string name="admin_action_mark_as_featured">Marcar como destaque (instância)</string>
     <string name="admin_action_unmark_as_featured">Desmarcar como destaque (instância)</string>
+    <string name="community_set_preferred_language">Definir idioma preferido</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ro/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ro/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Epurează</string>
     <string name="admin_action_mark_as_featured">Marchează ca recomandat (instanță)</string>
     <string name="admin_action_unmark_as_featured">Anulează marcare ca recomandat (instanță)</string>
+    <string name="community_set_preferred_language">Setează limba preferată</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-ru/strings.xml
+++ b/core/l10n/src/androidMain/res/values-ru/strings.xml
@@ -397,4 +397,5 @@
     <string name="admin_action_purge">Удалять</string>
     <string name="admin_action_mark_as_featured">Отметить как избранное (экземпляр)</string>
     <string name="admin_action_unmark_as_featured">Снять пометку как избранное (экземпляр)</string>
+    <string name="community_set_preferred_language">Установить предпочитаемый язык</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-se/strings.xml
+++ b/core/l10n/src/androidMain/res/values-se/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Rena</string>
     <string name="admin_action_mark_as_featured">Markera som utvald (instans)</string>
     <string name="admin_action_unmark_as_featured">Avmarkera som utvald (instans)</string>
+    <string name="community_set_preferred_language">Ställ in önskat språk</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sk/strings.xml
@@ -398,5 +398,5 @@
     <string name="admin_action_purge">Vyčistiť</string>
     <string name="admin_action_mark_as_featured">Označiť ako odporúčané (inštancia)</string>
     <string name="admin_action_unmark_as_featured">Zrušiť označenie ako odporúčané (inštancia)</string>
-
+    <string name="community_set_preferred_language">Nastavenie preferovaného jazyka</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sl/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sl/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Čiščenje</string>
     <string name="admin_action_mark_as_featured">Označi kot predstavljeno (primer)</string>
     <string name="admin_action_unmark_as_featured">Odznači kot predstavljeno (primer)</string>
+    <string name="community_set_preferred_language">Nastavitev prednostnega jezika</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sq/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sq/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Pastrim</string>
     <string name="admin_action_mark_as_featured">Shëno si të paraqitur (shembull)</string>
     <string name="admin_action_unmark_as_featured">Hiq shënimin si të paraqitur (shembull)</string>
+    <string name="community_set_preferred_language">Cakto gjuhën e preferuar</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-sr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-sr/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Чистка</string>
     <string name="admin_action_mark_as_featured">Означи као истакнуто (инстанца)</string>
     <string name="admin_action_unmark_as_featured">Уклони ознаку као истакнуто (инстанца)</string>
+    <string name="community_set_preferred_language">Подеси преферирани језик</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tok/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tok/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">o weka kin</string>
     <string name="admin_action_mark_as_featured">o sitelen sama sewi (ilo nanpa)</string>
     <string name="admin_action_unmark_as_featured">o sitelen ala sama sewi (ilo nanpa)</string>
+    <string name="community_set_preferred_language">o anu e toki pi wile sina</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-tr/strings.xml
+++ b/core/l10n/src/androidMain/res/values-tr/strings.xml
@@ -398,4 +398,5 @@
     <string name="admin_action_purge">Tasfiye</string>
     <string name="admin_action_mark_as_featured">Öne çıkan olarak işaretle (örnek)</string>
     <string name="admin_action_unmark_as_featured">Öne çıkan işaretini kaldır (örnek)</string>
+    <string name="community_set_preferred_language">Tercih edilen dili ayarla</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values-uk/strings.xml
+++ b/core/l10n/src/androidMain/res/values-uk/strings.xml
@@ -397,4 +397,5 @@
     <string name="admin_action_purge">Чистка</string>
     <string name="admin_action_mark_as_featured">Позначити як рекомендоване (екземпляр)</string>
     <string name="admin_action_unmark_as_featured">Скасувати позначення як рекомендованого (екземпляр)</string>
+    <string name="community_set_preferred_language">Tercih edilen dili ayarla</string>
 </resources>

--- a/core/l10n/src/androidMain/res/values/strings.xml
+++ b/core/l10n/src/androidMain/res/values/strings.xml
@@ -406,4 +406,5 @@
     <string name="admin_action_purge">Purge</string>
     <string name="admin_action_mark_as_featured">Mark as featured (instance)</string>
     <string name="admin_action_unmark_as_featured">Unmark as featured (instance)</string>
+    <string name="community_set_preferred_language">Set preferred language</string>
 </resources>

--- a/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunityPreferredLanguageRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunityPreferredLanguageRepositoryTest.kt
@@ -1,0 +1,108 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository
+
+import com.github.diegoberaldin.raccoonforlemmy.core.preferences.TemporaryKeyStore
+import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class DefaultCommunityPreferredLanguageRepositoryTest {
+    @get:Rule
+    val dispatcherTestRule = DispatcherTestRule()
+
+    private val keyStore = mockk<TemporaryKeyStore>(relaxUnitFun = true)
+
+    private val sut = DefaultCommunityPreferredLanguageRepository(keyStore = keyStore)
+
+    @Test
+    fun givenEmptyInitialState_whenSave_thenValueIsStored() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf()
+
+        sut.save("!raccoonforlemmy@lemmy.world", 1)
+
+        verify {
+            keyStore.save(KEY, listOf("!raccoonforlemmy@lemmy.world:1"))
+        }
+    }
+
+    @Test
+    fun givenCommunityAlreadyExisting_whenSave_thenValueIsStored() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:0")
+
+        sut.save("!raccoonforlemmy@lemmy.world", 1)
+
+        verify {
+            keyStore.save(KEY, listOf("!raccoonforlemmy@lemmy.world:1"))
+        }
+    }
+
+    @Test
+    fun givenCommunityAlreadyExisting_whenSaveNull_thenValueIsRemoved() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:0")
+
+        sut.save("!raccoonforlemmy@lemmy.world", null)
+
+        verify {
+            keyStore.save(KEY, emptyList())
+        }
+    }
+
+    @Test
+    fun givenOtherCommunityAlreadyExisting_whenSave_thenBothValuesAreStored() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!test@lemmy.world:1")
+
+        sut.save("!raccoonforlemmy@lemmy.world", 1)
+
+        verify {
+            keyStore.save(KEY, listOf("!test@lemmy.world:1", "!raccoonforlemmy@lemmy.world:1"))
+        }
+    }
+
+    @Test
+    fun givenOtherCommunityAlreadyExisting_whenSaveNull_thenValueIsRemovedButTheOtherIsNot() =
+        runTest {
+            every { keyStore.get(KEY, listOf()) } returns listOf("!test@lemmy.world:1")
+
+            sut.save("!raccoonforlemmy@lemmy.world", null)
+
+            verify {
+                keyStore.save(KEY, listOf("!test@lemmy.world:1"))
+            }
+        }
+
+    @Test
+    fun givenEmptyInitialState_whenGet_thenResultIsAsExpected() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf()
+
+        val res = sut.get("!raccoonforlemmy@lemmy.world")
+
+        assertNull(res)
+    }
+
+    @Test
+    fun givenCommunityExists_whenGet_thenResultIsAsExpected() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:2")
+
+        val res = sut.get("!raccoonforlemmy@lemmy.world")
+
+        assertEquals(2, res)
+    }
+
+    @Test
+    fun givenCommunityDoesNotExist_whenGet_thenResultIsAsExpected() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!test@lemmy.world:2")
+
+        val res = sut.get("!raccoonforlemmy@lemmy.world")
+
+        assertNull(res)
+    }
+
+    companion object {
+        private const val KEY = "communityPreferredLanguage"
+    }
+}

--- a/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunitySortRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunitySortRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -19,62 +20,66 @@ class DefaultCommunitySortRepositoryTest {
     private val sut = DefaultCommunitySortRepository(keyStore = keyStore)
 
     @Test
-    fun givenEmptyInitialState_whenSaveSort_thenValueIsStored() {
-        every { keyStore.get("communitySort", listOf()) } returns listOf()
+    fun givenEmptyInitialState_whenSave_thenValueIsStored() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf()
 
-        sut.saveSort("!raccoonforlemmy@lemmy.world", 1)
+        sut.save("!raccoonforlemmy@lemmy.world", 1)
 
         verify {
-            keyStore.save("communitySort", listOf("!raccoonforlemmy@lemmy.world:1"))
+            keyStore.save(KEY, listOf("!raccoonforlemmy@lemmy.world:1"))
         }
     }
 
     @Test
-    fun givenCommunityAlreadyExisting_whenSaveSort_thenValueIsStored() {
-        every { keyStore.get("communitySort", listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:0")
+    fun givenCommunityAlreadyExisting_whenSave_thenValueIsStored() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:0")
 
-        sut.saveSort("!raccoonforlemmy@lemmy.world", 1)
+        sut.save("!raccoonforlemmy@lemmy.world", 1)
 
         verify {
-            keyStore.save("communitySort", listOf("!raccoonforlemmy@lemmy.world:1"))
+            keyStore.save(KEY, listOf("!raccoonforlemmy@lemmy.world:1"))
         }
     }
 
     @Test
-    fun givenOtherCommunityAlreadyExisting_whenSaveSort_thenBothValuesAreStored() {
-        every { keyStore.get("communitySort", listOf()) } returns listOf("!test@lemmy.world:1")
+    fun givenOtherCommunityAlreadyExisting_whenSave_thenBothValuesAreStored() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!test@lemmy.world:1")
 
-        sut.saveSort("!raccoonforlemmy@lemmy.world", 1)
+        sut.save("!raccoonforlemmy@lemmy.world", 1)
 
         verify {
-            keyStore.save("communitySort", listOf("!test@lemmy.world:1", "!raccoonforlemmy@lemmy.world:1"))
+            keyStore.save(KEY, listOf("!test@lemmy.world:1", "!raccoonforlemmy@lemmy.world:1"))
         }
     }
 
     @Test
-    fun givenEmptyInitialState_whenGet_thenResultIsAsExpected() {
-        every { keyStore.get("communitySort", listOf()) } returns listOf()
+    fun givenEmptyInitialState_whenGet_thenResultIsAsExpected() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf()
 
-        val res = sut.getSort("!raccoonforlemmy@lemmy.world")
+        val res = sut.get("!raccoonforlemmy@lemmy.world")
 
         assertNull(res)
     }
 
     @Test
-    fun givenCommunityExists_whenGet_thenResultIsAsExpected() {
-        every { keyStore.get("communitySort", listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:2")
+    fun givenCommunityExists_whenGet_thenResultIsAsExpected() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!raccoonforlemmy@lemmy.world:2")
 
-        val res = sut.getSort("!raccoonforlemmy@lemmy.world")
+        val res = sut.get("!raccoonforlemmy@lemmy.world")
 
         assertEquals(2, res)
     }
 
     @Test
-    fun givenCommunityDoesNotExist_whenGet_thenResultIsAsExpected() {
-        every { keyStore.get("communitySort", listOf()) } returns listOf("!test@lemmy.world:2")
+    fun givenCommunityDoesNotExist_whenGet_thenResultIsAsExpected() = runTest {
+        every { keyStore.get(KEY, listOf()) } returns listOf("!test@lemmy.world:2")
 
-        val res = sut.getSort("!raccoonforlemmy@lemmy.world")
+        val res = sut.get("!raccoonforlemmy@lemmy.world")
 
         assertNull(res)
+    }
+
+    companion object {
+        private const val KEY = "communitySort"
     }
 }

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/di/CorePersistenceModule.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/di/CorePersistenceModule.kt
@@ -3,8 +3,10 @@ package com.github.diegoberaldin.raccoonforlemmy.core.persistence.di
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.DatabaseProvider
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.DefaultDatabaseProvider
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.DefaultAccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.DefaultCommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.DefaultCommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.DefaultDraftRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.DefaultFavoriteCommunityRepository
@@ -63,6 +65,11 @@ val corePersistenceModule =
         }
         single<CommunitySortRepository> {
             DefaultCommunitySortRepository(
+                keyStore = get(),
+            )
+        }
+        single<CommunityPreferredLanguageRepository> {
+            DefaultCommunityPreferredLanguageRepository(
                 keyStore = get(),
             )
         }

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/CommunityPreferredLanguageRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/CommunityPreferredLanguageRepository.kt
@@ -1,0 +1,12 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository
+
+interface CommunityPreferredLanguageRepository {
+    suspend fun get(handle: String): Long?
+
+    suspend fun save(
+        handle: String,
+        value: Long?,
+    )
+
+    suspend fun clear()
+}

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/CommunitySortRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/CommunitySortRepository.kt
@@ -1,12 +1,12 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository
 
 interface CommunitySortRepository {
-    fun getSort(handle: String): Int?
+    suspend fun get(handle: String): Int?
 
-    fun saveSort(
+    suspend fun save(
         handle: String,
         value: Int,
     )
 
-    fun clear()
+    suspend fun clear()
 }

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunityPreferredLanguageRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunityPreferredLanguageRepository.kt
@@ -1,0 +1,52 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository
+
+import com.github.diegoberaldin.raccoonforlemmy.core.preferences.TemporaryKeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+private const val SETTINGS_KEY = "communityPreferredLanguage"
+
+internal class DefaultCommunityPreferredLanguageRepository(
+    private val keyStore: TemporaryKeyStore,
+) : CommunityPreferredLanguageRepository {
+
+    override suspend fun get(handle: String): Long? = withContext(Dispatchers.IO) {
+        val map = deserializeMap()
+        map[handle]
+    }
+
+    override suspend fun save(
+        handle: String,
+        value: Long?,
+    ) = withContext(Dispatchers.IO) {
+        val map = deserializeMap()
+        if (value != null) {
+            map[handle] = value
+        } else {
+            map.remove(handle)
+        }
+        val newValue = serializeMap(map)
+        keyStore.save(SETTINGS_KEY, newValue)
+    }
+
+    private fun deserializeMap(): MutableMap<String, Long> =
+        keyStore.get(SETTINGS_KEY, listOf()).mapNotNull {
+            it.split(":").takeIf { e -> e.size == 2 }?.let { e -> e[0] to e[1] }
+        }.let { pairs ->
+            val res = mutableMapOf<String, Long>()
+            for (pair in pairs) {
+                res[pair.first] = pair.second.toLong()
+            }
+            res
+        }
+
+    private fun serializeMap(map: Map<String, Long>): List<String> =
+        map.map { e ->
+            e.key + ":" + e.value
+        }
+
+    override suspend fun clear() = withContext(Dispatchers.IO) {
+        keyStore.remove(SETTINGS_KEY)
+    }
+}

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunitySortRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultCommunitySortRepository.kt
@@ -1,21 +1,24 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository
 
 import com.github.diegoberaldin.raccoonforlemmy.core.preferences.TemporaryKeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
 private const val SETTINGS_KEY = "communitySort"
 
 internal class DefaultCommunitySortRepository(
     private val keyStore: TemporaryKeyStore,
 ) : CommunitySortRepository {
-    override fun getSort(handle: String): Int? {
+    override suspend fun get(handle: String): Int? = withContext(Dispatchers.IO) {
         val map = deserializeMap()
-        return map[handle]
+        map[handle]
     }
 
-    override fun saveSort(
+    override suspend fun save(
         handle: String,
         value: Int,
-    ) {
+    ) = withContext(Dispatchers.IO) {
         val map = deserializeMap()
         map[handle] = value
         val newValue = serializeMap(map)
@@ -38,7 +41,7 @@ internal class DefaultCommunitySortRepository(
             e.key + ":" + e.value
         }
 
-    override fun clear() {
+    override suspend fun clear() = withContext(Dispatchers.IO) {
         keyStore.remove(SETTINGS_KEY)
     }
 }

--- a/domain/identity/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLoginUseCaseTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLoginUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.LoginResponse
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.AccountModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.SettingsModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
@@ -36,6 +37,8 @@ class DefaultLoginUseCaseTest {
     private val settingsRepository = mockk<SettingsRepository>(relaxUnitFun = true)
     private val siteRepository = mockk<SiteRepository>(relaxUnitFun = true)
     private val communitySortRepository = mockk<CommunitySortRepository>(relaxUnitFun = true)
+    private val communityPreferredLanguageRepository =
+        mockk<CommunityPreferredLanguageRepository>(relaxUnitFun = true)
     private val sut =
         DefaultLoginUseCase(
             authRepository = authRepository,
@@ -45,6 +48,7 @@ class DefaultLoginUseCaseTest {
             settingsRepository = settingsRepository,
             siteRepository = siteRepository,
             communitySortRepository = communitySortRepository,
+            communityPreferredLanguageRepository = communityPreferredLanguageRepository,
         )
 
     @Test
@@ -184,6 +188,7 @@ class DefaultLoginUseCaseTest {
                 accountRepository.setActive(accountId, true)
                 settingsRepository.changeCurrentSettings(oldSettings)
                 communitySortRepository.clear()
+                communityPreferredLanguageRepository.clear()
             }
             coVerify(inverse = true) {
                 accountRepository.createAccount(any())

--- a/domain/identity/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationC
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.AccountModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.SettingsModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
@@ -27,6 +28,8 @@ class DefaultSwitchAccountUseCaseTest {
     private val serviceProvider = mockk<ServiceProvider>(relaxUnitFun = true)
     private val notificationCenter = mockk<NotificationCenter>(relaxUnitFun = true)
     private val communitySortRepository = mockk<CommunitySortRepository>(relaxUnitFun = true)
+    private val communityPreferredLanguageRepository =
+        mockk<CommunityPreferredLanguageRepository>(relaxUnitFun = true)
     private val sut =
         DefaultSwitchAccountUseCase(
             identityRepository = identityRepository,
@@ -35,6 +38,7 @@ class DefaultSwitchAccountUseCaseTest {
             serviceProvider = serviceProvider,
             notificationCenter = notificationCenter,
             communitySortRepository = communitySortRepository,
+            communityPreferredLanguageRepository = communityPreferredLanguageRepository,
         )
 
     @Test
@@ -79,6 +83,7 @@ class DefaultSwitchAccountUseCaseTest {
                 settingsRepository.getSettings(accountId)
                 settingsRepository.changeCurrentSettings(newSettings)
                 communitySortRepository.clear()
+                communityPreferredLanguageRepository.clear()
                 notificationCenter.send(ofType(NotificationCenterEvent.Logout::class))
                 identityRepository.storeToken("new-token")
                 identityRepository.refreshLoggedState()

--- a/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/di/IdentityModule.kt
+++ b/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/di/IdentityModule.kt
@@ -47,6 +47,7 @@ val coreIdentityModule =
                 settingsRepository = get(),
                 siteRepository = get(),
                 communitySortRepository = get(),
+                communityPreferredLanguageRepository = get(),
             )
         }
         single<LogoutUseCase> {
@@ -66,6 +67,7 @@ val coreIdentityModule =
                 serviceProvider = get(named("default")),
                 notificationCenter = get(),
                 communitySortRepository = get(),
+                communityPreferredLanguageRepository = get(),
             )
         }
         single<DeleteAccountUseCase> {

--- a/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLoginUseCase.kt
+++ b/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLoginUseCase.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.domain.identity.usecase
 
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.AccountModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.debug.logDebug
@@ -18,6 +19,7 @@ internal class DefaultLoginUseCase(
     private val settingsRepository: SettingsRepository,
     private val siteRepository: SiteRepository,
     private val communitySortRepository: CommunitySortRepository,
+    private val communityPreferredLanguageRepository: CommunityPreferredLanguageRepository,
 ) : LoginUseCase {
     override suspend operator fun invoke(
         instance: String,
@@ -78,6 +80,7 @@ internal class DefaultLoginUseCase(
             accountRepository.setActive(id, true)
 
             communitySortRepository.clear()
+            communityPreferredLanguageRepository.clear()
 
             val newSettings = settingsRepository.getSettings(id)
             settingsRepository.changeCurrentSettings(newSettings)

--- a/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
+++ b/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
@@ -5,6 +5,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationC
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.AccountModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
@@ -16,6 +17,7 @@ internal class DefaultSwitchAccountUseCase(
     private val notificationCenter: NotificationCenter,
     private val settingsRepository: SettingsRepository,
     private val communitySortRepository: CommunitySortRepository,
+    private val communityPreferredLanguageRepository: CommunityPreferredLanguageRepository,
 ) : SwitchAccountUseCase {
     override suspend fun invoke(account: AccountModel) {
         val accountId = account.id ?: return
@@ -29,6 +31,7 @@ internal class DefaultSwitchAccountUseCase(
         notificationCenter.send(NotificationCenterEvent.Logout)
 
         communitySortRepository.clear()
+        communityPreferredLanguageRepository.clear()
 
         serviceProvider.changeInstance(instance)
 

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
@@ -7,6 +7,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.LanguageModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
@@ -69,6 +70,8 @@ interface CommunityDetailMviModel :
         data object WillOpenDetail : Intent
 
         data object UnhideCommunity : Intent
+
+        data class SelectPreferredLanguage(val languageId: Long?) : Intent
     }
 
     data class UiState(
@@ -104,6 +107,8 @@ interface CommunityDetailMviModel :
         val fadeReadPosts: Boolean = false,
         val showUnreadComments: Boolean = false,
         val downVoteEnabled: Boolean = true,
+        val currentPreferredLanguageId: Long? = null,
+        val availableLanguages: List<LanguageModel> = emptyList(),
     )
 
     sealed interface Effect {

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -132,7 +132,6 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.unit.ban.BanUserScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.communityinfo.CommunityInfoScreen
-import com.github.diegoberaldin.raccoonforlemmy.unit.createcomment.CreateCommentMviModel
 import com.github.diegoberaldin.raccoonforlemmy.unit.editcommunity.EditCommunityScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.explore.ExploreScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.instanceinfo.InstanceInfoScreen
@@ -1490,6 +1489,7 @@ class CommunityDetailScreen(
                                 if (quotation != null) {
                                     detailOpener.openReply(
                                         originalComment = content,
+                                        originalPost = PostModel(id = content.postId),
                                         initialText =
                                             buildString {
                                                 append("> ")

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -109,6 +109,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.PostCard
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.PostCardPlaceholder
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.di.getFabNestedScrollConnection
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.CopyPostBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectLanguageDialog
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.ShareBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SortBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.LocalXmlStrings
@@ -131,6 +132,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.unit.ban.BanUserScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.communityinfo.CommunityInfoScreen
+import com.github.diegoberaldin.raccoonforlemmy.unit.createcomment.CreateCommentMviModel
 import com.github.diegoberaldin.raccoonforlemmy.unit.editcommunity.EditCommunityScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.explore.ExploreScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.instanceinfo.InstanceInfoScreen
@@ -209,6 +211,7 @@ class CommunityDetailScreen(
             with(LocalDensity.current) {
                 WindowInsets.statusBars.getTop(this)
             }
+        var selectLanguageDialogOpen by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
             model.effects.onEach { effect ->
@@ -368,6 +371,12 @@ class CommunityDetailScreen(
                                             OptionId.SetCustomSort,
                                             LocalXmlStrings.current.communitySetCustomSort,
                                         )
+                                    if (uiState.isLogged) {
+                                        this += Option(
+                                            OptionId.SetPreferredLanguage,
+                                            LocalXmlStrings.current.communitySetPreferredLanguage,
+                                        )
+                                    }
                                     this +=
                                         Option(
                                             OptionId.InfoInstance,
@@ -598,6 +607,10 @@ class CommunityDetailScreen(
                                                             contentId = uiState.community.id,
                                                         )
                                                     navigationCoordinator.pushScreen(screen)
+                                                }
+
+                                                OptionId.SetPreferredLanguage -> {
+                                                    selectLanguageDialogOpen = true
                                                 }
 
                                                 else -> Unit
@@ -1517,6 +1530,22 @@ class CommunityDetailScreen(
                 },
                 text = {
                     Text(text = LocalXmlStrings.current.messageAreYouSure)
+                },
+            )
+        }
+
+        if (selectLanguageDialogOpen) {
+            SelectLanguageDialog(
+                languages = uiState.availableLanguages,
+                currentLanguageId = uiState.currentPreferredLanguageId,
+                onSelect =
+                rememberCallbackArgs { langId ->
+                    model.reduce(CommunityDetailMviModel.Intent.SelectPreferredLanguage(langId))
+                    selectLanguageDialogOpen = false
+                },
+                onDismiss =
+                rememberCallback {
+                    selectLanguageDialogOpen = false
                 },
             )
         }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationC
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.FavoriteCommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunitySortRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.FavoriteCommunityRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
@@ -64,6 +65,7 @@ class CommunityDetailViewModel(
     private val itemCache: LemmyItemCache,
     private val communitySortRepository: CommunitySortRepository,
     private val postNavigationManager: PostNavigationManager,
+    private val communityPreferredLanguageRepository: CommunityPreferredLanguageRepository,
 ) : CommunityDetailMviModel,
     DefaultMviModel<CommunityDetailMviModel.Intent, CommunityDetailMviModel.UiState, CommunityDetailMviModel.Effect>(
         initialState = CommunityDetailMviModel.UiState(),
@@ -79,8 +81,8 @@ class CommunityDetailViewModel(
                     it.copy(
                         community = community,
                         instance =
-                            otherInstance.takeIf { n -> n.isNotEmpty() }
-                                ?: apiConfigurationRepository.instance.value,
+                        otherInstance.takeIf { n -> n.isNotEmpty() }
+                            ?: apiConfigurationRepository.instance.value,
                     )
                 }
             }
@@ -132,16 +134,16 @@ class CommunityDetailViewModel(
                     updateState {
                         it.copy(
                             posts =
-                                it.posts.map { p ->
-                                    if (p.id == postId) {
-                                        p.copy(
-                                            creator = newUser,
-                                            updateDate = newUser.updateDate,
-                                        )
-                                    } else {
-                                        p
-                                    }
-                                },
+                            it.posts.map { p ->
+                                if (p.id == postId) {
+                                    p.copy(
+                                        creator = newUser,
+                                        updateDate = newUser.updateDate,
+                                    )
+                                } else {
+                                    p
+                                }
+                            },
                         )
                     }
                 }.launchIn(this)
@@ -153,12 +155,12 @@ class CommunityDetailViewModel(
                         handlePostUpdate(newPost)
                     }
                 }.launchIn(this)
+            val communityHandle = uiState.value.community.readableHandle
             notificationCenter.subscribe(NotificationCenterEvent.ChangeSortType::class)
                 .onEach { evt ->
-                    if (evt.screenKey == uiState.value.community.readableHandle) {
+                    if (evt.screenKey == communityHandle) {
                         if (evt.defaultForCommunity) {
-                            val handle = uiState.value.community.readableHandle
-                            communitySortRepository.save(handle, evt.value.toInt())
+                            communitySortRepository.save(communityHandle, evt.value.toInt())
                         }
                         applySortType(evt.value)
                     }
@@ -189,10 +191,20 @@ class CommunityDetailViewModel(
                 }
             }
             if (uiState.value.initial) {
-                val defaultPostSortType = settingsRepository.currentSettings.value.defaultPostSortType.toSortType()
+                val defaultPostSortType =
+                    settingsRepository.currentSettings.value.defaultPostSortType.toSortType()
                 val customPostSortType =
-                    communitySortRepository.get(uiState.value.community.readableHandle)?.toSortType()
-                updateState { it.copy(sortType = customPostSortType ?: defaultPostSortType) }
+                    communitySortRepository.get(communityHandle)?.toSortType()
+                val preferredLanguageId = communityPreferredLanguageRepository.get(communityHandle)
+                val auth = identityRepository.authToken.value.orEmpty()
+                val languages = siteRepository.getLanguages(auth)
+                updateState {
+                    it.copy(
+                        sortType = customPostSortType ?: defaultPostSortType,
+                        currentPreferredLanguageId = preferredLanguageId,
+                        availableLanguages = languages,
+                    )
+                }
                 refresh(initial = true)
             }
         }
@@ -330,6 +342,10 @@ class CommunityDetailViewModel(
             CommunityDetailMviModel.Intent.UnhideCommunity -> {
                 unhideCommunity()
             }
+
+            is CommunityDetailMviModel.Intent.SelectPreferredLanguage -> {
+                updatePreferredLanguage(intent.languageId)
+            }
         }
     }
 
@@ -356,7 +372,8 @@ class CommunityDetailViewModel(
         }
         val auth = identityRepository.authToken.value
         val accountId = accountRepository.getActive()?.id
-        val isFavorite = favoriteCommunityRepository.getBy(accountId, currentState.community.id) != null
+        val isFavorite =
+            favoriteCommunityRepository.getBy(accountId, currentState.community.id) != null
         val refreshedCommunity =
             communityRepository.get(
                 auth = auth,
@@ -553,7 +570,11 @@ class CommunityDetailViewModel(
                 )
             if (community != null) {
                 updateState { it.copy(community = community) }
-                notificationCenter.send(NotificationCenterEvent.CommunitySubscriptionChanged(community))
+                notificationCenter.send(
+                    NotificationCenterEvent.CommunitySubscriptionChanged(
+                        community
+                    )
+                )
             }
         }
     }
@@ -568,7 +589,11 @@ class CommunityDetailViewModel(
                 )
             if (community != null) {
                 updateState { it.copy(community = community) }
-                notificationCenter.send(NotificationCenterEvent.CommunitySubscriptionChanged(community))
+                notificationCenter.send(
+                    NotificationCenterEvent.CommunitySubscriptionChanged(
+                        community
+                    )
+                )
             }
         }
     }
@@ -578,13 +603,13 @@ class CommunityDetailViewModel(
             updateState {
                 it.copy(
                     posts =
-                        it.posts.map { p ->
-                            if (p.id == post.id) {
-                                post
-                            } else {
-                                p
-                            }
-                        },
+                    it.posts.map { p ->
+                        if (p.id == post.id) {
+                            post
+                        } else {
+                            p
+                        }
+                    },
                 )
             }
         }
@@ -756,6 +781,16 @@ class CommunityDetailViewModel(
             } catch (e: Throwable) {
                 val message = e.message
                 emitEffect(CommunityDetailMviModel.Effect.Failure(message))
+            }
+        }
+    }
+
+    private fun updatePreferredLanguage(languageId: Long?) {
+        screenModelScope.launch {
+            val communityHandle = uiState.value.community.readableHandle
+            communityPreferredLanguageRepository.save(handle = communityHandle, value = languageId)
+            updateState {
+                it.copy(currentPreferredLanguageId = languageId)
             }
         }
     }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -158,7 +158,7 @@ class CommunityDetailViewModel(
                     if (evt.screenKey == uiState.value.community.readableHandle) {
                         if (evt.defaultForCommunity) {
                             val handle = uiState.value.community.readableHandle
-                            communitySortRepository.saveSort(handle, evt.value.toInt())
+                            communitySortRepository.save(handle, evt.value.toInt())
                         }
                         applySortType(evt.value)
                     }
@@ -191,7 +191,7 @@ class CommunityDetailViewModel(
             if (uiState.value.initial) {
                 val defaultPostSortType = settingsRepository.currentSettings.value.defaultPostSortType.toSortType()
                 val customPostSortType =
-                    communitySortRepository.getSort(uiState.value.community.readableHandle)?.toSortType()
+                    communitySortRepository.get(uiState.value.community.readableHandle)?.toSortType()
                 updateState { it.copy(sortType = customPostSortType ?: defaultPostSortType) }
                 refresh(initial = true)
             }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/di/CommunityDetailModule.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/di/CommunityDetailModule.kt
@@ -29,6 +29,7 @@ val communityDetailModule =
                 communitySortRepository = get(),
                 postPaginationManager = get(),
                 postNavigationManager = get(),
+                communityPreferredLanguageRepository = get(),
             )
         }
     }

--- a/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentViewModel.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/CreateCommentViewModel.kt
@@ -8,11 +8,13 @@ import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationC
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.DraftModel
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.DraftType
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.CommunityPreferredLanguageRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.DraftRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.ValidationError
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.datetime.epochMillis
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.LemmyItemCache
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.PostRepository
@@ -36,6 +38,7 @@ class CreateCommentViewModel(
     private val itemCache: LemmyItemCache,
     private val accountRepository: AccountRepository,
     private val draftRepository: DraftRepository,
+    private val communityPreferredLanguageRepository: CommunityPreferredLanguageRepository,
 ) : CreateCommentMviModel,
     DefaultMviModel<CreateCommentMviModel.Intent, CreateCommentMviModel.UiState, CreateCommentMviModel.Effect>(
         initialState = CreateCommentMviModel.UiState(),
@@ -61,6 +64,8 @@ class CreateCommentViewModel(
                 } else {
                     originalCommentFromCache
                 }
+            val communityHandle = originalPost?.community?.readableHandle.orEmpty()
+            val preferredLanguageId = communityPreferredLanguageRepository.get(communityHandle)
             updateState {
                 it.copy(
                     originalPost = originalPost,
@@ -97,7 +102,7 @@ class CreateCommentViewModel(
                         fullHeightImages = settings.fullHeightImages,
                         fullWidthImages = settings.fullWidthImages,
                         showScores = settings.showScores,
-                        currentLanguageId = settings.defaultLanguageId,
+                        currentLanguageId = preferredLanguageId ?: settings.defaultLanguageId,
                     )
                 }
             }.launchIn(this)

--- a/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/di/CreateCommentModule.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createcomment/di/CreateCommentModule.kt
@@ -22,6 +22,7 @@ val createCommentModule =
                 itemCache = get(),
                 accountRepository = get(),
                 draftRepository = get(),
+                communityPreferredLanguageRepository = get(),
             )
         }
     }

--- a/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/di/CreatePostModule.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/di/CreatePostModule.kt
@@ -21,6 +21,7 @@ val createPostModule =
                 accountRepository = get(),
                 draftRepository = get(),
                 notificationCenter = get(),
+                communityPreferredLanguageRepository = get(),
             )
         }
     }

--- a/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -269,10 +269,9 @@ class DraftsScreen : Screen {
                                         rememberCallback {
                                             detailOpener.openReply(
                                                 draftId = draft.id,
-                                                originalPost =
-                                                    draft.postId?.let {
-                                                        PostModel(id = it)
-                                                    },
+                                                originalPost = PostModel(
+                                                    id = draft.postId ?: 0
+                                                ),
                                                 originalComment =
                                                     draft.parentId?.let {
                                                         CommentModel(id = it, text = "")

--- a/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -413,7 +413,9 @@ class ExploreScreen(
                                                                 ?: defaultReplyColor,
                                                         onTriggered =
                                                             rememberCallback {
-                                                                detailOpener.openReply(originalPost = result.model)
+                                                                detailOpener.openReply(
+                                                                    originalPost = result.model,
+                                                                )
                                                             },
                                                     )
 

--- a/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -744,7 +744,10 @@ class FilteredContentsScreen(
                                                     backgroundColor = replyColor ?: defaultReplyColor,
                                                     onTriggered =
                                                         rememberCallback {
-                                                            detailOpener.openReply(originalComment = comment)
+                                                            detailOpener.openReply(
+                                                                originalPost = PostModel(comment.postId),
+                                                                originalComment = comment,
+                                                            )
                                                         },
                                                 )
 
@@ -822,7 +825,10 @@ class FilteredContentsScreen(
                                                 },
                                             onReply =
                                                 rememberCallback {
-                                                    detailOpener.openReply(originalComment = comment)
+                                                    detailOpener.openReply(
+                                                        originalPost = PostModel(id = comment.postId),
+                                                        originalComment = comment,
+                                                    )
                                                 },
                                             options =
                                                 buildList {
@@ -1028,6 +1034,7 @@ class FilteredContentsScreen(
                                     rawContent = null
                                     if (quotation != null) {
                                         detailOpener.openReply(
+                                            originalPost = PostModel(id = content.postId),
                                             originalComment = content,
                                             initialText =
                                                 buildString {

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -501,6 +501,7 @@ object ProfileLoggedScreen : Tab {
 
                                                 OptionId.Edit -> {
                                                     detailOpener.openReply(
+                                                        originalPost = PostModel(id = comment.postId),
                                                         editedComment = comment,
                                                     )
                                                 }
@@ -635,6 +636,7 @@ object ProfileLoggedScreen : Tab {
                                 rawContent = null
                                 if (quotation != null) {
                                     detailOpener.openReply(
+                                        originalPost = PostModel(id = content.postId),
                                         originalComment = content,
                                         initialText =
                                             buildString {

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -1343,6 +1343,7 @@ class PostDetailScreen(
 
                                                                 OptionId.Edit -> {
                                                                     detailOpener.openReply(
+                                                                        originalPost = PostModel(id = comment.postId),
                                                                         editedComment = comment,
                                                                     )
                                                                 }
@@ -1583,6 +1584,7 @@ class PostDetailScreen(
 
                                                         OptionId.Edit -> {
                                                             detailOpener.openReply(
+                                                                originalPost = PostModel(id = comment.postId),
                                                                 editedComment = comment,
                                                             )
                                                         }

--- a/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -1277,6 +1277,7 @@ class UserDetailScreen(
                                 rawContent = null
                                 if (quotation != null) {
                                     detailOpener.openReply(
+                                        originalPost = PostModel(id = content.id),
                                         originalComment = content,
                                         initialText =
                                             buildString {


### PR DESCRIPTION
This PR adds the possibility to set a preferred language to use for posts and comments within a specific community.
 The caching logic is similar to what has been implemented for custom sort types and is reset upon logout.