### PR TITLE
chore: bump multiplatform-markdown-renderer from 0.20.0-coil2 to 0.21.0

### DIFF
--- a/core/markdown/build.gradle.kts
+++ b/core/markdown/build.gradle.kts
@@ -28,6 +28,11 @@ kotlin {
     }
 
     sourceSets {
+        val androidMain by getting {
+            dependencies {
+                implementation(libs.multiplatform.markdown.renderer.coil2)
+            }
+        }
         val commonMain by getting {
             dependencies {
                 implementation(compose.runtime)

--- a/core/markdown/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/ProvideImageTransformer.kt
+++ b/core/markdown/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/ProvideImageTransformer.kt
@@ -1,0 +1,6 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.markdown
+
+import com.mikepenz.markdown.coil2.Coil2ImageTransformerImpl
+import com.mikepenz.markdown.model.ImageTransformer
+
+actual fun provideImageTransformer(): ImageTransformer = Coil2ImageTransformerImpl

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownWrapper.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/CustomMarkdownWrapper.kt
@@ -156,6 +156,7 @@ fun CustomMarkdownWrapper(
             typography = typography,
             padding = padding,
             components = components,
+            imageTransformer = provideImageTransformer(),
         )
     }
 }

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/ProvideImageTransformer.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/ProvideImageTransformer.kt
@@ -1,0 +1,5 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.markdown
+
+import com.mikepenz.markdown.model.ImageTransformer
+
+expect fun provideImageTransformer(): ImageTransformer

--- a/core/markdown/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/ProvideImageTransformer.kt
+++ b/core/markdown/src/iosMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/ProvideImageTransformer.kt
@@ -1,0 +1,6 @@
+package com.github.diegoberaldin.raccoonforlemmy.core.markdown
+
+import com.mikepenz.markdown.model.ImageTransformer
+import com.mikepenz.markdown.model.NoOpImageTransformerImpl
+
+actual fun provideImageTransformer(): ImageTransformer = NoOpImageTransformerImpl()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ ktorfit = "2.0.0-rc01"
 lyricist = "1.7.0"
 materialKolor = "1.6.1"
 mockk = "1.13.11"
-multiplatform-markdown-renderer = "0.20.0-coil2"
+multiplatform-markdown-renderer = "0.21.0"
 multiplatform-settings = "1.1.1"
 reorderable = "2.1.1"
 stately = "2.0.7"
@@ -52,6 +52,7 @@ coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 
 multiplatform-markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "multiplatform-markdown-renderer" }
 multiplatform-markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "multiplatform-markdown-renderer" }
+multiplatform-markdown-renderer-coil2 = { module = "com.mikepenz:multiplatform-markdown-renderer-coil2", version.ref = "multiplatform-markdown-renderer" }
 
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 
@@ -102,7 +103,6 @@ reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reo
 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
-core = { group = "androidx.core", name = "core", version.ref = "androidx-core" }
 
 [plugins]
 


### PR DESCRIPTION
This PR manually updates MikePenz's multiplatform markdown renderer to version 0.21.0 because it requires manual resolution and the dependabot would have created an invalid PR.