### PR TITLE
fix: populate inbox check period in advanced settings

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -103,6 +103,7 @@ class AdvancedSettingsViewModel(
                     appIconChangeSupported = appIconManager.supportsMultipleIcons,
                     fadeReadPosts = settings.fadeReadPosts,
                     showUnreadComments = settings.showUnreadComments,
+                    inboxBackgroundCheckPeriod = settings.inboxBackgroundCheckPeriod,
                     supportSettingsImportExport = fileSystemManager.isSupported,
                     enableButtonsToScrollBetweenComments = settings.enableButtonsToScrollBetweenComments,
                 )


### PR DESCRIPTION
This PR fixes a bug in the initial loading of the advanced settings screen, due to which the value of the inbox background check period is not populated with the current value.