### PR TITLE
feat: add possibility to create a new community

### DIFF
--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/Community.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/Community.kt
@@ -21,4 +21,5 @@ data class Community(
     @SerialName("hidden") val hidden: Boolean,
     @SerialName("posting_restricted_to_mods") val postingRestrictedToMods: Boolean,
     @SerialName("instance_id") val instanceId: InstanceId,
+    @SerialName("visibility") val visibility: CommunityVisibility? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CommunityVisibility.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CommunityVisibility.kt
@@ -1,0 +1,11 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.api.dto
+
+import kotlinx.serialization.SerialName
+
+enum class CommunityVisibility {
+    @SerialName("Public")
+    Public,
+
+    @SerialName("LocalOnly")
+    LocalOnly,
+}

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreateCommunityForm.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreateCommunityForm.kt
@@ -1,0 +1,17 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateCommunityForm(
+    @SerialName("name") val name: String,
+    @SerialName("icon") val icon: String? = null,
+    @SerialName("banner") val banner: String? = null,
+    @SerialName("title") val title: String? = null,
+    @SerialName("description") val description: String? = null,
+    @SerialName("nsfw") val nsfw: Boolean? = null,
+    @SerialName("posting_restricted_to_mods") val postingRestrictedToMods: Boolean? = null,
+    @SerialName("local_only") val localOnly: Boolean? = null,
+    @SerialName("discussion_languages") val discussionLanguages: List<LanguageId>? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreateCommunityForm.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/CreateCommunityForm.kt
@@ -14,4 +14,5 @@ data class CreateCommunityForm(
     @SerialName("posting_restricted_to_mods") val postingRestrictedToMods: Boolean? = null,
     @SerialName("local_only") val localOnly: Boolean? = null,
     @SerialName("discussion_languages") val discussionLanguages: List<LanguageId>? = null,
+    @SerialName("visibility") val visibility: CommunityVisibility? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/DeleteCommunityForm.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/DeleteCommunityForm.kt
@@ -1,0 +1,10 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeleteCommunityForm(
+    @SerialName("community_id") val communityId: CommunityId,
+    @SerialName("deleted") val deleted: Boolean,
+)

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/EditCommunityForm.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/EditCommunityForm.kt
@@ -14,4 +14,5 @@ data class EditCommunityForm(
     @SerialName("posting_restricted_to_mods") val postingRestrictedToMods: Boolean? = null,
     @SerialName("local_only") val localOnly: Boolean? = null,
     @SerialName("discussion_languages") val discussionLanguages: List<LanguageId>? = null,
+    @SerialName("visibility") val visibility: CommunityVisibility? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/service/CommunityService.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/service/CommunityService.kt
@@ -9,6 +9,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BlockCommunityRespo
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommunityId
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommunityResponse
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CreateCommunityForm
+import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.DeleteCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.EditCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.FollowCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.GetCommunityResponse
@@ -92,6 +93,13 @@ interface CommunityService {
         @Header("Authorization") authHeader: String? = null,
         @Body form: HideCommunityForm,
     ): SuccessResponse
+
+    @POST("community/delete")
+    @Headers("Content-Type: application/json")
+    suspend fun delete(
+        @Header("Authorization") authHeader: String? = null,
+        @Body form: DeleteCommunityForm,
+    ): CommunityResponse
 
     @POST("admin/purge/community")
     @Headers("Content-Type: application/json")

--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/service/CommunityService.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/service/CommunityService.kt
@@ -8,6 +8,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BlockCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BlockCommunityResponse
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommunityId
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommunityResponse
+import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CreateCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.EditCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.FollowCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.GetCommunityResponse
@@ -70,6 +71,13 @@ interface CommunityService {
         @Header("Authorization") authHeader: String? = null,
         @Body form: AddModToCommunityForm,
     ): AddModToCommunityResponse
+
+    @POST("community")
+    @Headers("Content-Type: application/json")
+    suspend fun create(
+        @Header("Authorization") authHeader: String? = null,
+        @Body form: CreateCommunityForm,
+    ): CommunityResponse
 
     @PUT("community")
     @Headers("Content-Type: application/json")

--- a/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/CommunityVisibilityBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/CommunityVisibilityBottomSheet.kt
@@ -1,0 +1,98 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import cafe.adriel.voyager.core.screen.Screen
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.BottomSheetHeader
+import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
+import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
+import com.github.diegoberaldin.raccoonforlemmy.core.notifications.di.getNotificationCenter
+import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityVisibilityType
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toIcon
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toReadableName
+
+class CommunityVisibilityBottomSheet() : Screen {
+    @Composable
+    override fun Content() {
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val notificationCenter = remember { getNotificationCenter() }
+
+        Column(
+            modifier =
+                Modifier
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .padding(
+                        top = Spacing.s,
+                        start = Spacing.s,
+                        end = Spacing.s,
+                        bottom = Spacing.m,
+                    ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            BottomSheetHeader(LocalStrings.current.editCommunityItemVisibility)
+            val values =
+                listOf(
+                    CommunityVisibilityType.LocalOnly,
+                    CommunityVisibilityType.Public,
+                )
+            Column(
+                modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+            ) {
+                for (value in values) {
+                    Row(
+                        modifier =
+                            Modifier.padding(
+                                horizontal = Spacing.s,
+                                vertical = Spacing.s,
+                            )
+                                .fillMaxWidth()
+                                .onClick(
+                                    onClick = {
+                                        notificationCenter.send(
+                                            NotificationCenterEvent.ChangeCommunityVisibility(
+                                                value = value,
+                                            ),
+                                        )
+                                        navigationCoordinator.hideBottomSheet()
+                                    },
+                                ),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = value.toReadableName(),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Image(
+                            imageVector = value.toIcon(),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
@@ -410,4 +410,8 @@ internal val ArStrings =
         override val communitySetPreferredLanguage = "تعيين اللغة المفضلة"
         override val appIconClassical = "كلاسيكي"
         override val settingsAboutAcknowledgements: String = "شكر وتقدير"
+        override val actionCreateCommunity: String = "إنشاء المجتمع"
+        override val editCommunityItemVisibility: String = "الرؤية"
+        override val communityVisibilityLocalOnly: String = "المثيل المحلي فقط"
+        override val communityVisibilityPublic: String = "عام"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
@@ -417,4 +417,8 @@ internal val BgStrings =
         override val communitySetPreferredLanguage = "Задаване на предпочитанияезик"
         override val appIconClassical = "Класическа"
         override val settingsAboutAcknowledgements: String = "Благодарности"
+        override val actionCreateCommunity: String = "Създайте общност"
+        override val editCommunityItemVisibility: String = "Видимост"
+        override val communityVisibilityLocalOnly: String = "само локален екземпляр"
+        override val communityVisibilityPublic: String = "публичен"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
@@ -413,4 +413,8 @@ internal val CsStrings =
         override val communitySetPreferredLanguage = "Nastavení preferovaného jazyka"
         override val appIconClassical = "Klasický"
         override val settingsAboutAcknowledgements: String = "Poděkování"
+        override val actionCreateCommunity: String = "Vytvořte komunitu"
+        override val editCommunityItemVisibility: String = "Viditelnost"
+        override val communityVisibilityLocalOnly: String = "pouze místní instance"
+        override val communityVisibilityPublic: String = "veřejnost"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
@@ -412,4 +412,8 @@ internal val DaStrings =
         override val communitySetPreferredLanguage = "Indstil foretrukket sprog"
         override val appIconClassical = "Klassisk"
         override val settingsAboutAcknowledgements: String = "Anerkendelser"
+        override val actionCreateCommunity: String = "Skab fællesskab"
+        override val editCommunityItemVisibility: String = "Sigtbarhed"
+        override val communityVisibilityLocalOnly: String = "kun lokal instans"
+        override val communityVisibilityPublic: String = "offentlig"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
@@ -417,4 +417,8 @@ internal val DeStrings =
         override val communitySetPreferredLanguage = "Bevorzugte Sprache festlegen"
         override val appIconClassical = "Klassisch"
         override val settingsAboutAcknowledgements: String = "Danksagungen"
+        override val actionCreateCommunity: String = "Gemeinschaft schaffen"
+        override val editCommunityItemVisibility: String = "Sichtweite"
+        override val communityVisibilityLocalOnly: String = "Nur lokale Instanz"
+        override val communityVisibilityPublic: String = "öffentlich"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
@@ -420,4 +420,8 @@ internal val ElStrings =
         override val communitySetPreferredLanguage = "Ορισμός προτιμώμενης γλώσσας"
         override val appIconClassical = "Κλασσική"
         override val settingsAboutAcknowledgements: String = "Ευχαριστίες"
+        override val actionCreateCommunity: String = "Δημιουργία κοινότητας"
+        override val editCommunityItemVisibility: String = "Ορατότητα"
+        override val communityVisibilityLocalOnly: String = "μόνο τοπική περίπτωση"
+        override val communityVisibilityPublic: String = "δημόσιο"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
@@ -410,4 +410,8 @@ internal val EnStrings =
         override val communitySetPreferredLanguage = "Set preferred language"
         override val appIconClassical = "Classical"
         override val settingsAboutAcknowledgements: String = "Acknowledgements"
+        override val actionCreateCommunity: String = "Create community"
+        override val editCommunityItemVisibility: String = "Visibility"
+        override val communityVisibilityLocalOnly: String = "local instance only"
+        override val communityVisibilityPublic: String = "public"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
@@ -409,4 +409,8 @@ internal val EoStrings =
         override val communitySetPreferredLanguage = "Agordi preferatan lingvon"
         override val appIconClassical = "Klasika"
         override val settingsAboutAcknowledgements: String = "Dankon"
+        override val actionCreateCommunity: String = "Krei komunumon"
+        override val editCommunityItemVisibility: String = "Videbleco"
+        override val communityVisibilityLocalOnly: String = "nur loka instanco"
+        override val communityVisibilityPublic: String = "publika"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
@@ -414,4 +414,8 @@ internal val EsStrings =
         override val communitySetPreferredLanguage = "Elegir idioma preferido"
         override val appIconClassical = "Clásico"
         override val settingsAboutAcknowledgements: String = "Agradecimientos"
+        override val actionCreateCommunity: String = "Crear comunidad"
+        override val editCommunityItemVisibility: String = "Visibilidad"
+        override val communityVisibilityLocalOnly: String = "sólo instancia local"
+        override val communityVisibilityPublic: String = "pública"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
@@ -415,4 +415,8 @@ internal val EtStrings =
         override val communitySetPreferredLanguage = "Eelistatud keele määramine"
         override val appIconClassical = "Klassikaline"
         override val settingsAboutAcknowledgements: String = "Tänuavaldused"
+        override val actionCreateCommunity: String = "Looge kogukond"
+        override val editCommunityItemVisibility: String = "Nähtavus"
+        override val communityVisibilityLocalOnly: String = "ainult kohalik eksemplar"
+        override val communityVisibilityPublic: String = "avalik"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
@@ -411,4 +411,8 @@ internal val FiStrings =
         override val communitySetPreferredLanguage = "Aseta ensisijainen kieli"
         override val appIconClassical = "Klassinen"
         override val settingsAboutAcknowledgements: String = "Kiitokset"
+        override val actionCreateCommunity: String = "Luo yhteisö"
+        override val editCommunityItemVisibility: String = "Näkyvyys"
+        override val communityVisibilityLocalOnly: String = "vain paikallinen esimerkki"
+        override val communityVisibilityPublic: String = "julkinen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
@@ -419,4 +419,8 @@ internal val FrStrings =
         override val communitySetPreferredLanguage = "Définir la langue préférée"
         override val appIconClassical = "Classique"
         override val settingsAboutAcknowledgements: String = "Remerciements"
+        override val actionCreateCommunity: String = "Créer une communauté"
+        override val editCommunityItemVisibility: String = "Visibilité"
+        override val communityVisibilityLocalOnly: String = "instance locale uniquement"
+        override val communityVisibilityPublic: String = "publique"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
@@ -415,4 +415,8 @@ internal val GaStrings =
         override val communitySetPreferredLanguage = "An teanga rogha a shocrú"
         override val appIconClassical = "Clasaiceach"
         override val settingsAboutAcknowledgements: String = "Buíochas"
+        override val actionCreateCommunity: String = "Cruthaigh pobail"
+        override val editCommunityItemVisibility: String = "Infheictheacht"
+        override val communityVisibilityLocalOnly: String = "shampla áitiúil amháin"
+        override val communityVisibilityPublic: String = "poiblí"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
@@ -414,4 +414,8 @@ internal val HrStrings =
         override val communitySetPreferredLanguage = "Postavljanje preferiranog jezik"
         override val appIconClassical = "Klasična"
         override val settingsAboutAcknowledgements: String = "Priznanja"
+        override val actionCreateCommunity: String = "Stvorite zajednicu"
+        override val editCommunityItemVisibility: String = "Vidljivost"
+        override val communityVisibilityLocalOnly: String = "samo lokalna instanca"
+        override val communityVisibilityPublic: String = "javnost"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
@@ -418,4 +418,8 @@ internal val HuStrings =
         override val communitySetPreferredLanguage = "Előnyben részesítettnyelv beállítása"
         override val appIconClassical = "Klasszikus"
         override val settingsAboutAcknowledgements: String = "Köszönetnyilvánítás"
+        override val actionCreateCommunity: String = "Közösség létrehozása"
+        override val editCommunityItemVisibility: String = "Láthatóság"
+        override val communityVisibilityLocalOnly: String = "csak helyi példány"
+        override val communityVisibilityPublic: String = "nyilvános"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -415,4 +415,8 @@ internal val ItStrings =
         override val communitySetPreferredLanguage = "Imposta lingua preferita"
         override val appIconClassical = "Classica"
         override val settingsAboutAcknowledgements: String = "Riconoscimenti"
+        override val actionCreateCommunity: String = "Crea comunità"
+        override val editCommunityItemVisibility: String = "Visibilità"
+        override val communityVisibilityLocalOnly: String = "solo istanza locale"
+        override val communityVisibilityPublic: String = "pubblica"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
@@ -412,4 +412,8 @@ internal val LtStrings =
         override val communitySetPreferredLanguage = "Nustatyti pageidaujamą kalbą"
         override val appIconClassical = "Klasikinis"
         override val settingsAboutAcknowledgements: String = "Padėkos"
+        override val actionCreateCommunity: String = "Sukurti bendruomenę"
+        override val editCommunityItemVisibility: String = "Matomumas"
+        override val communityVisibilityLocalOnly: String = "tik vietinis pavyzdys"
+        override val communityVisibilityPublic: String = "viešas"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
@@ -413,4 +413,8 @@ internal val LvStrings =
         override val communitySetPreferredLanguage = "Iestatīt vēlamo valodu"
         override val appIconClassical = "Klasiskā"
         override val settingsAboutAcknowledgements: String = "Pateicības"
+        override val actionCreateCommunity: String = "Izveidot kopienu"
+        override val editCommunityItemVisibility: String = "Redzamība"
+        override val communityVisibilityLocalOnly: String = "tikai vietējais gadījums"
+        override val communityVisibilityPublic: String = "publiski"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
@@ -414,4 +414,8 @@ internal val MtStrings =
         override val communitySetPreferredLanguage = "Issettja l-lingwa preferuta"
         override val appIconClassical = "Klassiku"
         override val settingsAboutAcknowledgements: String = "Rikonoxximenti"
+        override val actionCreateCommunity: String = "Oħloq komunità"
+        override val editCommunityItemVisibility: String = "Viżibilità"
+        override val communityVisibilityLocalOnly: String = "istanza lokali biss"
+        override val communityVisibilityPublic: String = "pubbliku"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
@@ -415,4 +415,8 @@ internal val NlStrings =
         override val communitySetPreferredLanguage = "Voorkeurstaal instellen"
         override val appIconClassical = "Klassiek"
         override val settingsAboutAcknowledgements: String = "Dankbetuigingen"
+        override val actionCreateCommunity: String = "Creëer gemeenschap"
+        override val editCommunityItemVisibility: String = "Zichtbaarheid"
+        override val communityVisibilityLocalOnly: String = "alleen lokale instantie"
+        override val communityVisibilityPublic: String = "openbaar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
@@ -411,4 +411,8 @@ internal val NoStrings =
         override val communitySetPreferredLanguage = "Sett foretrukket språk"
         override val appIconClassical = "Klassisk"
         override val settingsAboutAcknowledgements: String = "Anerkjennelser"
+        override val actionCreateCommunity: String = "Skap fellesskap"
+        override val editCommunityItemVisibility: String = "Synlighet"
+        override val communityVisibilityLocalOnly: String = "kun lokal instans"
+        override val communityVisibilityPublic: String = "offentlig"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
@@ -414,4 +414,8 @@ internal val PlStrings =
         override val communitySetPreferredLanguage = "Ustaw preferowany język"
         override val appIconClassical = "Klasyczny"
         override val settingsAboutAcknowledgements: String = "Podziękowanie"
+        override val actionCreateCommunity: String = "Utwórz społeczność"
+        override val editCommunityItemVisibility: String = "Widoczność"
+        override val communityVisibilityLocalOnly: String = "tylko instancja lokalna"
+        override val communityVisibilityPublic: String = "publiczny"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
@@ -413,4 +413,8 @@ internal val PtBrStrings =
         override val communitySetPreferredLanguage = "Definir idioma preferido"
         override val appIconClassical = "Clássico"
         override val settingsAboutAcknowledgements: String = "Reconhecimentos"
+        override val actionCreateCommunity: String = "Criar comunidade"
+        override val editCommunityItemVisibility: String = "Visibilidade"
+        override val communityVisibilityLocalOnly: String = "apenas instância local"
+        override val communityVisibilityPublic: String = "pública"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
@@ -414,4 +414,8 @@ internal val PtStrings =
         override val communitySetPreferredLanguage = "Definir idioma preferido"
         override val appIconClassical = "Clássico"
         override val settingsAboutAcknowledgements: String = "Reconhecimentos"
+        override val actionCreateCommunity: String = "Criar comunidade"
+        override val editCommunityItemVisibility: String = "Visibilidade"
+        override val communityVisibilityLocalOnly: String = "apenas instância local"
+        override val communityVisibilityPublic: String = "pública"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
@@ -413,4 +413,8 @@ internal val RoStrings =
         override val communitySetPreferredLanguage = "Setează limba preferată"
         override val appIconClassical = "Clasic"
         override val settingsAboutAcknowledgements: String = "Mulțumiri"
+        override val actionCreateCommunity: String = "Creează o comunitate"
+        override val editCommunityItemVisibility: String = "Vizibilitate"
+        override val communityVisibilityLocalOnly: String = "numai instanță locală"
+        override val communityVisibilityPublic: String = "publică"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
@@ -416,4 +416,8 @@ internal val RuStrings =
         override val communitySetPreferredLanguage = "Установить предпочитаемый язык"
         override val appIconClassical = "Классический"
         override val settingsAboutAcknowledgements: String = "Благодарности"
+        override val actionCreateCommunity: String = "Создать сообщество"
+        override val editCommunityItemVisibility: String = "Видимость"
+        override val communityVisibilityLocalOnly: String = "только локальный экземпляр"
+        override val communityVisibilityPublic: String = "общественный"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
@@ -413,4 +413,8 @@ internal val SeStrings =
         override val communitySetPreferredLanguage = "Ställ in önskat språk"
         override val appIconClassical = "Klassisk"
         override val settingsAboutAcknowledgements: String = "Erkännanden"
+        override val actionCreateCommunity: String = "Skapa gemenskap"
+        override val editCommunityItemVisibility: String = "Synlighet"
+        override val communityVisibilityLocalOnly: String = "endast lokal instans"
+        override val communityVisibilityPublic: String = "offentlig"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
@@ -415,4 +415,8 @@ internal val SkStrings =
         override val communitySetPreferredLanguage = "Nastavenie preferovaného jazyka"
         override val appIconClassical = "Klasická"
         override val settingsAboutAcknowledgements: String = "Poďakovanie"
+        override val actionCreateCommunity: String = "Vytvorte komunitu"
+        override val editCommunityItemVisibility: String = "Viditeľnosť"
+        override val communityVisibilityLocalOnly: String = "iba lokálna inštancia"
+        override val communityVisibilityPublic: String = "verejnosti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
@@ -413,4 +413,8 @@ internal val SlStrings =
         override val communitySetPreferredLanguage = "Nastavitev prednostnega jezika"
         override val appIconClassical = "Klasična"
         override val settingsAboutAcknowledgements: String = "Zahvala"
+        override val actionCreateCommunity: String = "Ustvari skupnost"
+        override val editCommunityItemVisibility: String = "Vidnost"
+        override val communityVisibilityLocalOnly: String = "samo lokalni primerek"
+        override val communityVisibilityPublic: String = "javnosti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
@@ -415,4 +415,8 @@ internal val SqStrings =
         override val communitySetPreferredLanguage = "Cakto gjuhën e preferuar"
         override val appIconClassical = "Klasike"
         override val settingsAboutAcknowledgements: String = "Mirënjohje"
+        override val actionCreateCommunity: String = "Krijo komunitet"
+        override val editCommunityItemVisibility: String = "Dukshmëria"
+        override val communityVisibilityLocalOnly: String = "vetëm për shembull lokal"
+        override val communityVisibilityPublic: String = "publike"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
@@ -415,4 +415,8 @@ internal val SrStrings =
         override val communitySetPreferredLanguage = "Подеси преферирани језик"
         override val appIconClassical = "Цлассицал"
         override val settingsAboutAcknowledgements: String = "Признања"
+        override val actionCreateCommunity: String = "Креирајте заједницу"
+        override val editCommunityItemVisibility: String = "Видљивост"
+        override val communityVisibilityLocalOnly: String = "само локална инстанца"
+        override val communityVisibilityPublic: String = "јавности"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -409,6 +409,10 @@ interface Strings {
     val communitySetPreferredLanguage: String
     val appIconClassical: String
     val settingsAboutAcknowledgements: String
+    val actionCreateCommunity: String
+    val editCommunityItemVisibility: String
+    val communityVisibilityLocalOnly: String
+    val communityVisibilityPublic: String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
@@ -5,7 +5,7 @@ internal val TokStrings =
         override val actionBackToTop = "o tawa sewi"
         override val actionChat = "o open e toki"
         override val actionClearRead = "lukin la, o weka"
-        override val actionCreatePost = "o sin e lipu"
+        override val actionCreatePost = "o pali e lipu sin"
         override val actionReply = "o toki lili"
         override val actionActivateZombieMode = "o open e nasin pi jan moli"
         override val actionDeactivateZombieMode = "o pini e nasin pi jan moli"
@@ -410,4 +410,8 @@ internal val TokStrings =
         override val communitySetPreferredLanguage = "o anu e toki pi wile sina"
         override val appIconClassical = "majuna"
         override val settingsAboutAcknowledgements: String = "jan pona"
+        override val actionCreateCommunity: String = "o pali e kulupu sin"
+        override val editCommunityItemVisibility: String = "nasin lukin"
+        override val communityVisibilityLocalOnly: String = "tawa ilo nanpa ni taso"
+        override val communityVisibilityPublic: String = "tawa ale"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
@@ -414,4 +414,8 @@ internal val TrStrings =
         override val communitySetPreferredLanguage = "Tercih edilen dili ayarla"
         override val appIconClassical = "Klasik"
         override val settingsAboutAcknowledgements: String = "Teşekkür"
+        override val actionCreateCommunity: String = "Topluluk oluştur"
+        override val editCommunityItemVisibility: String = "Görünürlük"
+        override val communityVisibilityLocalOnly: String = "yalnızca yerel örnek"
+        override val communityVisibilityPublic: String = "halk"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
@@ -415,4 +415,8 @@ internal val UkStrings =
         override val communitySetPreferredLanguage = "Встановіть бажану мову"
         override val appIconClassical = "Класичний"
         override val settingsAboutAcknowledgements: String = "Подяки"
+        override val actionCreateCommunity: String = "Створіть спільноту"
+        override val editCommunityItemVisibility: String = "Видимість"
+        override val communityVisibilityLocalOnly: String = "лише локальний екземпляр"
+        override val communityVisibilityPublic: String = "громадськість"
     }

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -14,6 +14,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.ActionOnSw
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.MultiCommunityModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityVisibilityType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SearchResultType
@@ -158,4 +159,7 @@ sealed interface NotificationCenterEvent {
     }
 
     data class ChangeUrlOpeningMode(val value: Int) : NotificationCenterEvent
+
+    data class ChangeCommunityVisibility(val value: CommunityVisibilityType) :
+        NotificationCenterEvent
 }

--- a/docs/acknowledgements.json
+++ b/docs/acknowledgements.json
@@ -28,5 +28,11 @@
     "avatar": "https://avatars.githubusercontent.com/u/98353605?v=4",
     "subtitle": "German translation",
     "url": "https://github.com/reusityback"
+  },
+  {
+    "title": "outerair",
+    "avatar": "https://avatars.githubusercontent.com/u/10137?v=4",
+    "subtitle": "Brazilian Portuguese translation",
+    "url": null
   }
 ]

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/CommunityModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/CommunityModel.kt
@@ -24,6 +24,7 @@ data class CommunityModel(
     val postingRestrictedToMods: Boolean? = null,
     @Transient val favorite: Boolean = false,
     val hidden: Boolean = false,
+    val visibilityType: CommunityVisibilityType = CommunityVisibilityType.Public,
 )
 
 fun CommunityModel.readableName(preferNickname: Boolean): String {

--- a/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/CommunityVisibilityType.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/data/CommunityVisibilityType.kt
@@ -1,0 +1,28 @@
+package com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cottage
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
+
+sealed interface CommunityVisibilityType {
+    data object Public : CommunityVisibilityType
+
+    data object LocalOnly : CommunityVisibilityType
+}
+
+@Composable
+fun CommunityVisibilityType.toIcon(): ImageVector =
+    when (this) {
+        CommunityVisibilityType.LocalOnly -> Icons.Default.Cottage
+        else -> Icons.Default.Public
+    }
+
+@Composable
+fun CommunityVisibilityType.toReadableName(): String =
+    when (this) {
+        CommunityVisibilityType.LocalOnly -> LocalStrings.current.communityVisibilityLocalOnly
+        else -> LocalStrings.current.communityVisibilityPublic
+    }

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepositoryTest.kt
@@ -208,11 +208,12 @@ class DefaultCommunityRepositoryTest {
                 )
             } returns
                 mockk {
-                    every { communities } returns listOf(
-                        mockk(relaxed = true) {
-                            every { community } returns mockk(relaxed = true)
-                        },
-                    )
+                    every { communities } returns
+                        listOf(
+                            mockk(relaxed = true) {
+                                every { community } returns mockk(relaxed = true)
+                            },
+                        )
                 }
 
             val token = "fake-token"
@@ -490,7 +491,7 @@ class DefaultCommunityRepositoryTest {
 
             val token = "fake-token"
             val newName = "fake-community-name"
-            val data = CommunityModel(id = communityId, name = newName)
+            val data = CommunityModel(id = communityId, title = newName)
             sut.update(
                 auth = token,
                 community = data,
@@ -502,6 +503,34 @@ class DefaultCommunityRepositoryTest {
                     withArg { data ->
                         assertEquals(communityId, data.communityId)
                         assertEquals(newName, data.title)
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun givenSuccess_whenCreate_thenInteractionsAreAsExpected() =
+        runTest {
+            coEvery {
+                communityService.create(any(), any())
+            } returns mockk(relaxed = true)
+
+            val token = "fake-token"
+            val newName = "fake-community-name"
+            val data = CommunityModel(name = newName)
+
+            val res =
+                sut.create(
+                    auth = token,
+                    community = data,
+                )
+
+            assertNotNull(res)
+            coVerify {
+                communityService.create(
+                    authHeader = token.toAuthHeader(),
+                    withArg { data ->
+                        assertEquals(newName, data.name)
                     },
                 )
             }

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepositoryTest.kt
@@ -82,7 +82,7 @@ class DefaultCommunityRepositoryTest {
                     users = emptyList(),
                 )
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val query = "q"
             val res =
                 sut.search(
@@ -172,7 +172,7 @@ class DefaultCommunityRepositoryTest {
                     every { community } returns mockk(relaxed = true)
                 }
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val query = "q"
             val res =
                 sut.getResolved(
@@ -216,7 +216,7 @@ class DefaultCommunityRepositoryTest {
                         )
                 }
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val res =
                 sut.getSubscribed(
                     auth = token,
@@ -263,7 +263,7 @@ class DefaultCommunityRepositoryTest {
                         }
                 }
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val res =
                 sut.get(
                     auth = token,
@@ -305,7 +305,7 @@ class DefaultCommunityRepositoryTest {
                         }
                 }
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val res =
                 sut.getModerators(
                     auth = token,
@@ -340,7 +340,7 @@ class DefaultCommunityRepositoryTest {
                         }
                 }
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val res =
                 sut.subscribe(
                     auth = token,
@@ -377,7 +377,7 @@ class DefaultCommunityRepositoryTest {
                         }
                 }
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val res =
                 sut.unsubscribe(
                     auth = token,
@@ -404,7 +404,7 @@ class DefaultCommunityRepositoryTest {
             coEvery {
                 communityService.block(any(), any())
             } returns mockk()
-            val token = "fake-token"
+            val token = AUTH_TOKEN
 
             sut.block(
                 auth = token,
@@ -432,7 +432,7 @@ class DefaultCommunityRepositoryTest {
                 communityService.ban(any(), any())
             } returns mockk()
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             sut.banUser(
                 auth = token,
                 communityId = communityId,
@@ -461,7 +461,7 @@ class DefaultCommunityRepositoryTest {
                 communityService.addMod(any(), any())
             } returns mockk()
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             sut.addModerator(
                 auth = token,
                 communityId = communityId,
@@ -489,7 +489,7 @@ class DefaultCommunityRepositoryTest {
                 communityService.edit(any(), any())
             } returns mockk()
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val newName = "fake-community-name"
             val data = CommunityModel(id = communityId, title = newName)
             sut.update(
@@ -515,7 +515,7 @@ class DefaultCommunityRepositoryTest {
                 communityService.create(any(), any())
             } returns mockk(relaxed = true)
 
-            val token = "fake-token"
+            val token = AUTH_TOKEN
             val newName = "fake-community-name"
             val data = CommunityModel(name = newName)
 
@@ -535,4 +535,84 @@ class DefaultCommunityRepositoryTest {
                 )
             }
         }
+
+    @Test
+    fun whenDelete_thenInteractionsAreAsExpected() =
+        runTest {
+            val communityId = 1L
+            coEvery {
+                communityService.delete(any(), any())
+            } returns mockk()
+
+            sut.delete(
+                auth = AUTH_TOKEN,
+                communityId = communityId,
+            )
+
+            coVerify {
+                communityService.delete(
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                    withArg {
+                        assertEquals(1, it.communityId)
+                        assertTrue(it.deleted)
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun whenHide_thenInteractionsAreAsExpected() =
+        runTest {
+            val communityId = 1L
+            coEvery {
+                communityService.hide(any(), any())
+            } returns mockk { every { success } returns true }
+
+            sut.hide(
+                auth = AUTH_TOKEN,
+                communityId = communityId,
+                hidden = true,
+                reason = "fake-reason",
+            )
+
+            coVerify {
+                communityService.hide(
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                    withArg {
+                        assertEquals(1, it.communityId)
+                        assertTrue(it.hidden)
+                        assertEquals("fake-reason", it.reason)
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun whenPurge_thenInteractionsAreAsExpected() =
+        runTest {
+            val communityId = 1L
+            coEvery {
+                communityService.purge(any(), any())
+            } returns mockk { every { success } returns true }
+
+            sut.purge(
+                auth = AUTH_TOKEN,
+                communityId = communityId,
+                reason = "fake-reason",
+            )
+
+            coVerify {
+                communityService.purge(
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                    withArg {
+                        assertEquals(1, it.communityId)
+                        assertEquals("fake-reason", it.reason)
+                    },
+                )
+            }
+        }
+
+    companion object {
+        private const val AUTH_TOKEN = "fake-token"
+    }
 }

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultSiteRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultSiteRepositoryTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -187,14 +188,41 @@ class DefaultSiteRepositoryTest {
                         mockk {
                             every { localSite } returns
                                 mockk {
-                                    every { enableDownvotes } returns true
+                                    every { enableDownvotes } returns false
                                 }
                         }
                 }
 
             val res = sut.isDownVoteEnabled(auth = AUTH_TOKEN)
 
-            assertTrue(res)
+            assertFalse(res)
+            coVerify {
+                siteService.get(
+                    auth = AUTH_TOKEN,
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                )
+            }
+        }
+
+    @Test
+    fun whenIsCommunityCreationAdminOnly_thenResultAndInteractionsAreAsExpected() =
+        runTest {
+            coEvery {
+                siteService.get(auth = any(), authHeader = any())
+            } returns
+                mockk(relaxed = true) {
+                    every { siteView } returns
+                        mockk {
+                            every { localSite } returns
+                                mockk {
+                                    every { communityCreationAdminOnly } returns false
+                                }
+                        }
+                }
+
+            val res = sut.isCommunityCreationAdminOnly(auth = AUTH_TOKEN)
+
+            assertFalse(res)
             coVerify {
                 siteService.get(
                     auth = AUTH_TOKEN,

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
@@ -88,6 +88,11 @@ interface CommunityRepository {
         added: Boolean,
     ): List<UserModel>
 
+    suspend fun create(
+        auth: String? = null,
+        community: CommunityModel,
+    ): CommunityModel?
+
     suspend fun update(
         auth: String? = null,
         community: CommunityModel,

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommunityRepository.kt
@@ -98,6 +98,11 @@ interface CommunityRepository {
         community: CommunityModel,
     )
 
+    suspend fun delete(
+        auth: String,
+        communityId: Long,
+    )
+
     suspend fun hide(
         auth: String?,
         communityId: Long,

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepository.kt
@@ -4,6 +4,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.AddModToCommunityFo
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BanFromCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BlockCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CreateCommunityForm
+import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.DeleteCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.EditCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.FollowCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.HideCommunityForm
@@ -339,6 +340,22 @@ internal class DefaultCommunityRepository(
             services.community.edit(
                 authHeader = auth.toAuthHeader(),
                 form = data,
+            )
+        }
+
+    override suspend fun delete(
+        auth: String,
+        communityId: Long,
+    ): Unit =
+        withContext(Dispatchers.IO) {
+            val data =
+                DeleteCommunityForm(
+                    communityId = communityId,
+                    deleted = true,
+                )
+            services.community.delete(
+                form = data,
+                authHeader = auth.toAuthHeader(),
             )
         }
 

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommunityRepository.kt
@@ -3,6 +3,7 @@ package com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.repository
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.AddModToCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BanFromCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.BlockCommunityForm
+import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CreateCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.EditCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.FollowCommunityForm
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.HideCommunityForm
@@ -297,6 +298,29 @@ internal class DefaultCommunityRepository(
             }.getOrElse { emptyList() }
         }
 
+    override suspend fun create(
+        auth: String?,
+        community: CommunityModel,
+    ): CommunityModel =
+        withContext(Dispatchers.IO) {
+            val data =
+                CreateCommunityForm(
+                    name = community.name,
+                    icon = community.icon,
+                    banner = community.banner,
+                    title = community.name,
+                    description = community.description,
+                    nsfw = community.nsfw,
+                    postingRestrictedToMods = community.postingRestrictedToMods,
+                )
+            val res =
+                services.community.create(
+                    authHeader = auth.toAuthHeader(),
+                    form = data,
+                )
+            res.communityView.toModel()
+        }
+
     override suspend fun update(
         auth: String?,
         community: CommunityModel,
@@ -307,7 +331,7 @@ internal class DefaultCommunityRepository(
                     communityId = community.id,
                     icon = community.icon,
                     banner = community.banner,
-                    title = community.name,
+                    title = community.title,
                     description = community.description,
                     nsfw = community.nsfw,
                     postingRestrictedToMods = community.postingRestrictedToMods,

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultSiteRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultSiteRepository.kt
@@ -110,6 +110,21 @@ internal class DefaultSiteRepository(
             }.getOrElse { true }
         }
 
+    override suspend fun isCommunityCreationAdminOnly(auth: String?): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                if (auth.isNullOrEmpty()) {
+                    return@runCatching true
+                }
+                val response =
+                    services.site.get(
+                        auth = auth,
+                        authHeader = auth.toAuthHeader(),
+                    )
+                response.siteView?.localSite?.communityCreationAdminOnly == true
+            }.getOrElse { true }
+        }
+
     override suspend fun getAccountSettings(auth: String): AccountSettingsModel? =
         withContext(Dispatchers.IO) {
             runCatching {

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/SiteRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/SiteRepository.kt
@@ -26,6 +26,8 @@ interface SiteRepository {
 
     suspend fun isDownVoteEnabled(auth: String?): Boolean
 
+    suspend fun isCommunityCreationAdminOnly(auth: String?): Boolean
+
     suspend fun getAccountSettings(auth: String): AccountSettingsModel?
 
     suspend fun updateAccountSettings(

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
@@ -11,6 +11,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommentSortType
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommentView
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.Community
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommunityView
+import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.CommunityVisibility
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.Instance
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.Language
 import com.github.diegoberaldin.raccoonforlemmy.core.api.dto.ListingType.All
@@ -63,6 +64,7 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.AccountSetting
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommentReportModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityVisibilityType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.InstanceModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.LanguageModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.ListingType
@@ -153,6 +155,12 @@ internal fun SearchResultType.toDto(): SearchType =
         SearchResultType.Posts -> SearchType.Posts
         SearchResultType.Users -> SearchType.Users
         SearchResultType.Urls -> SearchType.Url
+    }
+
+internal fun CommunityVisibility?.toModel(): CommunityVisibilityType =
+    when (this) {
+        CommunityVisibility.LocalOnly -> CommunityVisibilityType.LocalOnly
+        else -> CommunityVisibilityType.Public
     }
 
 internal fun Person.toModel() =
@@ -260,6 +268,7 @@ internal fun Community.toModel() =
         creationDate = published,
         postingRestrictedToMods = postingRestrictedToMods,
         hidden = hidden,
+        visibilityType = visibility.toModel(),
     )
 
 internal fun CommunityView.toModel() =

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
@@ -72,6 +72,8 @@ interface CommunityDetailMviModel :
         data object UnhideCommunity : Intent
 
         data class SelectPreferredLanguage(val languageId: Long?) : Intent
+
+        data object DeleteCommunity : Intent
     }
 
     data class UiState(
@@ -123,5 +125,7 @@ interface CommunityDetailMviModel :
         data class ZombieModeTick(val index: Int) : Effect
 
         data class TriggerCopy(val text: String) : Effect
+
+        data object Back : Effect
     }
 }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -212,6 +212,7 @@ class CommunityDetailScreen(
             }
         var selectLanguageDialogOpen by remember { mutableStateOf(false) }
         var unsubscribeConfirmDialogOpen by remember { mutableStateOf(false) }
+        var deleteConfirmDialogOpen by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
             model.effects.onEach { effect ->
@@ -250,6 +251,8 @@ class CommunityDetailScreen(
                     is CommunityDetailMviModel.Effect.Failure -> {
                         snackbarHostState.showSnackbar(effect.message ?: genericError)
                     }
+
+                    CommunityDetailMviModel.Effect.Back -> navigationCoordinator.popScreen()
                 }
             }.launchIn(this)
         }
@@ -437,11 +440,15 @@ class CommunityDetailScreen(
                                                 OptionId.OpenReports,
                                                 LocalStrings.current.modActionOpenReports,
                                             )
-
                                         this +=
                                             Option(
                                                 OptionId.Edit,
                                                 LocalStrings.current.communityActionEdit,
+                                            )
+                                        this +=
+                                            Option(
+                                                OptionId.Delete,
+                                                LocalStrings.current.commentActionDelete,
                                             )
                                     }
                                     if (uiState.isAdmin) {
@@ -588,6 +595,10 @@ class CommunityDetailScreen(
                                                     val screen =
                                                         EditCommunityScreen(uiState.community.id)
                                                     navigationCoordinator.pushScreen(screen)
+                                                }
+
+                                                OptionId.Delete -> {
+                                                    deleteConfirmDialogOpen = true
                                                 }
 
                                                 OptionId.Hide -> {
@@ -1593,6 +1604,42 @@ class CommunityDetailScreen(
                         onClick = {
                             unsubscribeConfirmDialogOpen = false
                             model.reduce(CommunityDetailMviModel.Intent.Unsubscribe)
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonConfirm)
+                    }
+                },
+            )
+        }
+
+        if (deleteConfirmDialogOpen) {
+            AlertDialog(
+                onDismissRequest = {
+                    deleteConfirmDialogOpen = false
+                },
+                title = {
+                    Text(
+                        text = LocalStrings.current.commentActionDelete,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                },
+                text = {
+                    Text(text = LocalStrings.current.messageAreYouSure)
+                },
+                dismissButton = {
+                    Button(
+                        onClick = {
+                            deleteConfirmDialogOpen = false
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonCancel)
+                    }
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            deleteConfirmDialogOpen = false
+                            model.reduce(CommunityDetailMviModel.Intent.DeleteCommunity)
                         },
                     ) {
                         Text(text = LocalStrings.current.buttonConfirm)

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -347,6 +347,10 @@ class CommunityDetailViewModel(
             is CommunityDetailMviModel.Intent.SelectPreferredLanguage -> {
                 updatePreferredLanguage(intent.languageId)
             }
+
+            CommunityDetailMviModel.Intent.DeleteCommunity -> {
+                deleteCommunity()
+            }
         }
     }
 
@@ -780,8 +784,7 @@ class CommunityDetailViewModel(
                 )
                 emitEffect(CommunityDetailMviModel.Effect.Success)
             } catch (e: Throwable) {
-                val message = e.message
-                emitEffect(CommunityDetailMviModel.Effect.Failure(message))
+                emitEffect(CommunityDetailMviModel.Effect.Failure(e.message))
             }
         }
     }
@@ -792,6 +795,21 @@ class CommunityDetailViewModel(
             communityPreferredLanguageRepository.save(handle = communityHandle, value = languageId)
             updateState {
                 it.copy(currentPreferredLanguageId = languageId)
+            }
+        }
+    }
+
+    private fun deleteCommunity() {
+        screenModelScope.launch {
+            val auth = identityRepository.authToken.value.orEmpty()
+            try {
+                communityRepository.delete(
+                    auth = auth,
+                    communityId = communityId,
+                )
+                emitEffect(CommunityDetailMviModel.Effect.Back)
+            } catch (e: Exception) {
+                emitEffect(CommunityDetailMviModel.Effect.Failure(e.message))
             }
         }
     }

--- a/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityMviModel.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityMviModel.kt
@@ -2,6 +2,7 @@ package com.github.diegoberaldin.raccoonforlemmy.unit.editcommunity
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.MviModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityVisibilityType
 
 interface EditCommunityMviModel :
     ScreenModel,
@@ -62,6 +63,7 @@ interface EditCommunityMviModel :
         val hasUnsavedChanges: Boolean = false,
         val nsfw: Boolean = false,
         val postingRestrictedToMods: Boolean = false,
+        val visibilityType: CommunityVisibilityType = CommunityVisibilityType.Public,
     )
 
     sealed interface Effect {

--- a/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityMviModel.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityMviModel.kt
@@ -9,6 +9,8 @@ interface EditCommunityMviModel :
     sealed interface Intent {
         data object Refresh : Intent
 
+        data class ChangeName(val value: String) : Intent
+
         data class ChangeTitle(val value: String) : Intent
 
         data class ChangeDescription(val value: String) : Intent
@@ -52,6 +54,7 @@ interface EditCommunityMviModel :
 
     data class UiState(
         val loading: Boolean = false,
+        val name: String = "",
         val title: String = "",
         val description: String = "",
         val icon: String = "",

--- a/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -20,7 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Badge
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.SettingsApplications
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.TextFormat
 import androidx.compose.material3.AlertDialog
@@ -60,8 +62,10 @@ import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.toTypograp
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsFormattedInfo
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsHeader
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsImageInfo
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsTextualInfo
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.CommunityVisibilityBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.EditFormattedInfoDialog
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.EditTextualInfoDialog
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
@@ -71,6 +75,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.gallery.getGalleryHelper
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.toReadableName
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.koin.core.parameter.parametersOf
@@ -81,7 +86,8 @@ class EditCommunityScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model = getScreenModel<EditCommunityMviModel>(parameters = { parametersOf(communityId) })
+        val model =
+            getScreenModel<EditCommunityMviModel>(parameters = { parametersOf(communityId) })
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
@@ -219,6 +225,7 @@ class EditCommunityScreen(
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
+                            bottom = Spacing.m,
                         )
                         .then(
                             if (settings.hideNavigationBarWhileScrolling) {
@@ -311,8 +318,8 @@ class EditCommunityScreen(
                     )
 
                     SettingsHeader(
-                        icon = Icons.Default.Shield,
-                        title = LocalStrings.current.settingsSectionNsfw,
+                        icon = Icons.Default.SettingsApplications,
+                        title = LocalStrings.current.navigationSettings,
                     )
 
                     SettingsSwitchRow(
@@ -328,9 +335,25 @@ class EditCommunityScreen(
                         value = uiState.postingRestrictedToMods,
                         onValueChanged =
                             rememberCallbackArgs(model) { value ->
-                                model.reduce(EditCommunityMviModel.Intent.ChangePostingRestrictedToMods(value))
+                                model.reduce(
+                                    EditCommunityMviModel.Intent.ChangePostingRestrictedToMods(
+                                        value,
+                                    ),
+                                )
                             },
                     )
+
+                    SettingsRow(
+                        title = LocalStrings.current.editCommunityItemVisibility,
+                        value = uiState.visibilityType.toReadableName(),
+                        onTap =
+                            rememberCallback {
+                                val sheet = CommunityVisibilityBottomSheet()
+                                navigationCoordinator.showBottomSheet(sheet)
+                            },
+                    )
+
+                    Spacer(modifier = Modifier.height(Spacing.m))
                 }
 
                 Box(

--- a/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/di/EditCommunityModule.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/editcommunity/di/EditCommunityModule.kt
@@ -12,6 +12,7 @@ val editCommunityModule =
                 identityRepository = get(),
                 communityRepository = get(),
                 postRepository = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/unit/managesubscriptions/build.gradle.kts
+++ b/unit/managesubscriptions/build.gradle.kts
@@ -58,6 +58,8 @@ kotlin {
                 implementation(projects.domain.identity)
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.repository)
+
+                implementation(projects.unit.editcommunity)
             }
         }
         val commonTest by getting {

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsMviModel.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsMviModel.kt
@@ -36,6 +36,7 @@ interface ManageSubscriptionsMviModel :
         val searchText: String = "",
         val canFetchMore: Boolean = true,
         val loading: Boolean = false,
+        val canCreateCommunity: Boolean = false,
     )
 
     sealed interface Effect {

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/ManageSubscriptionsScreen.kt
@@ -81,6 +81,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.persistence.di.getSettingsR
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.onClick
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallback
 import com.github.diegoberaldin.raccoonforlemmy.core.utils.compose.rememberCallbackArgs
+import com.github.diegoberaldin.raccoonforlemmy.unit.editcommunity.EditCommunityScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.multicommunity.detail.MultiCommunityScreen
 import com.github.diegoberaldin.raccoonforlemmy.unit.multicommunity.editor.MultiCommunityEditorScreen
 import kotlinx.coroutines.flow.launchIn
@@ -283,12 +284,46 @@ class ManageSubscriptionsScreen : Screen {
                         state = lazyListState,
                         verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
                     ) {
+                        if (uiState.canCreateCommunity) {
+                            // create community header
+                            item {
+                                Row(
+                                    modifier =
+                                        Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        modifier = Modifier.padding(vertical = Spacing.xs),
+                                        text = LocalStrings.current.actionCreateCommunity,
+                                        style = MaterialTheme.typography.titleMedium,
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                    )
+                                    Spacer(modifier = Modifier.weight(1f))
+                                    Icon(
+                                        modifier =
+                                            Modifier
+                                                .padding(horizontal = Spacing.xs)
+                                                .onClick(
+                                                    onClick = {
+                                                        navigatorCoordinator.pushScreen(
+                                                            EditCommunityScreen(),
+                                                        )
+                                                    },
+                                                ),
+                                        imageVector = Icons.Default.AddCircle,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onBackground,
+                                    )
+                                }
+                            }
+                        }
                         item {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 Text(
+                                    modifier = Modifier.padding(vertical = Spacing.xs),
                                     text = LocalStrings.current.manageSubscriptionsHeaderMulticommunities,
                                     style = MaterialTheme.typography.titleMedium,
                                     color = MaterialTheme.colorScheme.onBackground,
@@ -297,6 +332,7 @@ class ManageSubscriptionsScreen : Screen {
                                 Icon(
                                     modifier =
                                         Modifier
+                                            .padding(horizontal = Spacing.xs)
                                             .onClick(
                                                 onClick = {
                                                     navigatorCoordinator.pushScreen(
@@ -364,6 +400,7 @@ class ManageSubscriptionsScreen : Screen {
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 Text(
+                                    modifier = Modifier.padding(vertical = Spacing.xs),
                                     text = LocalStrings.current.manageSubscriptionsHeaderSubscriptions,
                                     style = MaterialTheme.typography.titleMedium,
                                     color = MaterialTheme.colorScheme.onBackground,
@@ -409,12 +446,18 @@ class ManageSubscriptionsScreen : Screen {
                                     rememberCallbackArgs(model) { optionId ->
                                         when (optionId) {
                                             OptionId.Unsubscribe -> {
-                                                model.reduce(ManageSubscriptionsMviModel.Intent.Unsubscribe(community.id))
+                                                model.reduce(
+                                                    ManageSubscriptionsMviModel.Intent.Unsubscribe(
+                                                        community.id,
+                                                    ),
+                                                )
                                             }
 
                                             OptionId.Favorite -> {
                                                 model.reduce(
-                                                    ManageSubscriptionsMviModel.Intent.ToggleFavorite(community.id),
+                                                    ManageSubscriptionsMviModel.Intent.ToggleFavorite(
+                                                        community.id,
+                                                    ),
                                                 )
                                             }
 
@@ -484,7 +527,11 @@ class ManageSubscriptionsScreen : Screen {
                 confirmButton = {
                     Button(
                         onClick = {
-                            model.reduce(ManageSubscriptionsMviModel.Intent.DeleteMultiCommunity(itemId))
+                            model.reduce(
+                                ManageSubscriptionsMviModel.Intent.DeleteMultiCommunity(
+                                    itemId,
+                                ),
+                            )
                             multiCommunityIdToDelete = null
                         },
                     ) {

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/di/ManageSubscriptionsModule.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/managesubscriptions/di/ManageSubscriptionsModule.kt
@@ -19,6 +19,7 @@ val manageSubscriptionsModule =
                 notificationCenter = get(),
                 settingsRepository = get(),
                 favoriteCommunityRepository = get(),
+                siteRepository = get(),
             )
         }
     }


### PR DESCRIPTION
If the current instance allows the creation of community to regular users or if the current user is an admin, it would be nice to have the possibility to create a new community on that instance.

Additionally, the dual method to delete a community should be created.