### PR TITLE
fix: pagination in subscription list

### DIFF
--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepositoryTest.kt
@@ -193,34 +193,49 @@ class DefaultCommunityRepositoryTest {
     fun givenSuccess_whenGetSubscribed_thenResultIsAsExpected() =
         runTest {
             coEvery {
-                siteService.get(
+                searchService.search(
                     authHeader = any(),
                     auth = any(),
+                    q = any(),
+                    communityId = any(),
+                    communityName = any(),
+                    creatorId = any(),
+                    type = any(),
+                    sort = any(),
+                    listingType = any(),
+                    page = any(),
+                    limit = any(),
                 )
             } returns
                 mockk {
-                    every { myUser } returns
-                        mockk {
-                            every { follows } returns
-                                listOf(
-                                    mockk {
-                                        every { community } returns mockk(relaxed = true)
-                                    },
-                                )
-                        }
+                    every { communities } returns listOf(
+                        mockk(relaxed = true) {
+                            every { community } returns mockk(relaxed = true)
+                        },
+                    )
                 }
 
             val token = "fake-token"
             val res =
                 sut.getSubscribed(
                     auth = token,
+                    page = 1,
                 )
 
             assertEquals(1, res.size)
             coVerify {
-                siteService.get(
-                    auth = token,
+                searchService.search(
                     authHeader = token.toAuthHeader(),
+                    auth = token,
+                    q = "",
+                    communityId = null,
+                    communityName = null,
+                    creatorId = null,
+                    type = SearchType.Communities,
+                    sort = null,
+                    listingType = ListingType.Subscribed.toDto(),
+                    page = 1,
+                    limit = 20,
                 )
             }
         }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
@@ -36,7 +36,12 @@ interface CommunityRepository {
         auth: String? = null,
     ): CommunityModel?
 
-    suspend fun getSubscribed(auth: String? = null): List<CommunityModel>
+    suspend fun getSubscribed(
+        auth: String? = null,
+        page: Int,
+        limit: Int = DEFAULT_PAGE_SIZE,
+        query: String = "",
+    ): List<CommunityModel>
 
     suspend fun get(
         auth: String? = null,

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepository.kt
@@ -117,15 +117,25 @@ internal class DefaultCommunityRepository(
             }.getOrNull()
         }
 
-    override suspend fun getSubscribed(auth: String?): List<CommunityModel> =
+    override suspend fun getSubscribed(
+        auth: String?,
+        page: Int,
+        limit: Int,
+        query: String,
+    ): List<CommunityModel> =
         withContext(Dispatchers.IO) {
             runCatching {
                 val response =
-                    services.site.get(
+                    services.search.search(
                         authHeader = auth.toAuthHeader(),
+                        q = query,
                         auth = auth,
+                        page = page,
+                        limit = limit,
+                        type = SearchResultType.Communities.toDto(),
+                        listingType = ListingType.Subscribed.toDto(),
                     )
-                response.myUser?.follows?.map { it.community.toModel() }.orEmpty()
+                response.communities.map { it.toModel() }
             }.getOrElse { emptyList() }
         }
 

--- a/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
+++ b/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
@@ -15,6 +16,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -39,6 +41,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
@@ -273,6 +276,23 @@ object ModalDrawerContent : Tab {
                                     }
                                 },
                             )
+                        }
+
+                        item {
+                            if (!uiState.loading && !uiState.refreshing && uiState.canFetchMore) {
+                                model.reduce(ModalDrawerMviModel.Intent.LoadNextPage)
+                            }
+                            if (uiState.loading && !uiState.refreshing) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(Spacing.xs),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(25.dp),
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            }
                         }
                     }
                     PullRefreshIndicator(

--- a/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerMviModel.kt
+++ b/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerMviModel.kt
@@ -15,9 +15,12 @@ interface ModalDrawerMviModel :
         data object Refresh : Intent
 
         data class SetSearch(val value: String) : Intent
+        data object LoadNextPage : Intent
     }
 
     data class UiState(
+        val loading: Boolean = false,
+        val canFetchMore: Boolean = true,
         val user: UserModel? = null,
         val autoLoadImages: Boolean = true,
         val preferNicknames: Boolean = true,

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsMviModel.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsMviModel.kt
@@ -22,6 +22,8 @@ interface ManageSubscriptionsMviModel :
         data class ToggleFavorite(val id: Long) : Intent
 
         data class SetSearch(val value: String) : Intent
+
+        data object LoadNextPage : Intent
     }
 
     data class UiState(
@@ -32,6 +34,8 @@ interface ManageSubscriptionsMviModel :
         val autoLoadImages: Boolean = true,
         val preferNicknames: Boolean = true,
         val searchText: String = "",
+        val canFetchMore: Boolean = true,
+        val loading: Boolean = false,
     )
 
     sealed interface Effect {

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -29,6 +30,7 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +62,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
@@ -429,6 +432,23 @@ class ManageSubscriptionsScreen : Screen {
                                     style = MaterialTheme.typography.bodyLarge,
                                     color = MaterialTheme.colorScheme.onBackground,
                                 )
+                            }
+                        }
+
+                        item {
+                            if (!uiState.loading && !uiState.refreshing && uiState.canFetchMore) {
+                                model.reduce(ManageSubscriptionsMviModel.Intent.LoadNextPage)
+                            }
+                            if (uiState.loading && !uiState.refreshing) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(Spacing.xs),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(25.dp),
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
                             }
                         }
                     }

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorMviModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorMviModel.kt
@@ -17,6 +17,8 @@ interface MultiCommunityEditorMviModel :
 
         data class ToggleCommunity(val id: Long) : Intent
 
