### PR TITLE
feat: edit swipe action

### DIFF
--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/ActionOnSwipe.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/ActionOnSwipe.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.ArrowCircleDown
 import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MarkChatUnread
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -36,6 +37,8 @@ sealed interface ActionOnSwipe {
     data object Save : ActionOnSwipe
 
     data object ToggleRead : ActionOnSwipe
+
+    data object Edit : ActionOnSwipe
 
     companion object {
         val DEFAULT_SWIPE_TO_START_POSTS =
@@ -83,6 +86,7 @@ internal fun ActionOnSwipe.toInt(): Int =
         ActionOnSwipe.Reply -> 3
         ActionOnSwipe.Save -> 4
         ActionOnSwipe.ToggleRead -> 5
+        ActionOnSwipe.Edit -> 6
     }
 
 internal fun Int.toActionOnSwipe(): ActionOnSwipe =
@@ -92,6 +96,7 @@ internal fun Int.toActionOnSwipe(): ActionOnSwipe =
         3 -> ActionOnSwipe.Reply
         4 -> ActionOnSwipe.Save
         5 -> ActionOnSwipe.ToggleRead
+        6 -> ActionOnSwipe.Edit
         else -> ActionOnSwipe.None
     }
 
@@ -104,6 +109,7 @@ fun ActionOnSwipe.toReadableName(): String =
         ActionOnSwipe.Save -> LocalStrings.current.actionSave
         ActionOnSwipe.ToggleRead -> LocalStrings.current.actionToggleRead
         ActionOnSwipe.UpVote -> LocalStrings.current.actionUpvote
+        ActionOnSwipe.Edit -> LocalStrings.current.postActionEdit
     }
 
 @Composable
@@ -115,4 +121,5 @@ fun ActionOnSwipe.toIcon(): ImageVector? =
         ActionOnSwipe.Save -> Icons.Default.Bookmark
         ActionOnSwipe.ToggleRead -> Icons.Default.MarkChatUnread
         ActionOnSwipe.UpVote -> Icons.Default.ArrowCircleUp
+        ActionOnSwipe.Edit -> Icons.Default.Edit
     }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
