### PR TITLE
feat: notice for LocalOnly communities

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/IndicatorCallout.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/IndicatorCallout.kt
@@ -1,0 +1,28 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+
+@Composable
+fun IndicatorCallout(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+    ) {
+        Text(
+            modifier = Modifier.padding(Spacing.s),
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontFamily = FontFamily.Default,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
@@ -414,4 +414,5 @@ internal val ArStrings =
         override val editCommunityItemVisibility: String = "الرؤية"
         override val communityVisibilityLocalOnly: String = "المثيل المحلي فقط"
         override val communityVisibilityPublic: String = "عام"
+        override val noticeCommunityLocalOnly: String = "هذا المجتمع مرئي فقط في المثيل الحالي"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
@@ -421,4 +421,6 @@ internal val BgStrings =
         override val editCommunityItemVisibility: String = "Видимост"
         override val communityVisibilityLocalOnly: String = "само локален екземпляр"
         override val communityVisibilityPublic: String = "публичен"
+        override val noticeCommunityLocalOnly: String =
+            "Тази общност е видима само в рамките на текущия екземпляр"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
@@ -417,4 +417,6 @@ internal val CsStrings =
         override val editCommunityItemVisibility: String = "Viditelnost"
         override val communityVisibilityLocalOnly: String = "pouze místní instance"
         override val communityVisibilityPublic: String = "veřejnost"
+        override val noticeCommunityLocalOnly: String =
+            "Tato komunita je viditelná pouze v aktuální instanci"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
@@ -416,4 +416,6 @@ internal val DaStrings =
         override val editCommunityItemVisibility: String = "Sigtbarhed"
         override val communityVisibilityLocalOnly: String = "kun lokal instans"
         override val communityVisibilityPublic: String = "offentlig"
+        override val noticeCommunityLocalOnly: String =
+            "Dette fællesskab er kun synligt i den aktuelle forekomst"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
@@ -421,4 +421,6 @@ internal val DeStrings =
         override val editCommunityItemVisibility: String = "Sichtweite"
         override val communityVisibilityLocalOnly: String = "Nur lokale Instanz"
         override val communityVisibilityPublic: String = "öffentlich"
+        override val noticeCommunityLocalOnly: String =
+            "Diese Community ist nur innerhalb der aktuellen Instanz sichtbar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
@@ -424,4 +424,6 @@ internal val ElStrings =
         override val editCommunityItemVisibility: String = "Ορατότητα"
         override val communityVisibilityLocalOnly: String = "μόνο τοπική περίπτωση"
         override val communityVisibilityPublic: String = "δημόσιο"
+        override val noticeCommunityLocalOnly: String =
+            "Αυτή η κοινότητα είναι ορατή μόνο στην τρέχουσα παρουσία"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
@@ -414,4 +414,6 @@ internal val EnStrings =
         override val editCommunityItemVisibility: String = "Visibility"
         override val communityVisibilityLocalOnly: String = "local instance only"
         override val communityVisibilityPublic: String = "public"
+        override val noticeCommunityLocalOnly: String =
+            "This community is only visible within the current instance"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
@@ -413,4 +413,6 @@ internal val EoStrings =
         override val editCommunityItemVisibility: String = "Videbleco"
         override val communityVisibilityLocalOnly: String = "nur loka instanco"
         override val communityVisibilityPublic: String = "publika"
+        override val noticeCommunityLocalOnly: String =
+            "Ĉi tiu komunumo estas videbla nur ene de la nuna nodo"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
@@ -418,4 +418,6 @@ internal val EsStrings =
         override val editCommunityItemVisibility: String = "Visibilidad"
         override val communityVisibilityLocalOnly: String = "sólo instancia local"
         override val communityVisibilityPublic: String = "pública"
+        override val noticeCommunityLocalOnly: String =
+            "Esta comunidad sólo es visible dentro de la instancia actual"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
@@ -419,4 +419,6 @@ internal val EtStrings =
         override val editCommunityItemVisibility: String = "Nähtavus"
         override val communityVisibilityLocalOnly: String = "ainult kohalik eksemplar"
         override val communityVisibilityPublic: String = "avalik"
+        override val noticeCommunityLocalOnly: String =
+            "See kommuun on nähtav ainult praeguses eksemplaris"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
@@ -415,4 +415,6 @@ internal val FiStrings =
         override val editCommunityItemVisibility: String = "Näkyvyys"
         override val communityVisibilityLocalOnly: String = "vain paikallinen esimerkki"
         override val communityVisibilityPublic: String = "julkinen"
+        override val noticeCommunityLocalOnly: String =
+            "Tämä yhteisö näkyy vain nykyisessä ilmentymässä"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
@@ -423,4 +423,6 @@ internal val FrStrings =
         override val editCommunityItemVisibility: String = "Visibilité"
         override val communityVisibilityLocalOnly: String = "instance locale uniquement"
         override val communityVisibilityPublic: String = "publique"
+        override val noticeCommunityLocalOnly: String =
+            "Cette communauté n\'est visible que dans l\'instance actuelle"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
@@ -419,4 +419,6 @@ internal val GaStrings =
         override val editCommunityItemVisibility: String = "Infheictheacht"
         override val communityVisibilityLocalOnly: String = "shampla áitiúil amháin"
         override val communityVisibilityPublic: String = "poiblí"
+        override val noticeCommunityLocalOnly: String =
+            "Níl an pobal seo le feiceáil ach sa chás reatha"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
@@ -418,4 +418,6 @@ internal val HrStrings =
         override val editCommunityItemVisibility: String = "Vidljivost"
         override val communityVisibilityLocalOnly: String = "samo lokalna instanca"
         override val communityVisibilityPublic: String = "javnost"
+        override val noticeCommunityLocalOnly: String =
+            "Ova je zajednica vidljiva samo unutar trenutne instance"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
@@ -422,4 +422,6 @@ internal val HuStrings =
         override val editCommunityItemVisibility: String = "Láthatóság"
         override val communityVisibilityLocalOnly: String = "csak helyi példány"
         override val communityVisibilityPublic: String = "nyilvános"
+        override val noticeCommunityLocalOnly: String =
+            "Ez a közösség csak az aktuális példányon belül látható"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -419,4 +419,6 @@ internal val ItStrings =
         override val editCommunityItemVisibility: String = "Visibilità"
         override val communityVisibilityLocalOnly: String = "solo istanza locale"
         override val communityVisibilityPublic: String = "pubblica"
+        override val noticeCommunityLocalOnly: String =
+            "Questa comunità è visibile esclusivamente all'interno dell'istanza corrente"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
@@ -416,4 +416,6 @@ internal val LtStrings =
         override val editCommunityItemVisibility: String = "Matomumas"
         override val communityVisibilityLocalOnly: String = "tik vietinis pavyzdys"
         override val communityVisibilityPublic: String = "viešas"
+        override val noticeCommunityLocalOnly: String =
+            "Ši bendruomenė matoma tik dabartiniame egzemplioriuje"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
@@ -417,4 +417,6 @@ internal val LvStrings =
         override val editCommunityItemVisibility: String = "Redzamība"
         override val communityVisibilityLocalOnly: String = "tikai vietējais gadījums"
         override val communityVisibilityPublic: String = "publiski"
+        override val noticeCommunityLocalOnly: String =
+            "Šī kopiena ir redzama tikai pašreizējā instancē"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
@@ -418,4 +418,6 @@ internal val MtStrings =
         override val editCommunityItemVisibility: String = "Viżibilità"
         override val communityVisibilityLocalOnly: String = "istanza lokali biss"
         override val communityVisibilityPublic: String = "pubbliku"
+        override val noticeCommunityLocalOnly: String =
+            "Din il-komunità hija viżibbli biss fl-istanza attwali"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
@@ -419,4 +419,6 @@ internal val NlStrings =
         override val editCommunityItemVisibility: String = "Zichtbaarheid"
         override val communityVisibilityLocalOnly: String = "alleen lokale instantie"
         override val communityVisibilityPublic: String = "openbaar"
+        override val noticeCommunityLocalOnly: String =
+            "Deze community is alleen zichtbaar binnen het huidige exemplaar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
@@ -415,4 +415,6 @@ internal val NoStrings =
         override val editCommunityItemVisibility: String = "Synlighet"
         override val communityVisibilityLocalOnly: String = "kun lokal instans"
         override val communityVisibilityPublic: String = "offentlig"
+        override val noticeCommunityLocalOnly: String =
+            "Dette fellesskapet er bare synlig i gjeldende forekomst"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
@@ -418,4 +418,6 @@ internal val PlStrings =
         override val editCommunityItemVisibility: String = "Widoczność"
         override val communityVisibilityLocalOnly: String = "tylko instancja lokalna"
         override val communityVisibilityPublic: String = "publiczny"
+        override val noticeCommunityLocalOnly: String =
+            "Ta społeczność jest widoczna tylko w bieżącej instancji"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
@@ -417,4 +417,6 @@ internal val PtBrStrings =
         override val editCommunityItemVisibility: String = "Visibilidade"
         override val communityVisibilityLocalOnly: String = "apenas instância local"
         override val communityVisibilityPublic: String = "pública"
+        override val noticeCommunityLocalOnly: String =
+            "Esta comunidade só é visível na instância atual"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
@@ -418,4 +418,6 @@ internal val PtStrings =
         override val editCommunityItemVisibility: String = "Visibilidade"
         override val communityVisibilityLocalOnly: String = "apenas instância local"
         override val communityVisibilityPublic: String = "pública"
+        override val noticeCommunityLocalOnly: String =
+            "Esta comunidade só é visível na instância atual"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
@@ -417,4 +417,6 @@ internal val RoStrings =
         override val editCommunityItemVisibility: String = "Vizibilitate"
         override val communityVisibilityLocalOnly: String = "numai instanță locală"
         override val communityVisibilityPublic: String = "publică"
+        override val noticeCommunityLocalOnly: String =
+            "Această comunitate este vizibilă numai în instanța curentă"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
@@ -420,4 +420,6 @@ internal val RuStrings =
         override val editCommunityItemVisibility: String = "Видимость"
         override val communityVisibilityLocalOnly: String = "только локальный экземпляр"
         override val communityVisibilityPublic: String = "общественный"
+        override val noticeCommunityLocalOnly: String =
+            "Это сообщество видно только в текущем экземпляре"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
@@ -417,4 +417,6 @@ internal val SeStrings =
         override val editCommunityItemVisibility: String = "Synlighet"
         override val communityVisibilityLocalOnly: String = "endast lokal instans"
         override val communityVisibilityPublic: String = "offentlig"
+        override val noticeCommunityLocalOnly: String =
+            "Denna grupp är endast synlig inom den aktuella instansen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
@@ -419,4 +419,6 @@ internal val SkStrings =
         override val editCommunityItemVisibility: String = "Viditeľnosť"
         override val communityVisibilityLocalOnly: String = "iba lokálna inštancia"
         override val communityVisibilityPublic: String = "verejnosti"
+        override val noticeCommunityLocalOnly: String =
+            "Táto komunita je viditeľná iba v rámci aktuálnej inštancie"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
@@ -417,4 +417,6 @@ internal val SlStrings =
         override val editCommunityItemVisibility: String = "Vidnost"
         override val communityVisibilityLocalOnly: String = "samo lokalni primerek"
         override val communityVisibilityPublic: String = "javnosti"
+        override val noticeCommunityLocalOnly: String =
+            "Ta skupnost je vidna samo znotraj trenutne instance"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
@@ -419,4 +419,6 @@ internal val SqStrings =
         override val editCommunityItemVisibility: String = "Dukshmëria"
         override val communityVisibilityLocalOnly: String = "vetëm për shembull lokal"
         override val communityVisibilityPublic: String = "publike"
+        override val noticeCommunityLocalOnly: String =
+            "Ky komunitet është i dukshëm vetëm brenda shembullit aktual"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
@@ -419,4 +419,6 @@ internal val SrStrings =
         override val editCommunityItemVisibility: String = "Видљивост"
         override val communityVisibilityLocalOnly: String = "само локална инстанца"
         override val communityVisibilityPublic: String = "јавности"
+        override val noticeCommunityLocalOnly: String =
+            "Ова заједница је видљива само у оквиру тренутне инстанце"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -413,6 +413,7 @@ interface Strings {
     val editCommunityItemVisibility: String
     val communityVisibilityLocalOnly: String
     val communityVisibilityPublic: String
+    val noticeCommunityLocalOnly: String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
@@ -414,4 +414,6 @@ internal val TokStrings =
         override val editCommunityItemVisibility: String = "nasin lukin"
         override val communityVisibilityLocalOnly: String = "tawa ilo nanpa ni taso"
         override val communityVisibilityPublic: String = "tawa ale"
+        override val noticeCommunityLocalOnly: String =
+            "kulupu ni li ken lukin lon ilo nanpa ni taso"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
@@ -418,4 +418,6 @@ internal val TrStrings =
         override val editCommunityItemVisibility: String = "Görünürlük"
         override val communityVisibilityLocalOnly: String = "yalnızca yerel örnek"
         override val communityVisibilityPublic: String = "halk"
+        override val noticeCommunityLocalOnly: String =
+            "Bu topluluk yalnızca mevcut örnekte görülebilir"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
@@ -419,4 +419,6 @@ internal val UkStrings =
         override val editCommunityItemVisibility: String = "Видимість"
         override val communityVisibilityLocalOnly: String = "лише локальний екземпляр"
         override val communityVisibilityPublic: String = "громадськість"
+        override val noticeCommunityLocalOnly: String =
+            "Цю спільноту можна побачити лише в поточному екземплярі"
     }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
@@ -12,6 +12,10 @@ import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.UserModel
 
+sealed interface CommunityNotices {
+    data object LocalOnlyVisibility : CommunityNotices
+}
+
 @Stable
 interface CommunityDetailMviModel :
     MviModel<CommunityDetailMviModel.Intent, CommunityDetailMviModel.UiState, CommunityDetailMviModel.Effect>,
@@ -111,6 +115,7 @@ interface CommunityDetailMviModel :
         val downVoteEnabled: Boolean = true,
         val currentPreferredLanguageId: Long? = null,
         val availableLanguages: List<LanguageModel> = emptyList(),
+        val notices: List<CommunityNotices> = emptyList(),
     )
 
     sealed interface Effect {

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -103,6 +103,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.SwipeAc
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.SwipeActionCard
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.CommunityHeader
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.IndicatorCallout
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.PostCard
@@ -851,6 +852,30 @@ class CommunityDetailScreen(
                                                 navigationCoordinator.openSideMenu(screen)
                                             },
                                     )
+                                }
+                            }
+                            item {
+                                if (!uiState.searching && uiState.notices.isNotEmpty()) {
+                                    Column(
+                                        modifier =
+                                            Modifier.padding(
+                                                start = Spacing.s,
+                                                end = Spacing.s,
+                                                bottom = Spacing.s,
+                                            ),
+                                        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                                    ) {
+                                        for (notice in uiState.notices) {
+                                            IndicatorCallout(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                text =
+                                                    when (notice) {
+                                                        CommunityNotices.LocalOnlyVisibility ->
+                                                            LocalStrings.current.noticeCommunityLocalOnly
+                                                    },
+                                            )
+                                        }
+                                    }
                                 }
                             }
                             if (uiState.posts.isEmpty() && uiState.initial) {

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -21,6 +21,7 @@ import com.github.diegoberaldin.raccoonforlemmy.core.utils.zombiemode.ZombieMode
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.ApiConfigurationRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityModel
+import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.CommunityVisibilityType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.SortType
 import com.github.diegoberaldin.raccoonforlemmy.domain.lemmy.data.containsId
@@ -392,12 +393,20 @@ class CommunityDetailViewModel(
                 id = currentState.community.id,
             )
         if (refreshedCommunity != null) {
+            val newNotices = currentState.notices.toMutableList()
+            if (
+                refreshedCommunity.visibilityType == CommunityVisibilityType.LocalOnly &&
+                newNotices.none { it == CommunityNotices.LocalOnlyVisibility }
+            ) {
+                newNotices += CommunityNotices.LocalOnlyVisibility
+            }
             updateState {
                 it.copy(
                     community = refreshedCommunity,
                     moderators = moderators,
                     loading = false,
                     zombieModeActive = false,
+                    notices = newNotices,
                 )
             }
         }


### PR DESCRIPTION
This adds a notice in the community detail when users are visiting a local-only community (Lemmy > 0.19.4).

Epic reference: #946.