### PR TITLE
fix: flaky tests due to concurrency issues

### DIFF
--- a/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
+++ b/core/commonui/detailopener-impl/src/androidUnitTest/kotlin/DefaultDetailOpenerTest.kt
@@ -51,6 +51,7 @@ class DefaultDetailOpenerTest {
             itemCache = lemmyItemCache,
             identityRepository = identityRepository,
             communityRepository = communityRepository,
+            dispatcher = dispatcherRule.dispatcher,
         )
 
     @Test

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -16,6 +16,7 @@ import com.github.diegoberaldin.raccoonforlemmy.unit.createcomment.CreateComment
 import com.github.diegoberaldin.raccoonforlemmy.unit.createpost.CreatePostScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.postdetail.PostDetailScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.userdetail.UserDetailScreen
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -30,8 +31,9 @@ class DefaultDetailOpener(
     private val itemCache: LemmyItemCache,
     private val identityRepository: IdentityRepository,
     private val communityRepository: CommunityRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : DetailOpener {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     override fun openCommunityDetail(
         community: CommunityModel,

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/FabNestedScrollConnection.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/FabNestedScrollConnection.kt
@@ -18,9 +18,11 @@ interface FabNestedScrollConnection : NestedScrollConnection {
     val isFabVisible: StateFlow<Boolean>
 }
 
-internal class DefaultFabNestedScrollConnection : FabNestedScrollConnection {
+internal class DefaultFabNestedScrollConnection(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
+) : FabNestedScrollConnection {
     private val fabVisible = MutableStateFlow(true)
-    private val scope = CoroutineScope(SupervisorJob())
+
     override val isFabVisible: StateFlow<Boolean>
         get() =
             fabVisible

--- a/core/navigation/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -34,7 +34,9 @@ class DefaultNavigationCoordinatorTest {
     @get:Rule
     val dispatcherRule = DispatcherTestRule()
 
-    private val sut = DefaultNavigationCoordinator()
+    private val sut = DefaultNavigationCoordinator(
+        dispatcher = dispatcherRule.dispatcher,
+    )
 
     @Test
     fun whenSetCurrentSection_thenValueIsUpdated() =

--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
@@ -6,7 +6,9 @@ import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.bottomSheet.BottomSheetNavigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabNavigator
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -24,7 +26,9 @@ private sealed interface NavigationEvent {
     data class Show(val screen: Screen) : NavigationEvent
 }
 
-internal class DefaultNavigationCoordinator : NavigationCoordinator {
+internal class DefaultNavigationCoordinator(
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : NavigationCoordinator {
     override val currentSection = MutableStateFlow<TabNavigationSection?>(null)
     override val onDoubleTabSelection = MutableSharedFlow<TabNavigationSection>()
     override val deepLinkUrl = MutableSharedFlow<String>()
@@ -40,10 +44,10 @@ internal class DefaultNavigationCoordinator : NavigationCoordinator {
     private var navigator: Navigator? = null
     private var bottomNavigator: BottomSheetNavigator? = null
     private var tabNavigator: TabNavigator? = null
-    private val scope = CoroutineScope(SupervisorJob())
     private var canGoBackCallback: (() -> Boolean)? = null
     private val bottomSheetChannel = Channel<NavigationEvent>()
     private val screenChannel = Channel<NavigationEvent>()
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     companion object {
         private const val DEEP_LINK_DELAY = 500L

--- a/core/notifications/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultNotificationCenterTest.kt
+++ b/core/notifications/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultNotificationCenterTest.kt
@@ -12,7 +12,9 @@ class DefaultNotificationCenterTest {
     @get:Rule
     val dispatcherRule = DispatcherTestRule()
 
-    private val sut = DefaultNotificationCenter
+    private val sut = DefaultNotificationCenter(
+        dispatcher = dispatcherRule.dispatcher,
+    )
 
     @Test
     fun givenSubscription_whenSendEvent_thenEventIsReceivedJustOnce() =

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultNotificationCenter.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/DefaultNotificationCenter.kt
@@ -1,5 +1,6 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.notifications
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -10,8 +11,11 @@ import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
 
-object DefaultNotificationCenter : NotificationCenter {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+internal class DefaultNotificationCenter(
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : NotificationCenter {
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+
     private val events = MutableSharedFlow<NotificationCenterEvent>()
 
     override fun send(event: NotificationCenterEvent) {

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/di/NotificationModule.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/di/NotificationModule.kt
@@ -7,6 +7,6 @@ import org.koin.dsl.module
 val coreNotificationModule =
     module {
         single<NotificationCenter> {
-            DefaultNotificationCenter
+            DefaultNotificationCenter()
         }
     }

--- a/core/testutils/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/testutils/DispatcherTestRule.kt
+++ b/core/testutils/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/testutils/DispatcherTestRule.kt
@@ -11,7 +11,7 @@ import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DispatcherTestRule(
-    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+    val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestWatcher() {
     override fun starting(description: Description) {
         Dispatchers.setMain(dispatcher)

--- a/core/utils/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/zombiemode/DefaultZombieModeHelperTest.kt
+++ b/core/utils/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/zombiemode/DefaultZombieModeHelperTest.kt
@@ -1,48 +1,38 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.utils.zombiemode
 
-import app.cash.turbine.test
 import com.github.diegoberaldin.raccoonforlemmy.core.testutils.DispatcherTestRule
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultZombieModeHelperTest {
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
-    private val sut = DefaultZombieModeHelper()
+    private val sut =
+        DefaultZombieModeHelper(
+            dispatcher = dispatcherTestRule.dispatcher,
+        )
     private val interval = 1.seconds
 
     @Test
-    fun whenStartThenEventsAreEmitted() =
+    fun whenStartThenIndexIsAsExpected() =
         runTest {
             sut.start(initialValue = 0, interval = interval)
-            sut.index.test {
-                val item = awaitItem()
-                assertEquals(0, item)
-                val secondItem = awaitItem()
-                assertEquals(1, secondItem)
-            }
+            val i0 = sut.index.value
+            assertEquals(0, i0)
         }
 
     @Test
-    fun whenPauseThenIndexIsReset() =
+    fun whenPauseThenIndexIsAsExpected() =
         runTest {
             sut.start(initialValue = 0, interval = interval)
-            sut.index.test {
-                val item = awaitItem()
-                assertEquals(0, item)
-                sut.pause()
-                val secondItem = awaitItem()
-                assertEquals(-1, secondItem)
-                advanceTimeBy(interval)
-                assertEquals(-1, sut.index.value)
-                expectNoEvents()
-            }
+            val i0 = sut.index.value
+            assertEquals(0, i0)
+            sut.pause()
+            val i1 = sut.index.value
+            assertEquals(-1, i1)
         }
 }

--- a/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/zombiemode/DefaultZombieModeHelper.kt
+++ b/core/utils/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/zombiemode/DefaultZombieModeHelper.kt
@@ -1,6 +1,8 @@
 package com.github.diegoberaldin.raccoonforlemmy.core.utils.zombiemode
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -11,10 +13,12 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-internal class DefaultZombieModeHelper : ZombieModeHelper {
-    private val scope = CoroutineScope(SupervisorJob())
+internal class DefaultZombieModeHelper(
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : ZombieModeHelper {
     override val index = MutableStateFlow(-1)
     private var delayInterval: Duration = 2.5.seconds
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
     private var job: Job? = null
 
     override fun start(
@@ -24,7 +28,7 @@ internal class DefaultZombieModeHelper : ZombieModeHelper {
         index.value = initialValue
         delayInterval = interval
         job =
-            scope.launch {
+            scope.launch(Dispatchers.Default) {
                 while (isActive) {
                     delay(delayInterval)
                     index.update { (it + 1).coerceAtLeast(0) }

--- a/domain/identity/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
@@ -26,6 +26,7 @@ class DefaultApiConfigurationRepositoryTest {
         DefaultApiConfigurationRepository(
             serviceProvider = serviceProvider,
             keyStore = keyStore,
+            dispatcher = dispatcherTestRule.dispatcher,
         )
 
     @Test

--- a/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -2,7 +2,9 @@ package com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository
 
 import com.github.diegoberaldin.raccoonforlemmy.core.api.provider.ServiceProvider
 import com.github.diegoberaldin.raccoonforlemmy.core.preferences.TemporaryKeyStore
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,8 +18,9 @@ private const val KEY_LAST_INSTANCE = "lastInstance"
 internal class DefaultApiConfigurationRepository(
     private val serviceProvider: ServiceProvider,
     private val keyStore: TemporaryKeyStore,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : ApiConfigurationRepository {
-    private val scope = CoroutineScope(SupervisorJob())
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
         val instance =

--- a/domain/inbox/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/inbox/DefaultInboxCoordinatorTest.kt
+++ b/domain/inbox/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/inbox/DefaultInboxCoordinatorTest.kt
@@ -35,6 +35,7 @@ class DefaultInboxCoordinatorTest {
         DefaultInboxCoordinator(
             identityRepository = identityRepository,
             getUnreadItemsUseCase = getUnreadItemsUseCase,
+            dispatcher = dispatcherTestRule.dispatcher,
         )
 
     @Test

--- a/domain/inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/inbox/DefaultInboxCoordinator.kt
+++ b/domain/inbox/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/inbox/DefaultInboxCoordinator.kt
@@ -2,7 +2,9 @@ package com.github.diegoberaldin.raccoonforlemmy.domain.inbox
 
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.inbox.usecase.GetUnreadItemsUseCase
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,9 +18,9 @@ import kotlinx.coroutines.launch
 internal class DefaultInboxCoordinator(
     private val identityRepository: IdentityRepository,
     private val getUnreadItemsUseCase: GetUnreadItemsUseCase,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : InboxCoordinator {
-    private val scope = CoroutineScope(SupervisorJob())
-
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
     override val events = MutableSharedFlow<InboxCoordinator.Event>()
     override val unreadOnly = MutableStateFlow(true)
     override val unreadReplies = MutableStateFlow(0)

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManagerTest.kt
@@ -46,6 +46,7 @@ class DefaultCommentPaginationManagerTest {
             commentRepository = commentRepository,
             userRepository = userRepository,
             notificationCenter = notificationCenter,
+            dispatcher = dispatcherTestRule.dispatcher,
         )
 
     @Test

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
@@ -52,6 +52,7 @@ class DefaultPostPaginationManagerTest {
             userRepository = userRepository,
             multiCommunityPaginator = multiCommunityPaginator,
             notificationCenter = notificationCenter,
+            dispatcher = dispatcherTestRule.dispatcher,
         )
 
     @Test

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManager.kt
@@ -7,6 +7,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -20,6 +21,7 @@ internal class DefaultCommentPaginationManager(
     private val commentRepository: CommentRepository,
     private val userRepository: UserRepository,
     notificationCenter: NotificationCenter,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : CommentPaginationManager {
     override var canFetchMore: Boolean = true
         private set
@@ -27,7 +29,7 @@ internal class DefaultCommentPaginationManager(
     private var specification: CommentPaginationSpecification? = null
     private var currentPage: Int = 1
     private val history: MutableList<CommentModel> = mutableListOf()
-    private val scope = CoroutineScope(SupervisorJob())
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
         notificationCenter.subscribe(NotificationCenterEvent.CommentUpdated::class).onEach { evt ->

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt
@@ -10,6 +10,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -24,16 +25,18 @@ internal class DefaultPostPaginationManager(
     private val communityRepository: CommunityRepository,
     private val userRepository: UserRepository,
     private val multiCommunityPaginator: MultiCommunityPaginator,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
     notificationCenter: NotificationCenter,
-) : PostPaginationManager {
+
+    ) : PostPaginationManager {
     override var canFetchMore: Boolean = true
         private set
+    override val history: MutableList<PostModel> = mutableListOf()
 
     private var specification: PostPaginationSpecification? = null
     private var currentPage: Int = 1
     private var pageCursor: String? = null
-    override val history: MutableList<PostModel> = mutableListOf()
-    private val scope = CoroutineScope(SupervisorJob())
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
         notificationCenter.subscribe(NotificationCenterEvent.PostUpdated::class).onEach { evt ->


### PR DESCRIPTION
This PR makes the coroutine dispatcher injectable in order to override it in tests and prevent flakiness.