### PR TITLE
fix: workaround for dollar sign in Markdown

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
@@ -18,11 +18,13 @@ internal fun ASTNode.findChildOfTypeRecursive(type: IElementType): ASTNode? {
 }
 
 internal fun String.sanitize(): String =
-    this.removeEntities()
+    this
+        .removeEntities()
         .spoilerFixUp()
         .quoteFixUp()
         .expandLemmyHandles()
         .cleanupEscapes()
+        .dollarSignFixUp()
         .emptyLinkFixup()
 
 private fun String.removeEntities(): String =
@@ -80,9 +82,12 @@ private fun String.quoteFixUp(): String =
         finalLines.joinToString("\n")
     }
 
-private fun String.expandLemmyHandles(): String =
-    LemmyLinkRegex.lemmyHandle.replace(this, "[$1@$2](!$1@$2)")
+private fun String.expandLemmyHandles(): String = LemmyLinkRegex.lemmyHandle.replace(this, "[$1@$2](!$1@$2)")
 
 private fun String.cleanupEscapes(): String = replace("\\#", "#")
+
+private fun String.dollarSignFixUp(): String =
+    // due to a bug in how the renderer builds annotated strings, replace with full width dollar sign
+    replace("$", "\uff04")
 
 private fun String.emptyLinkFixup(): String = replace("[]()", "")


### PR DESCRIPTION
This PR replaces `U+0024` characters with `U+FF04` (full-width dollar sign) to avoid a bug in how annotated strings are built inside the Markdown rendering library.