+        data object LoadNextPage : Intent
+
         data object Submit : Intent
     }
 
@@ -27,8 +29,12 @@ interface MultiCommunityEditorMviModel :
         val nameError: ValidationError? = null,
         val icon: String? = null,
         val availableIcons: List<String> = emptyList(),
-        val communities: List<Pair<CommunityModel, Boolean>> = emptyList(),
+        val communities: List<CommunityModel> = emptyList(),
+        val selectedCommunityIds: List<Long> = emptyList(),
         val searchText: String = "",
+        val refreshing: Boolean = false,
+        val loading: Boolean = false,
+        val canFetchMore: Boolean = true,
     )
 
     sealed interface Effect {

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -348,9 +349,8 @@ class MultiCommunityEditorScreen(
                         .weight(1f),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
                 ) {
-                    items(uiState.communities) { communityItem ->
-                        val community = communityItem.first
-                        val selected = communityItem.second
+                    items(uiState.communities) { community ->
+                        val selected = uiState.selectedCommunityIds.contains(community.id)
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
@@ -373,6 +373,23 @@ class MultiCommunityEditorScreen(
                                     )
                                 },
                             )
+                        }
+                    }
+
+                    item {
+                        if (!uiState.loading && uiState.canFetchMore) {
+                            model.reduce(MultiCommunityEditorMviModel.Intent.LoadNextPage)
+                        }
+                        if (uiState.loading) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(Spacing.xs),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(25.dp),
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
                         }
                     }
                 }

--- a/unit/selectcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/selectcommunity/SelectCommunityDialog.kt
+++ b/unit/selectcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/selectcommunity/SelectCommunityDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
@@ -18,6 +19,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -149,6 +151,23 @@ class SelectCommunityDialog : Screen {
                                 preferNicknames = uiState.preferNicknames,
                                 community = community,
                             )
+                        }
+
+                        item {
+                            if (!uiState.initial && !uiState.loading && uiState.canFetchMore) {
+                                model.reduce(SelectCommunityMviModel.Intent.LoadNextPage)
+                            }
+                            if (!uiState.initial && uiState.loading) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(Spacing.xs),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(25.dp),
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/unit/selectcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/selectcommunity/SelectCommunityMviModel.kt
+++ b/unit/selectcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/selectcommunity/SelectCommunityMviModel.kt
@@ -9,6 +9,8 @@ interface SelectCommunityMviModel :
     ScreenModel {
     sealed interface Intent {
         data class SetSearch(val value: String) : Intent
+
+        data object LoadNextPage : Intent
     }
 
     data class UiState(
@@ -17,6 +19,9 @@ interface SelectCommunityMviModel :
         val searchText: String = "",
         val autoLoadImages: Boolean = true,
         val preferNicknames: Boolean = true,
+        val loading: Boolean = false,
+        val refreshing: Boolean = false,
+        val canFetchMore: Boolean = true,
     )
 
     sealed interface Effect


### PR DESCRIPTION
As observed [on Lemmy](https://lemmy.world/comment/10249351) when a user is subscribed to a lot of communities the side menu, as well as the manage subscription list or the post creation screen, won't load because the results are taken from the GET `/site` call which does not allow pagination for the contents of `myUser.follows`.

The idea to solve this issue is to load the subscription list one page at a time, as normally done for post, comments and search results. This will also improve the search because, until now, filtering on subscriptions was done client-side (sadly, but again because the `/site` endpoint was not intended to be used like that at all).

Moreover, the multi-community editor had been jotted down quite in a rush in October 2023, I found a lot of quite ugly logic I should be ashamed for ,and took the opportunity to clean it up (e.g. no more storing results in a member variable in order to filter and at the same time retaining the selected items).

![](https://media.tenor.com/mweqSDA_s_gAAAAe/game-of-thrones-got.png)