### PR TITLE
fix: sanitize markdown for empty links

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
@@ -18,12 +18,12 @@ internal fun ASTNode.findChildOfTypeRecursive(type: IElementType): ASTNode? {
 }
 
 internal fun String.sanitize(): String =
-    this
-        .removeEntities()
+    this.removeEntities()
         .spoilerFixUp()
         .quoteFixUp()
         .expandLemmyHandles()
         .cleanupEscapes()
+        .emptyLinkFixup()
 
 private fun String.removeEntities(): String =
     replace("&amp;", "&")
@@ -103,3 +103,5 @@ private fun String.expandLemmyHandles(): String =
     }
 
 private fun String.cleanupEscapes(): String = replace("\\#", "#")
+
+private fun String.emptyLinkFixup(): String = replace("[]()", "")


### PR DESCRIPTION
There was an issue in the Markdown renderer for when an empty link(`[]()`)  is found in the input. This PR adds a sanitization step to replace offending characters.