@@ -216,46 +217,47 @@ class CommunityDetailScreen(
         var deleteConfirmDialogOpen by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
-            model.effects.onEach { effect ->
-                when (effect) {
-                    is CommunityDetailMviModel.Effect.Error -> {
-                        snackbarHostState.showSnackbar(effect.message ?: genericError)
-                    }
-
-                    CommunityDetailMviModel.Effect.Success -> {
-                        snackbarHostState.showSnackbar(successMessage)
-                    }
-
-                    CommunityDetailMviModel.Effect.BackToTop -> {
-                        runCatching {
-                            lazyListState.scrollToItem(0)
-                            topAppBarState.heightOffset = 0f
-                            topAppBarState.contentOffset = 0f
+            model.effects
+                .onEach { effect ->
+                    when (effect) {
+                        is CommunityDetailMviModel.Effect.Error -> {
+                            snackbarHostState.showSnackbar(effect.message ?: genericError)
                         }
-                    }
 
-                    is CommunityDetailMviModel.Effect.ZombieModeTick -> {
-                        runCatching {
-                            if (effect.index >= 0) {
-                                lazyListState.animateScrollBy(
-                                    value = settings.zombieModeScrollAmount,
-                                    animationSpec = tween(350),
-                                )
+                        CommunityDetailMviModel.Effect.Success -> {
+                            snackbarHostState.showSnackbar(successMessage)
+                        }
+
+                        CommunityDetailMviModel.Effect.BackToTop -> {
+                            runCatching {
+                                lazyListState.scrollToItem(0)
+                                topAppBarState.heightOffset = 0f
+                                topAppBarState.contentOffset = 0f
                             }
                         }
-                    }
 
-                    is CommunityDetailMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(text = effect.text))
-                    }
+                        is CommunityDetailMviModel.Effect.ZombieModeTick -> {
+                            runCatching {
+                                if (effect.index >= 0) {
+                                    lazyListState.animateScrollBy(
+                                        value = settings.zombieModeScrollAmount,
+                                        animationSpec = tween(350),
+                                    )
+                                }
+                            }
+                        }
 
-                    is CommunityDetailMviModel.Effect.Failure -> {
-                        snackbarHostState.showSnackbar(effect.message ?: genericError)
-                    }
+                        is CommunityDetailMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(text = effect.text))
+                        }
 
-                    CommunityDetailMviModel.Effect.Back -> navigationCoordinator.popScreen()
-                }
-            }.launchIn(this)
+                        is CommunityDetailMviModel.Effect.Failure -> {
+                            snackbarHostState.showSnackbar(effect.message ?: genericError)
+                        }
+
+                        CommunityDetailMviModel.Effect.Back -> navigationCoordinator.popScreen()
+                    }
+                }.launchIn(this)
         }
         LaunchedEffect(uiState.zombieModeActive) {
             if (uiState.zombieModeActive) {
@@ -265,11 +267,12 @@ class CommunityDetailScreen(
             }
         }
         LaunchedEffect(navigationCoordinator) {
-            navigationCoordinator.globalMessage.onEach { message ->
-                snackbarHostState.showSnackbar(
-                    message = message,
-                )
-            }.launchIn(this)
+            navigationCoordinator.globalMessage
+                .onEach { message ->
+                    snackbarHostState.showSnackbar(
+                        message = message,
+                    )
+                }.launchIn(this)
         }
 
         Scaffold(
@@ -277,16 +280,17 @@ class CommunityDetailScreen(
             topBar = {
                 val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
                 var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }.onEach {
-                    topInset =
-                        (maxTopInset * (1 - it)).let { insetValue ->
-                            if (uiState.searching) {
-                                insetValue.coerceAtLeast(statusBarInset.toFloat())
-                            } else {
-                                insetValue
+                snapshotFlow { topAppBarState.collapsedFraction }
+                    .onEach {
+                        topInset =
+                            (maxTopInset * (1 - it)).let { insetValue ->
+                                if (uiState.searching) {
+                                    insetValue.coerceAtLeast(statusBarInset.toFloat())
+                                } else {
+                                    insetValue
+                                }
                             }
-                        }
-                }.launchIn(scope)
+                    }.launchIn(scope)
 
                 TopAppBar(
                     windowInsets =
@@ -477,13 +481,14 @@ class CommunityDetailScreen(
                             var optionsOffset by remember { mutableStateOf(Offset.Zero) }
                             Image(
                                 modifier =
-                                    Modifier.onGloballyPositioned {
-                                        optionsOffset = it.positionInParent()
-                                    }.onClick(
-                                        onClick = {
-                                            optionsExpanded = true
-                                        },
-                                    ),
+                                    Modifier
+                                        .onGloballyPositioned {
+                                            optionsOffset = it.positionInParent()
+                                        }.onClick(
+                                            onClick = {
+                                                optionsExpanded = true
+                                            },
+                                        ),
                                 imageVector = Icons.Default.MoreVert,
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
@@ -816,8 +821,7 @@ class CommunityDetailScreen(
                                     } else {
                                         Modifier
                                     },
-                                )
-                                .nestedScroll(fabNestedScrollConnection)
+                                ).nestedScroll(fabNestedScrollConnection)
                                 .nestedScroll(keyboardScrollConnection)
                                 .pullRefresh(pullRefreshState),
                     ) {
@@ -904,7 +908,7 @@ class CommunityDetailScreen(
                                 }
 
                                 @Composable
-                                fun List<ActionOnSwipe>.toSwipeActions(): List<SwipeAction> =
+                                fun List<ActionOnSwipe>.toSwipeActions(canEdit: Boolean): List<SwipeAction> =
                                     mapNotNull {
                                         when (it) {
                                             ActionOnSwipe.UpVote ->
@@ -993,6 +997,26 @@ class CommunityDetailScreen(
                                                         },
                                                 )
 
+                                            ActionOnSwipe.Edit ->
+                                                if (!canEdit) {
+                                                    null
+                                                } else {
+                                                    SwipeAction(
+                                                        swipeContent = {
+                                                            Icon(
+                                                                imageVector = Icons.Default.Edit,
+                                                                contentDescription = null,
+                                                                tint = Color.White,
+                                                            )
+                                                        },
+                                                        backgroundColor = MaterialTheme.colorScheme.tertiary,
+                                                        onTriggered =
+                                                            rememberCallback {
+                                                                detailOpener.openCreatePost(editedPost = post)
+                                                            },
+                                                    )
+                                                }
+
                                             else -> null
                                         }
                                     }
@@ -1006,13 +1030,17 @@ class CommunityDetailScreen(
                                         },
                                     swipeToStartActions =
                                         if (uiState.isLogged && !isOnOtherInstance) {
-                                            uiState.actionsOnSwipeToStartPosts.toSwipeActions()
+                                            uiState.actionsOnSwipeToStartPosts.toSwipeActions(
+                                                canEdit = post.creator?.id == uiState.currentUserId,
+                                            )
                                         } else {
                                             emptyList()
                                         },
                                     swipeToEndActions =
                                         if (uiState.isLogged && !isOnOtherInstance) {
-                                            uiState.actionsOnSwipeToEndPosts.toSwipeActions()
+                                            uiState.actionsOnSwipeToEndPosts.toSwipeActions(
+                                                canEdit = post.creator?.id == uiState.currentUserId,
+                                            )
                                         } else {
                                             emptyList()
                                         },
@@ -1438,7 +1466,8 @@ class CommunityDetailScreen(
                                     } else {
                                         Row(
                                             modifier =
-                                                Modifier.fillMaxWidth()
+                                                Modifier
+                                                    .fillMaxWidth()
                                                     .padding(top = Spacing.s),
                                             horizontalArrangement = Arrangement.Center,
                                             verticalAlignment = Alignment.CenterVertically,

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
@@ -104,8 +104,7 @@ class ConfigureSwipeActionsScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        )
-                        .then(
+                        ).then(
                             if (settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                             } else {
@@ -580,6 +579,10 @@ class ConfigureSwipeActionsScreen : Screen {
                                 navigationCoordinator.showBottomSheet(sheet)
                             }
                         }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxxl))
                     }
                 }
             }

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsViewModel.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsViewModel.kt
@@ -21,15 +21,16 @@ class ConfigureSwipeActionsViewModel(
     private val identityRepository: IdentityRepository,
     private val siteRepository: SiteRepository,
     private val notificationCenter: NotificationCenter,
-) : ConfigureSwipeActionsMviModel,
-    DefaultMviModel<ConfigureSwipeActionsMviModel.Intent, ConfigureSwipeActionsMviModel.UiState, ConfigureSwipeActionsMviModel.Effect>(
+) : DefaultMviModel<ConfigureSwipeActionsMviModel.Intent, ConfigureSwipeActionsMviModel.UiState, ConfigureSwipeActionsMviModel.Effect>(
         initialState = ConfigureSwipeActionsMviModel.UiState(),
-    ) {
+    ),
+    ConfigureSwipeActionsMviModel {
     init {
         screenModelScope.launch {
             val downVoteEnabled = siteRepository.isDownVoteEnabled(identityRepository.authToken.value)
             updateState { it.copy(downVoteEnabled = downVoteEnabled) }
-            notificationCenter.subscribe(NotificationCenterEvent.ActionsOnSwipeSelected::class)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.ActionsOnSwipeSelected::class)
                 .onEach { evt ->
                     when (evt.target) {
                         ActionOnSwipeTarget.Posts ->
@@ -493,6 +494,7 @@ class ConfigureSwipeActionsViewModel(
             buildSet {
                 this += ActionOnSwipe.DEFAULT_SWIPE_TO_START_POSTS
                 this += ActionOnSwipe.DEFAULT_SWIPE_TO_END_POSTS
+                this += ActionOnSwipe.Edit
                 if (preventActionsOnBothSides) {
                     this -= currentState.actionsOnSwipeToStartPosts.toSet()
                     this -= currentState.actionsOnSwipeToEndPosts.toSet()
@@ -502,6 +504,7 @@ class ConfigureSwipeActionsViewModel(
             buildSet {
                 this += ActionOnSwipe.DEFAULT_SWIPE_TO_START_COMMENTS
                 this += ActionOnSwipe.DEFAULT_SWIPE_TO_END_COMMENTS
+                this += ActionOnSwipe.Edit
                 if (preventActionsOnBothSides) {
                     this -= currentState.actionsOnSwipeToStartComments.toSet()
                     this -= currentState.actionsOnSwipeToEndComments.toSet()

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.ArrowCircleDown
 import androidx.compose.material.icons.filled.ArrowCircleUp
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
@@ -1004,7 +1005,7 @@ class PostDetailScreen(
                                         },
                                     ) {
                                         @Composable
-                                        fun List<ActionOnSwipe>.toSwipeActions(): List<SwipeAction> =
+                                        fun List<ActionOnSwipe>.toSwipeActions(canEdit: Boolean): List<SwipeAction> =
                                             mapNotNull {
                                                 when (it) {
                                                     ActionOnSwipe.UpVote ->
@@ -1098,6 +1099,33 @@ class PostDetailScreen(
                                                                 },
                                                         )
 
+                                                    ActionOnSwipe.Edit ->
+                                                        if (!canEdit) {
+                                                            null
+                                                        } else {
+                                                            SwipeAction(
+                                                                swipeContent = {
+                                                                    Icon(
+                                                                        imageVector = Icons.Default.Edit,
+                                                                        contentDescription = null,
+                                                                        tint = Color.White,
+                                                                    )
+                                                                },
+                                                                backgroundColor = MaterialTheme.colorScheme.tertiary,
+                                                                onTriggered =
+                                                                    rememberCallback {
+                                                                        detailOpener.openReply(
+                                                                            originalPost = PostModel(id = comment.postId),
+                                                                            originalComment =
+                                                                                comment.parentId?.let { parentId ->
+                                                                                    CommentModel(id = parentId)
+                                                                                },
+                                                                            editedComment = comment,
+                                                                        )
+                                                                    },
+                                                            )
+                                                        }
+
                                                     else -> null
                                                 }
                                             }
@@ -1112,13 +1140,17 @@ class PostDetailScreen(
                                                     },
                                                 swipeToStartActions =
                                                     if (uiState.isLogged && !isOnOtherInstance) {
-                                                        uiState.actionsOnSwipeToStartComments.toSwipeActions()
+                                                        uiState.actionsOnSwipeToStartComments.toSwipeActions(
+                                                            canEdit = comment.creator?.id == uiState.currentUserId,
+                                                        )
                                                     } else {
                                                         emptyList()
                                                     },
                                                 swipeToEndActions =
                                                     if (uiState.isLogged && !isOnOtherInstance) {
-                                                        uiState.actionsOnSwipeToEndComments.toSwipeActions()
+                                                        uiState.actionsOnSwipeToEndComments.toSwipeActions(
+                                                            canEdit = comment.creator?.id == uiState.currentUserId,
+                                                        )
                                                     } else {
                                                         emptyList()
                                                     },


### PR DESCRIPTION
This PR adds the "Edit" option to the swipe action list for posts and comments. The action should be available only if the author of such items is the current user.