### PR TITLE
fix: keyboard type for text inputs

### DIFF
--- a/unit/chat/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -243,7 +243,7 @@ class InboxChatScreen(
                         value = textFieldValue,
                         keyboardOptions =
                             KeyboardOptions(
-                                keyboardType = KeyboardType.Ascii,
+                                keyboardType = KeyboardType.Text,
                                 autoCorrect = true,
                                 capitalization = KeyboardCapitalization.Sentences,
                             ),

--- a/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -403,7 +403,7 @@ class CreatePostScreen(
                     },
                     keyboardOptions =
                         KeyboardOptions(
-                            keyboardType = KeyboardType.Ascii,
+                            keyboardType = KeyboardType.Text,
                             autoCorrect = true,
                             imeAction = ImeAction.Next,
                             capitalization = KeyboardCapitalization.Sentences,
@@ -463,7 +463,7 @@ class CreatePostScreen(
                     singleLine = true,
                     keyboardOptions =
                         KeyboardOptions(
-                            keyboardType = KeyboardType.Ascii,
+                            keyboardType = KeyboardType.Text,
                             autoCorrect = false,
                             imeAction = ImeAction.Next,
                         ),

--- a/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
@@ -165,7 +165,7 @@ class MultiCommunityEditorScreen(
                     value = uiState.name,
                     keyboardOptions =
                         KeyboardOptions(
-                            keyboardType = KeyboardType.Ascii,
+                            keyboardType = KeyboardType.Text,
                             autoCorrect = false,
                             imeAction = ImeAction.Next,
                         ),


### PR DESCRIPTION
The type in `KeyboardOptions` was incorrectly set to `KeyboardType.Ascii` instead of `KeyboardType.Text` for some fields which should in turn accept regular text inputs.