### PR TITLE
fix: workaround for images after a newline

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Regexes.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Regexes.kt
@@ -17,4 +17,5 @@ internal object LemmyLinkRegex {
 
 internal object ImageRegex {
     val image = Regex("!\\[[^]]*]\\((?<url>.*?)\\)")
+    val imageNotAfter2Newlines = Regex("(?<before>[^\n])\n(?<image>!\\[[^]]*]\\(.*?\\))")
 }

--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
@@ -26,6 +26,7 @@ internal fun String.sanitize(): String =
         .cleanupEscapes()
         .dollarSignFixUp()
         .emptyLinkFixup()
+        .imageBeforeFixup()
 
 private fun String.removeEntities(): String =
     replace("&amp;", "&")
@@ -91,3 +92,8 @@ private fun String.dollarSignFixUp(): String =
     replace("$", "\uff04")
 
 private fun String.emptyLinkFixup(): String = replace("[]()", "")
+
+private fun String.imageBeforeFixup(): String =
+    // due to a bug in the renderer, images after a new line must be on a paragraph on their own,
+    // so an additional newline must be inserted (they are nor inline nor a block otherwise)
+    ImageRegex.imageNotAfter2Newlines.replace(this, "$1\n\n$2")


### PR DESCRIPTION
There is another weird bug in the renderer due to which images after a newline are neither inline nor treated as a block on their own, and instead overlap each other (and have the wrong height).

This PR introduces a quick workaround for that.