### PR TITLE
fix: comment navigation

### DIFF
--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -1886,9 +1886,7 @@ class PostDetailScreen(
                                     .onClick(
                                         onClick =
                                             rememberCallback(lazyListState) {
-                                                val idx =
-                                                    lazyListState.firstVisibleItemIndex +
-                                                        lazyListState.layoutInfo.visibleItemsInfo.size
+                                                val idx = lazyListState.firstVisibleItemIndex
                                                 model.reduce(
                                                     PostDetailMviModel.Intent.NavigateNextComment(idx),
                                                 )


### PR DESCRIPTION
This PR fixes a series of bugs related to comment navigation:
- the initial index was not calculated correctly because it didn't account for the initial item (the post card) which caused indices to be off-by-one
- the navigation to next comment skipped all the comments visible in the current screen and started from the bottom one, resulting in big "leaps" when navigating to the next one.