### PR TITLE
feat: restore deleted post and comments

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
@@ -95,17 +96,19 @@ fun CommentCard(
     ) {
         Box(
             modifier =
-                Modifier.onClick(
-                    onClick = onClick ?: {},
-                    onDoubleClick = onDoubleClick ?: {},
-                ).padding(
-                    start =
-                        indentAmount.takeIf {
-                            it > 0 && comment.depth > 0
-                        }?.let {
-                            (it * comment.depth).dp + Spacing.xxxs
-                        } ?: 0.dp,
-                ),
+                Modifier
+                    .onClick(
+                        onClick = onClick ?: {},
+                        onDoubleClick = onDoubleClick ?: {},
+                    ).padding(
+                        start =
+                            indentAmount
+                                .takeIf {
+                                    it > 0 && comment.depth > 0
+                                }?.let {
+                                    (it * comment.depth).dp + Spacing.xxxs
+                                } ?: 0.dp,
+                    ),
         ) {
             Column(
                 modifier =
@@ -144,6 +147,14 @@ fun CommentCard(
                 if (comment.removed) {
                     Text(
                         text = LocalStrings.current.messageContentRemoved,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
+                    )
+                } else if (comment.deleted) {
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = LocalStrings.current.messageContentDeleted,
+                        textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
                     )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/Options.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/Options.kt
@@ -5,7 +5,9 @@ data class Option(
     val text: String,
 )
 
-sealed class OptionId(val value: Int) {
+sealed class OptionId(
+    val value: Int,
+) {
     data object Share : OptionId(0)
 
     data object Hide : OptionId(1)
@@ -65,4 +67,6 @@ sealed class OptionId(val value: Int) {
     data object Unsubscribe : OptionId(28)
 
     data object PurgeCreator : OptionId(29)
+
+    data object Restore : OptionId(30)
 }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,6 +29,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.PostLayout
@@ -90,26 +92,25 @@ fun PostCard(
     val markRead = post.read && fadeRead
     Box(
         modifier =
-            modifier.then(
-                if (postLayout == PostLayout.Card) {
-                    Modifier
-                        .padding(horizontal = Spacing.xs)
-                        .shadow(
-                            elevation = 5.dp,
-                            shape = RoundedCornerShape(CornerSize.l),
-                        )
-                        .clip(RoundedCornerShape(CornerSize.l))
-                        .background(
-                            color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
-                        )
-                        .padding(vertical = Spacing.s)
-                } else {
-                    Modifier
-                },
-            ).onClick(
-                onClick = onClick ?: {},
-                onDoubleClick = onDoubleClick ?: {},
-            ),
+            modifier
+                .then(
+                    if (postLayout == PostLayout.Card) {
+                        Modifier
+                            .padding(horizontal = Spacing.xs)
+                            .shadow(
+                                elevation = 5.dp,
+                                shape = RoundedCornerShape(CornerSize.l),
+                            ).clip(RoundedCornerShape(CornerSize.l))
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
+                            ).padding(vertical = Spacing.s)
+                    } else {
+                        Modifier
+                    },
+                ).onClick(
+                    onClick = onClick ?: {},
+                    onDoubleClick = onDoubleClick ?: {},
+                ),
     ) {
         if (postLayout != PostLayout.Compact) {
             ExtendedPost(
@@ -219,7 +220,10 @@ private fun CompactPost(
     val customTabsHelper = remember { getCustomTabsHelper() }
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val postLinkUrl =
-        post.url.orEmpty().takeIf { !it.looksLikeAnImage && !it.looksLikeAVideo }.orEmpty()
+        post.url
+            .orEmpty()
+            .takeIf { !it.looksLikeAnImage && !it.looksLikeAVideo }
+            .orEmpty()
 
     Column(
         modifier =
@@ -268,97 +272,106 @@ private fun CompactPost(
             verticalAlignment = Alignment.Top,
             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
-            CustomizedContent(ContentFontClass.Title) {
-                PostCardTitle(
-                    modifier = Modifier.weight(0.75f),
-                    text = post.title,
-                    autoLoadImages = autoLoadImages,
-                    markRead = markRead,
-                    onClick = onClick,
-                    onOpenCommunity = onOpenCommunity,
-                    onOpenUser = onOpenCreator,
-                    onOpenPost = onOpenPost,
-                    onOpenImage = onOpenImage,
-                    onDoubleClick = onDoubleClick,
-                    onOpenWeb = onOpenWeb,
-                    onLongClick = {
-                        optionsMenuOpen.value = true
-                    },
-                )
-            }
-
-            if (post.videoUrl.isNotEmpty()) {
-                PostCardVideo(
-                    modifier =
-                        Modifier
-                            .weight(0.25f)
-                            .padding(vertical = Spacing.xxs),
-                    url = post.videoUrl,
-                    blurred = blurNsfw && post.nsfw,
-                    autoLoadImages = autoLoadImages,
-                    onOpen =
-                        rememberCallback {
-                            if (postLinkUrl.isNotEmpty()) {
-                                navigationCoordinator.handleUrl(
-                                    url = postLinkUrl,
-                                    openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                    uriHandler = uriHandler,
-                                    customTabsHelper = customTabsHelper,
-                                    onOpenWeb = onOpenWeb,
-                                    onOpenCommunity = onOpenCommunity,
-                                    onOpenPost = onOpenPost,
-                                    onOpenUser = onOpenCreator,
-                                )
-                            } else {
-                                onClick?.invoke()
-                            }
-                        },
+            if (post.deleted) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = LocalStrings.current.messageContentDeleted,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
                 )
             } else {
-                PostCardImage(
-                    modifier =
-                        Modifier
-                            .weight(0.25f)
-                            .then(
-                                if (fullHeightImage) {
-                                    Modifier
-                                } else {
-                                    Modifier.aspectRatio(1f)
-                                },
-                            )
-                            .padding(vertical = Spacing.xs)
-                            .clip(RoundedCornerShape(CornerSize.s)),
-                    minHeight = Dp.Unspecified,
-                    maxHeight = Dp.Unspecified,
-                    imageUrl = post.imageUrl,
-                    autoLoadImages = autoLoadImages,
-                    loadButtonContent = @Composable {
-                        Icon(imageVector = Icons.Default.Download, contentDescription = null)
-                    },
-                    blurred = blurNsfw && post.nsfw,
-                    onImageClick =
-                        rememberCallbackArgs { url ->
-                            if (postLinkUrl.isNotEmpty()) {
-                                navigationCoordinator.handleUrl(
-                                    url = postLinkUrl,
-                                    openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                    uriHandler = uriHandler,
-                                    customTabsHelper = customTabsHelper,
-                                    onOpenWeb = onOpenWeb,
-                                    onOpenCommunity = onOpenCommunity,
-                                    onOpenPost = onOpenPost,
-                                    onOpenUser = onOpenCreator,
-                                )
-                            } else {
-                                onOpenImage?.invoke(url)
-                            }
-                        },
-                    onDoubleClick = onDoubleClick,
-                    onLongClick =
-                        rememberCallback {
+                CustomizedContent(ContentFontClass.Title) {
+                    PostCardTitle(
+                        modifier = Modifier.weight(0.75f),
+                        text = post.title,
+                        autoLoadImages = autoLoadImages,
+                        markRead = markRead,
+                        onClick = onClick,
+                        onOpenCommunity = onOpenCommunity,
+                        onOpenUser = onOpenCreator,
+                        onOpenPost = onOpenPost,
+                        onOpenImage = onOpenImage,
+                        onDoubleClick = onDoubleClick,
+                        onOpenWeb = onOpenWeb,
+                        onLongClick = {
                             optionsMenuOpen.value = true
                         },
-                )
+                    )
+                }
+
+                if (post.videoUrl.isNotEmpty()) {
+                    PostCardVideo(
+                        modifier =
+                            Modifier
+                                .weight(0.25f)
+                                .padding(vertical = Spacing.xxs),
+                        url = post.videoUrl,
+                        blurred = blurNsfw && post.nsfw,
+                        autoLoadImages = autoLoadImages,
+                        onOpen =
+                            rememberCallback {
+                                if (postLinkUrl.isNotEmpty()) {
+                                    navigationCoordinator.handleUrl(
+                                        url = postLinkUrl,
+                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
+                                        uriHandler = uriHandler,
+                                        customTabsHelper = customTabsHelper,
+                                        onOpenWeb = onOpenWeb,
+                                        onOpenCommunity = onOpenCommunity,
+                                        onOpenPost = onOpenPost,
+                                        onOpenUser = onOpenCreator,
+                                    )
+                                } else {
+                                    onClick?.invoke()
+                                }
+                            },
+                    )
+                } else {
+                    PostCardImage(
+                        modifier =
+                            Modifier
+                                .weight(0.25f)
+                                .then(
+                                    if (fullHeightImage) {
+                                        Modifier
+                                    } else {
+                                        Modifier.aspectRatio(1f)
+                                    },
+                                ).padding(vertical = Spacing.xs)
+                                .clip(RoundedCornerShape(CornerSize.s)),
+                        minHeight = Dp.Unspecified,
+                        maxHeight = Dp.Unspecified,
+                        imageUrl = post.imageUrl,
+                        autoLoadImages = autoLoadImages,
+                        loadButtonContent = @Composable {
+                            Icon(imageVector = Icons.Default.Download, contentDescription = null)
+                        },
+                        blurred = blurNsfw && post.nsfw,
+                        onImageClick =
+                            rememberCallbackArgs { url ->
+                                if (postLinkUrl.isNotEmpty()) {
+                                    navigationCoordinator.handleUrl(
+                                        url = postLinkUrl,
+                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
+                                        uriHandler = uriHandler,
+                                        customTabsHelper = customTabsHelper,
+                                        onOpenWeb = onOpenWeb,
+                                        onOpenCommunity = onOpenCommunity,
+                                        onOpenPost = onOpenPost,
+                                        onOpenUser = onOpenCreator,
+                                    )
+                                } else {
+                                    onOpenImage?.invoke(url)
+                                }
+                            },
+                        onDoubleClick = onDoubleClick,
+                        onLongClick =
+                            rememberCallback {
+                                optionsMenuOpen.value = true
+                            },
+                    )
+                }
             }
         }
         PostCardFooter(
@@ -439,12 +452,14 @@ private fun ExtendedPost(
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val optionsMenuOpen = remember { mutableStateOf(false) }
     val postLinkUrl =
-        post.url.orEmpty().takeIf {
-            it != post.imageUrl &&
-                it != post.videoUrl &&
-                !it.looksLikeAnImage &&
-                !it.looksLikeAVideo
-        }.orEmpty()
+        post.url
+            .orEmpty()
+            .takeIf {
+                it != post.imageUrl &&
+                    it != post.videoUrl &&
+                    !it.looksLikeAnImage &&
+                    !it.looksLikeAVideo
+            }.orEmpty()
 
     Column(
         modifier =
@@ -487,85 +502,56 @@ private fun ExtendedPost(
                     optionsMenuOpen.value = true
                 },
         )
-        CustomizedContent(ContentFontClass.Title) {
-            PostCardTitle(
+        if (post.deleted) {
+            Text(
                 modifier =
-                    Modifier.padding(
-                        vertical = Spacing.xs,
-                        horizontal = Spacing.s,
+                    Modifier.fillMaxWidth().padding(
+                        all = Spacing.s,
                     ),
-                text = post.title,
-                markRead = markRead,
-                bolder = showBody,
-                autoLoadImages = autoLoadImages,
-                onOpenCommunity = onOpenCommunity,
-                onOpenUser = onOpenCreator,
-                onOpenPost = onOpenPost,
-                onOpenWeb = onOpenWeb,
-                onClick = onClick,
-                onOpenImage = onOpenImage,
-                onDoubleClick = onDoubleClick,
-                onLongClick =
-                    rememberCallback {
-                        optionsMenuOpen.value = true
-                    },
-            )
-        }
-
-        if (post.videoUrl.isNotEmpty()) {
-            PostCardVideo(
-                modifier =
-                    Modifier
-                        .padding(
-                            vertical = Spacing.xxs,
-                            horizontal = if (fullWidthImage) 0.dp else Spacing.s,
-                        ),
-                url = post.videoUrl,
-                blurred = blurNsfw && post.nsfw,
-                autoLoadImages = autoLoadImages,
-                backgroundColor = backgroundColor,
-                onOpen = {
-                    if (postLinkUrl.isNotEmpty()) {
-                        navigationCoordinator.handleUrl(
-                            url = postLinkUrl,
-                            openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                            uriHandler = uriHandler,
-                            customTabsHelper = customTabsHelper,
-                            onOpenWeb = onOpenWeb,
-                            onOpenCommunity = onOpenCommunity,
-                            onOpenPost = onOpenPost,
-                            onOpenUser = onOpenCreator,
-                        )
-                    } else {
-                        onClick?.invoke()
-                    }
-                },
+                text = LocalStrings.current.messageContentDeleted,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
             )
         } else {
-            PostCardImage(
-                modifier =
-                    Modifier
-                        .padding(
+            CustomizedContent(ContentFontClass.Title) {
+                PostCardTitle(
+                    modifier =
+                        Modifier.padding(
                             vertical = Spacing.xs,
-                            horizontal = if (fullWidthImage) 0.dp else Spacing.s,
-                        )
-                        .then(
-                            if (roundedCornerImage && !fullWidthImage) {
-                                Modifier.clip(RoundedCornerShape(CornerSize.xl))
-                            } else {
-                                Modifier
-                            },
-                        ).then(
-                            if (fullHeightImage) {
-                                Modifier
-                            } else {
-                                Modifier.heightIn(max = 200.dp)
-                            },
+                            horizontal = Spacing.s,
                         ),
-                imageUrl = post.imageUrl,
-                blurred = blurNsfw && post.nsfw,
-                onImageClick =
-                    rememberCallbackArgs { url ->
+                    text = post.title,
+                    markRead = markRead,
+                    bolder = showBody,
+                    autoLoadImages = autoLoadImages,
+                    onOpenCommunity = onOpenCommunity,
+                    onOpenUser = onOpenCreator,
+                    onOpenPost = onOpenPost,
+                    onOpenWeb = onOpenWeb,
+                    onClick = onClick,
+                    onOpenImage = onOpenImage,
+                    onDoubleClick = onDoubleClick,
+                    onLongClick =
+                        rememberCallback {
+                            optionsMenuOpen.value = true
+                        },
+                )
+            }
+
+            if (post.videoUrl.isNotEmpty()) {
+                PostCardVideo(
+                    modifier =
+                        Modifier
+                            .padding(
+                                vertical = Spacing.xxs,
+                                horizontal = if (fullWidthImage) 0.dp else Spacing.s,
+                            ),
+                    url = post.videoUrl,
+                    blurred = blurNsfw && post.nsfw,
+                    autoLoadImages = autoLoadImages,
+                    backgroundColor = backgroundColor,
+                    onOpen = {
                         if (postLinkUrl.isNotEmpty()) {
                             navigationCoordinator.handleUrl(
                                 url = postLinkUrl,
@@ -578,69 +564,35 @@ private fun ExtendedPost(
                                 onOpenUser = onOpenCreator,
                             )
                         } else {
-                            onOpenImage?.invoke(url)
+                            onClick?.invoke()
                         }
                     },
-                onDoubleClick = onDoubleClick,
-                autoLoadImages = autoLoadImages,
-                onLongClick = {
-                    optionsMenuOpen.value = true
-                },
-            )
-        }
-
-        if (showBody) {
-            if (post.removed) {
-                Text(
-                    modifier = Modifier.padding(horizontal = Spacing.s),
-                    text = LocalStrings.current.messageContentRemoved,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
                 )
             } else {
-                CustomizedContent(ContentFontClass.Body) {
-                    PostCardBody(
-                        modifier =
-                            Modifier.padding(
-                                top = Spacing.xxs,
-                                start = Spacing.s,
-                                end = Spacing.s,
+                PostCardImage(
+                    modifier =
+                        Modifier
+                            .padding(
+                                vertical = Spacing.xs,
+                                horizontal = if (fullWidthImage) 0.dp else Spacing.s,
+                            ).then(
+                                if (roundedCornerImage && !fullWidthImage) {
+                                    Modifier.clip(RoundedCornerShape(CornerSize.xl))
+                                } else {
+                                    Modifier
+                                },
+                            ).then(
+                                if (fullHeightImage) {
+                                    Modifier
+                                } else {
+                                    Modifier.heightIn(max = 200.dp)
+                                },
                             ),
-                        text = post.text,
-                        maxLines =
-                            if (limitBodyHeight) {
-                                settings.postBodyMaxLines
-                            } else {
-                                null
-                            },
-                        autoLoadImages = autoLoadImages,
-                        markRead = markRead,
-                        onClick = onClick,
-                        onOpenCommunity = onOpenCommunity,
-                        onOpenUser = onOpenCreator,
-                        onOpenPost = onOpenPost,
-                        onOpenImage = onOpenImage,
-                        onOpenWeb = onOpenWeb,
-                        onDoubleClick = onDoubleClick,
-                        onLongClick = {
-                            optionsMenuOpen.value = true
-                        },
-                    )
-                }
-            }
-        }
-        if (postLinkUrl.isNotEmpty()) {
-            PostLinkBanner(
-                modifier =
-                    Modifier
-                        .padding(
-                            top = Spacing.s,
-                            bottom = Spacing.xxs,
-                            start = Spacing.s,
-                            end = Spacing.s,
-                        )
-                        .onClick(
-                            onClick = {
+                    imageUrl = post.imageUrl,
+                    blurred = blurNsfw && post.nsfw,
+                    onImageClick =
+                        rememberCallbackArgs { url ->
+                            if (postLinkUrl.isNotEmpty()) {
                                 navigationCoordinator.handleUrl(
                                     url = postLinkUrl,
                                     openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
@@ -651,11 +603,85 @@ private fun ExtendedPost(
                                     onOpenPost = onOpenPost,
                                     onOpenUser = onOpenCreator,
                                 )
+                            } else {
+                                onOpenImage?.invoke(url)
+                            }
+                        },
+                    onDoubleClick = onDoubleClick,
+                    autoLoadImages = autoLoadImages,
+                    onLongClick = {
+                        optionsMenuOpen.value = true
+                    },
+                )
+            }
+
+            if (showBody) {
+                if (post.removed) {
+                    Text(
+                        modifier = Modifier.padding(horizontal = Spacing.s),
+                        text = LocalStrings.current.messageContentRemoved,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
+                    )
+                } else {
+                    CustomizedContent(ContentFontClass.Body) {
+                        PostCardBody(
+                            modifier =
+                                Modifier.padding(
+                                    top = Spacing.xxs,
+                                    start = Spacing.s,
+                                    end = Spacing.s,
+                                ),
+                            text = post.text,
+                            maxLines =
+                                if (limitBodyHeight) {
+                                    settings.postBodyMaxLines
+                                } else {
+                                    null
+                                },
+                            autoLoadImages = autoLoadImages,
+                            markRead = markRead,
+                            onClick = onClick,
+                            onOpenCommunity = onOpenCommunity,
+                            onOpenUser = onOpenCreator,
+                            onOpenPost = onOpenPost,
+                            onOpenImage = onOpenImage,
+                            onOpenWeb = onOpenWeb,
+                            onDoubleClick = onDoubleClick,
+                            onLongClick = {
+                                optionsMenuOpen.value = true
                             },
-                            onDoubleClick = onDoubleClick ?: {},
-                        ),
-                url = postLinkUrl,
-            )
+                        )
+                    }
+                }
+            }
+            if (postLinkUrl.isNotEmpty()) {
+                PostLinkBanner(
+                    modifier =
+                        Modifier
+                            .padding(
+                                top = Spacing.s,
+                                bottom = Spacing.xxs,
+                                start = Spacing.s,
+                                end = Spacing.s,
+                            ).onClick(
+                                onClick = {
+                                    navigationCoordinator.handleUrl(
+                                        url = postLinkUrl,
+                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
+                                        uriHandler = uriHandler,
+                                        customTabsHelper = customTabsHelper,
+                                        onOpenWeb = onOpenWeb,
+                                        onOpenCommunity = onOpenCommunity,
+                                        onOpenPost = onOpenPost,
+                                        onOpenUser = onOpenCreator,
+                                    )
+                                },
+                                onDoubleClick = onDoubleClick ?: {},
+                            ),
+                    url = postLinkUrl,
+                )
+            }
         }
         PostCardFooter(
             modifier =

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
@@ -417,4 +417,6 @@ internal val ArStrings =
         override val settingsHiddenPosts = "المشاركات المخفية"
         override val settingsMediaList = "تحميلات الوسائط"
         override val settingsEnableToggleFavoriteInNavDrawer = "إضافة/إزالة المفضلة في درج التنقل"
+        override val messageContentDeleted = "لقد قمت بحذف هذا المحتوى"
+        override val actionRestore = "يعيد"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
@@ -426,4 +426,6 @@ internal val BgStrings =
         override val settingsMediaList = "Качване на мултимедия"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Добавяне/премахване на любими в чекмеджето за навигация"
+        override val messageContentDeleted = "Вие изтрихте това съдържание"
+        override val actionRestore = "Възстанови"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
@@ -422,4 +422,6 @@ internal val CsStrings =
         override val settingsMediaList = "Nahrávání médií"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Přidat/odebrat oblíbené položky v navigační zásuvce"
+        override val messageContentDeleted = "Tento obsah jste smazali"
+        override val actionRestore = "Obnovit"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
@@ -422,4 +422,6 @@ internal val DaStrings =
         override val settingsMediaList = "Medieuploads"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Tilføj/fjern favoritter i navigationsskuffen"
+        override val messageContentDeleted = "Du har slettet dette indhold"
+        override val actionRestore = "Gendan"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
@@ -425,4 +425,6 @@ internal val DeStrings =
         override val settingsMediaList = "Medien-Uploads"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Favoriten in der Navigationsleiste hinzufügen/entfernen"
+        override val messageContentDeleted = "Sie haben diesen Inhalt gelöscht"
+        override val actionRestore = "Wiederherstellen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
@@ -429,4 +429,6 @@ internal val ElStrings =
         override val settingsMediaList = "Μεταφορτώσεις πολυμέσων"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Προσθήκη/αφαίρεση αγαπημένων στο συρτάρι πλοήγησης"
+        override val messageContentDeleted = "Έχετε διαγράψει αυτό το περιεχόμενο"
+        override val actionRestore = "Αποκαταστήστε το"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
@@ -417,5 +417,8 @@ internal val EnStrings =
         override val noticeBannedUser = "The current user has been banned from this community"
         override val settingsHiddenPosts = "Hidden posts"
         override val settingsMediaList = "Media uploads"
-        override val settingsEnableToggleFavoriteInNavDrawer = "Add/remove favorites in navigation drawer"
+        override val settingsEnableToggleFavoriteInNavDrawer =
+            "Add/remove favorites in navigation drawer"
+        override val messageContentDeleted = "You have deleted this content"
+        override val actionRestore = "Restore"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
@@ -416,5 +416,8 @@ internal val EoStrings =
         override val noticeBannedUser = "La nuna uzanto estas malpermesita de ĉi tiu komunumo"
         override val settingsHiddenPosts = "Kaŝitaj afiŝoj"
         override val settingsMediaList = "Amaskomunikiloj alŝutoj"
-        override val settingsEnableToggleFavoriteInNavDrawer = "Aldoni/forigi plej ŝatatajn en navigada tirkesto"
+        override val settingsEnableToggleFavoriteInNavDrawer =
+            "Aldoni/forigi plej ŝatatajn en navigada tirkesto"
+        override val messageContentDeleted = "Vi forigis ĉi tiun enhavon"
+        override val actionRestore = "Restaŭri"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
@@ -423,4 +423,6 @@ internal val EsStrings =
         override val settingsMediaList = "Cargas de medios"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Agregar/eliminar favoritos en el cajón de navegación"
+        override val messageContentDeleted = "Has eliminado este contenido"
+        override val actionRestore = "Restaurar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
@@ -424,4 +424,6 @@ internal val EtStrings =
         override val settingsMediaList = "Meedia üleslaadimine"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Lemmikute lisamine/eemaldamine navigeerimissahtlis"
+        override val messageContentDeleted = "Olete selle sisu kustutanud"
+        override val actionRestore = "Taastama"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
@@ -419,4 +419,6 @@ internal val FiStrings =
         override val settingsMediaList = "Median lataukset"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Lisää/poista suosikkeja navigointipaneelissa"
+        override val messageContentDeleted = "Olet poistanut tämän sisällön"
+        override val actionRestore = "Palauttaa"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
@@ -428,4 +428,6 @@ internal val FrStrings =
         override val settingsMediaList = "Téléchargements de médias"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Ajouter/supprimer des favoris dans le tiroir de navigation"
+        override val messageContentDeleted = "Vous avez supprimé ce contenu"
+        override val actionRestore = "Restaurer"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
@@ -423,4 +423,6 @@ internal val GaStrings =
         override val settingsMediaList = "Uaslódálacha meáin"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Cuir leis/bain na ceanáin sa tarraiceán nascleanúna"
+        override val messageContentDeleted = "Tá an t-ábhar seo scriosta agat"
+        override val actionRestore = "Athchóirigh"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
@@ -423,4 +423,6 @@ internal val HrStrings =
         override val settingsMediaList = "Prijenos medija"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Dodajte/uklonite favorite u ladici za navigaciju"
+        override val messageContentDeleted = "Izbrisali ste ovaj sadržaj"
+        override val actionRestore = "Vratiti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
@@ -427,4 +427,6 @@ internal val HuStrings =
         override val settingsMediaList = "Médiafeltöltések"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Kedvencek hozzáadása/eltávolítása a navigációs fiókban"
+        override val messageContentDeleted = "Ezt a tartalmat törölted"
+        override val actionRestore = "visszaállítás"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -422,5 +422,8 @@ internal val ItStrings =
         override val noticeBannedUser = "L\'utente corrente è stato bannato da questa comunità"
         override val settingsHiddenPosts = "Post nascosti"
         override val settingsMediaList = "Caricamenti multimediali"
-        override val settingsEnableToggleFavoriteInNavDrawer = "Aggiungi/rimuovi preferiti in menu laterale"
+        override val settingsEnableToggleFavoriteInNavDrawer =
+            "Aggiungi/rimuovi preferiti in menu laterale"
+        override val messageContentDeleted = "Hai eliminato questo contenuto"
+        override val actionRestore = "Ripristina"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
@@ -422,4 +422,6 @@ internal val LtStrings =
         override val settingsMediaList = "Žiniasklaidos įkėlimai"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Pridėti / pašalinti mėgstamiausius naršymo skydelyje"
+        override val messageContentDeleted = "Ištrynėte šį turinį"
+        override val actionRestore = "Atkurti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
@@ -421,4 +421,6 @@ internal val LvStrings =
         override val settingsMediaList = "Multivides augšupielādes"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Pievienojiet/noņemiet izlasi navigācijas atvilktnē"
+        override val messageContentDeleted = "Jūs esat izdzēsis šo saturu"
+        override val actionRestore = "Atjaunot"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
@@ -423,4 +423,6 @@ internal val MtStrings =
         override val settingsMediaList = "Uploads tal-midja"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Żid/neħħi l-favoriti fil-kexxun tan-navigazzjoni"
+        override val messageContentDeleted = "Ħassejt dan il-kontenut"
+        override val actionRestore = "Irrestawra"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
@@ -424,4 +424,6 @@ internal val NlStrings =
         override val settingsMediaList = "Media-uploads"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Favorieten toevoegen/verwijderen in de navigatielade"
+        override val messageContentDeleted = "Je hebt deze inhoud verwijderd"
+        override val actionRestore = "Herstellen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
@@ -421,4 +421,6 @@ internal val NoStrings =
         override val settingsMediaList = "Medieopplastinger"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Legg til/fjern favoritter i navigasjonsskuffen"
+        override val messageContentDeleted = "Du har slettet dette innholdet"
+        override val actionRestore = "Restaurere"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
@@ -421,5 +421,8 @@ internal val PlStrings =
         override val noticeBannedUser = "Bieżący użytkownik został zablokowany w tej społeczności"
         override val settingsHiddenPosts = "Ukryte posty"
         override val settingsMediaList = "Przesyłanie multimediów"
-        override val settingsEnableToggleFavoriteInNavDrawer = "Dodaj/usuń ulubione w szufladzie nawigacji"
+        override val settingsEnableToggleFavoriteInNavDrawer =
+            "Dodaj/usuń ulubione w szufladzie nawigacji"
+        override val messageContentDeleted = "Usunąłeś tę treść"
+        override val actionRestore = "Przywrócić"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
@@ -421,4 +421,6 @@ internal val PtBrStrings =
         override val settingsMediaList = "Carregamentos de mídia"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Adicionar/remover favoritos na gaveta de navegação"
+        override val messageContentDeleted = "Você excluiu este conteúdo"
+        override val actionRestore = "Restaura"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
@@ -422,4 +422,6 @@ internal val PtStrings =
         override val settingsMediaList = "Carregamentos de mídia"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Adicionar/remover favoritos na gaveta de navegação"
+        override val messageContentDeleted = "Você excluiu este conteúdo"
+        override val actionRestore = "Restaura"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
@@ -422,4 +422,6 @@ internal val RoStrings =
         override val settingsMediaList = "Încărcări media"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Adăugă/elimină favoritele din sertarul de navigare"
+        override val messageContentDeleted = "Ați șters acest conținut"
+        override val actionRestore = "Restaurați-l"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
@@ -424,4 +424,6 @@ internal val RuStrings =
         override val settingsMediaList = "Загрузка мультимедиа"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Добавить/удалить избранное в панели навигации"
+        override val messageContentDeleted = "Вы удалили этот контент"
+        override val actionRestore = "Восстановить"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
@@ -422,4 +422,6 @@ internal val SeStrings =
         override val settingsMediaList = "Mediauppladdningar"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Lägg till/ta bort favoriter i navigeringslådan"
+        override val messageContentDeleted = "Du har tagit bort detta innehåll"
+        override val actionRestore = "Återställ"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
@@ -424,4 +424,6 @@ internal val SkStrings =
         override val settingsMediaList = "Nahrávanie médií"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Pridať/odstrániť obľúbené položky v navigačnej zásuvke"
+        override val messageContentDeleted = "Tento obsah ste odstránili"
+        override val actionRestore = "Obnoviť"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
@@ -422,4 +422,6 @@ internal val SlStrings =
         override val settingsMediaList = "Nalaganje medijev"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Dodajte/odstranite priljubljene v predalu za krmarjenje"
+        override val messageContentDeleted = "To vsebino ste izbrisali"
+        override val actionRestore = "Obnovi"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
@@ -424,4 +424,6 @@ internal val SqStrings =
         override val settingsMediaList = "Ngarkimet e mediave"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Shto/hiq të preferuarat në sirtarin e navigimit"
+        override val messageContentDeleted = "Ju e keni fshirë këtë përmbajtje"
+        override val actionRestore = "Rivendos"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
@@ -424,4 +424,6 @@ internal val SrStrings =
         override val settingsMediaList = "Учитавање медија"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Додајте/уклоните фаворите у фиоци за навигацију"
+        override val messageContentDeleted = "Избрисали сте овај садржај"
+        override val actionRestore = "Ресторе"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -416,6 +416,8 @@ interface Strings {
     val settingsHiddenPosts: String
     val settingsMediaList: String
     val settingsEnableToggleFavoriteInNavDrawer: String
+    val messageContentDeleted: String
+    val actionRestore: String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
@@ -418,4 +418,6 @@ internal val TokStrings =
         override val settingsMediaList = "sitelen linluwi"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "o sin/o weka e ijo pona lon leko luka"
+        override val messageContentDeleted = "tenpo pini la, sina weka e ijo ni"
+        override val actionRestore = "o awen e ona"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
@@ -423,4 +423,6 @@ internal val TrStrings =
         override val settingsMediaList = "Medya yüklemeleri"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Gezinme çekmecesinde favorileri ekle/kaldır"
+        override val messageContentDeleted = "Bu içeriği sildiniz"
+        override val actionRestore = "Eski haline getirmek"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
@@ -424,4 +424,6 @@ internal val UkStrings =
         override val settingsMediaList = "Завантаження медіа"
         override val settingsEnableToggleFavoriteInNavDrawer =
             "Додати/видалити вибране в панелі навігації"
+        override val messageContentDeleted = "Ви видалили цей вміст"
+        override val actionRestore = "Відновлення"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhHkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhHkStrings.kt
@@ -411,6 +411,7 @@ internal val ZhHkStrings =
         override val noticeBannedUser = "呢個用戶已被呢個社區禁止"
         override val settingsHiddenPosts = "隱藏帖子"
         override val settingsMediaList = "媒體上傳"
-        override val settingsEnableToggleFavoriteInNavDrawer =
-            "Add/remove favorites in navigation drawer"
+        override val settingsEnableToggleFavoriteInNavDrawer = "加入/攞走導航櫃桶嘅最愛"
+        override val messageContentDeleted = "您刪除咗呢個內容"
+        override val actionRestore = "恢復"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
@@ -411,6 +411,7 @@ internal val ZhTwStrings =
         override val settingsAboutLicences = "授權"
         override val never = "從不"
         override val appIconDefault = "默認"
-        override val settingsEnableToggleFavoriteInNavDrawer =
-            "Add/remove favorites in navigation drawer"
+        override val settingsEnableToggleFavoriteInNavDrawer = "加入/移除導航抽屜中的收藏"
+        override val messageContentDeleted = "您已刪除此內容"
+        override val actionRestore = "恢復"
     }

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -27,37 +27,62 @@ sealed interface NotificationCenterEvent {
         val value: SortType,
         val defaultForCommunity: Boolean,
         val screenKey: String?,
-    ) :
-        NotificationCenterEvent
+    ) : NotificationCenterEvent
 
-    data class ChangeCommentSortType(val value: SortType, val screenKey: String?) :
-        NotificationCenterEvent
+    data class ChangeCommentSortType(
+        val value: SortType,
+        val screenKey: String?,
+    ) : NotificationCenterEvent
 
-    data class ChangeFeedType(val value: ListingType, val screenKey: String?) :
-        NotificationCenterEvent
+    data class ChangeFeedType(
+        val value: ListingType,
+        val screenKey: String?,
+    ) : NotificationCenterEvent
 
-    data class ChangeInboxType(val unreadOnly: Boolean) : NotificationCenterEvent
+    data class ChangeInboxType(
+        val unreadOnly: Boolean,
+    ) : NotificationCenterEvent
 
-    data class ChangeTheme(val value: UiTheme?) : NotificationCenterEvent
+    data class ChangeTheme(
+        val value: UiTheme?,
+    ) : NotificationCenterEvent
 
-    data class ChangeContentFontSize(val value: Float, val contentClass: ContentFontClass) :
-        NotificationCenterEvent
+    data class ChangeContentFontSize(
+        val value: Float,
+        val contentClass: ContentFontClass,
+    ) : NotificationCenterEvent
 
-    data class ChangeUiFontSize(val value: Float) : NotificationCenterEvent
+    data class ChangeUiFontSize(
+        val value: Float,
+    ) : NotificationCenterEvent
 
-    data class ChangeFontFamily(val value: UiFontFamily) : NotificationCenterEvent
+    data class ChangeFontFamily(
+        val value: UiFontFamily,
+    ) : NotificationCenterEvent
 
-    data class ChangeContentFontFamily(val value: UiFontFamily) : NotificationCenterEvent
+    data class ChangeContentFontFamily(
+        val value: UiFontFamily,
+    ) : NotificationCenterEvent
 
-    data class ChangeZombieInterval(val value: Duration) : NotificationCenterEvent
+    data class ChangeZombieInterval(
+        val value: Duration,
+    ) : NotificationCenterEvent
 
-    data class ChangeInboxBackgroundCheckPeriod(val value: Duration) : NotificationCenterEvent
+    data class ChangeInboxBackgroundCheckPeriod(
+        val value: Duration,
+    ) : NotificationCenterEvent
 
-    data class ChangeLanguage(val value: String) : NotificationCenterEvent
+    data class ChangeLanguage(
+        val value: String,
+    ) : NotificationCenterEvent
 
-    data class ChangePostLayout(val value: PostLayout) : NotificationCenterEvent
+    data class ChangePostLayout(
+        val value: PostLayout,
+    ) : NotificationCenterEvent
 
-    data class ChangeVoteFormat(val value: VoteFormat) : NotificationCenterEvent
+    data class ChangeVoteFormat(
+        val value: VoteFormat,
+    ) : NotificationCenterEvent
 
     data object Logout : NotificationCenterEvent
 
@@ -65,35 +90,58 @@ sealed interface NotificationCenterEvent {
 
     data object CommentCreated : NotificationCenterEvent
 
-    data class PostUpdated(val model: PostModel) : NotificationCenterEvent
+    data class PostUpdated(
+        val model: PostModel,
+    ) : NotificationCenterEvent
 
-    data class CommentUpdated(val model: CommentModel) : NotificationCenterEvent
+    data class CommentUpdated(
+        val model: CommentModel,
+    ) : NotificationCenterEvent
 
-    data class PostDeleted(val model: PostModel) : NotificationCenterEvent
+    data class ChangeColor(
+        val color: Color?,
+    ) : NotificationCenterEvent
 
-    data class ChangeColor(val color: Color?) : NotificationCenterEvent
+    data class ChangeActionColor(
+        val color: Color?,
+        val actionType: Int,
+    ) : NotificationCenterEvent
 
-    data class ChangeActionColor(val color: Color?, val actionType: Int) : NotificationCenterEvent
+    data class ChangeZombieScrollAmount(
+        val value: Float,
+    ) : NotificationCenterEvent
 
-    data class ChangeZombieScrollAmount(val value: Float) : NotificationCenterEvent
-
-    data class MultiCommunityCreated(val model: MultiCommunityModel) : NotificationCenterEvent
+    data class MultiCommunityCreated(
+        val model: MultiCommunityModel,
+    ) : NotificationCenterEvent
 
     data object CloseDialog : NotificationCenterEvent
 
-    data class SelectCommunity(val model: CommunityModel) : NotificationCenterEvent
+    data class SelectCommunity(
+        val model: CommunityModel,
+    ) : NotificationCenterEvent
 
-    data class PostRemoved(val model: PostModel) : NotificationCenterEvent
+    data class PostRemoved(
+        val model: PostModel,
+    ) : NotificationCenterEvent
 
-    data class CommentRemoved(val model: CommentModel) : NotificationCenterEvent
+    data class ChangeReportListType(
+        val unresolvedOnly: Boolean,
+    ) : NotificationCenterEvent
 
-    data class ChangeReportListType(val unresolvedOnly: Boolean) : NotificationCenterEvent
+    data class UserBannedPost(
+        val postId: Long,
+        val user: UserModel,
+    ) : NotificationCenterEvent
 
-    data class UserBannedPost(val postId: Long, val user: UserModel) : NotificationCenterEvent
+    data class UserBannedComment(
+        val commentId: Long,
+        val user: UserModel,
+    ) : NotificationCenterEvent
 
-    data class UserBannedComment(val commentId: Long, val user: UserModel) : NotificationCenterEvent
-
-    data class ChangeCommentBarTheme(val value: CommentBarTheme) : NotificationCenterEvent
+    data class ChangeCommentBarTheme(
+        val value: CommentBarTheme,
+    ) : NotificationCenterEvent
 
     data class BlockActionSelected(
         val userId: Long? = null,
@@ -101,11 +149,17 @@ sealed interface NotificationCenterEvent {
         val instanceId: Long? = null,
     ) : NotificationCenterEvent
 
-    data class Share(val url: String) : NotificationCenterEvent
+    data class Share(
+        val url: String,
+    ) : NotificationCenterEvent
 
-    data class ChangePostBodyMaxLines(val value: Int?) : NotificationCenterEvent
+    data class ChangePostBodyMaxLines(
+        val value: Int?,
+    ) : NotificationCenterEvent
 
-    data class InstanceSelected(val value: String) : NotificationCenterEvent
+    data class InstanceSelected(
+        val value: String,
+    ) : NotificationCenterEvent
 
     data class ActionsOnSwipeSelected(
         val value: ActionOnSwipe,
@@ -113,11 +167,15 @@ sealed interface NotificationCenterEvent {
         val target: ActionOnSwipeTarget,
     ) : NotificationCenterEvent
 
-    data class ChangeSystemBarTheme(val value: UiBarTheme) : NotificationCenterEvent
+    data class ChangeSystemBarTheme(
+        val value: UiBarTheme,
+    ) : NotificationCenterEvent
 
     data object DraftDeleted : NotificationCenterEvent
 
-    data class ModeratorZoneActionSelected(val value: Int) : NotificationCenterEvent
+    data class ModeratorZoneActionSelected(
+        val value: Int,
+    ) : NotificationCenterEvent
 
     data object ResetHome : NotificationCenterEvent
 
@@ -125,22 +183,37 @@ sealed interface NotificationCenterEvent {
 
     data object ResetInbox : NotificationCenterEvent
 
-    data class CopyText(val value: String) : NotificationCenterEvent
+    data class CopyText(
+        val value: String,
+    ) : NotificationCenterEvent
 
-    data class ChangedLikedType(val value: Boolean) : NotificationCenterEvent
+    data class ChangedLikedType(
+        val value: Boolean,
+    ) : NotificationCenterEvent
 
-    data class ChangeSearchResultType(val value: SearchResultType, val screenKey: String?) :
-        NotificationCenterEvent
+    data class ChangeSearchResultType(
+        val value: SearchResultType,
+        val screenKey: String?,
+    ) : NotificationCenterEvent
 
-    data class CommunitySubscriptionChanged(val value: CommunityModel) : NotificationCenterEvent
+    data class CommunitySubscriptionChanged(
+        val value: CommunityModel,
+    ) : NotificationCenterEvent
 
     sealed interface ShareImageModeSelected : NotificationCenterEvent {
-        data class ModeUrl(val url: String) : ShareImageModeSelected
+        data class ModeUrl(
+            val url: String,
+        ) : ShareImageModeSelected
 
-        data class ModeFile(val url: String, val source: String) : ShareImageModeSelected
+        data class ModeFile(
+            val url: String,
+            val source: String,
+        ) : ShareImageModeSelected
     }
 
-    data class AppIconVariantSelected(val value: Int) : NotificationCenterEvent
+    data class AppIconVariantSelected(
+        val value: Int,
+    ) : NotificationCenterEvent
 
     sealed interface ProfileSideMenuAction : NotificationCenterEvent {
         data object ManageAccounts : ProfileSideMenuAction
@@ -158,10 +231,13 @@ sealed interface NotificationCenterEvent {
         data object Logout : ProfileSideMenuAction
     }
 
-    data class ChangeUrlOpeningMode(val value: Int) : NotificationCenterEvent
+    data class ChangeUrlOpeningMode(
+        val value: Int,
+    ) : NotificationCenterEvent
 
-    data class ChangeCommunityVisibility(val value: CommunityVisibilityType) :
-        NotificationCenterEvent
+    data class ChangeCommunityVisibility(
+        val value: CommunityVisibilityType,
+    ) : NotificationCenterEvent
 
     data object FavoritesUpdated : NotificationCenterEvent
 }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/CommentPaginationSpecification.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/CommentPaginationSpecification.kt
@@ -9,6 +9,7 @@ sealed interface CommentPaginationSpecification {
         val listingType: ListingType? = null,
         val otherInstance: String? = null,
         val sortType: SortType = SortType.Active,
+        val includeDeleted: Boolean = false,
     ) : CommentPaginationSpecification
 
     data class User(
@@ -16,6 +17,7 @@ sealed interface CommentPaginationSpecification {
         val name: String? = null,
         val otherInstance: String? = null,
         val sortType: SortType = SortType.New,
+        val includeDeleted: Boolean = false,
     ) : CommentPaginationSpecification
 
     data class Votes(

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManager.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManager.kt
@@ -32,9 +32,11 @@ internal class DefaultCommentPaginationManager(
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
-        notificationCenter.subscribe(NotificationCenterEvent.CommentUpdated::class).onEach { evt ->
-            handleCommentUpdate(evt.model)
-        }.launchIn(scope)
+        notificationCenter
+            .subscribe(NotificationCenterEvent.CommentUpdated::class)
+            .onEach { evt ->
+                handleCommentUpdate(evt.model)
+            }.launchIn(scope)
     }
 
     override fun reset(specification: CommentPaginationSpecification) {
@@ -68,8 +70,13 @@ internal class DefaultCommentPaginationManager(
                         itemList
                             .orEmpty()
                             .deduplicate()
-                            .filterDeleted()
-                            .also {
+                            .let {
+                                if (specification.includeDeleted) {
+                                    it
+                                } else {
+                                    it.filterDeleted()
+                                }
+                            }.also {
                                 // deleted comments should not be counted
                                 canFetchMore = it.isNotEmpty()
                             }
@@ -92,8 +99,13 @@ internal class DefaultCommentPaginationManager(
                         itemList
                             .orEmpty()
                             .deduplicate()
-                            .filterDeleted()
-                            .also {
+                            .let {
+                                if (specification.includeDeleted) {
+                                    it
+                                } else {
+                                    it.filterDeleted()
+                                }
+                            }.also {
                                 canFetchMore = it.isNotEmpty()
                             }
                     }

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostPaginationSpecification.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/diegoberaldin/raccoonforlemmy/domain/lemmy/pagination/PostPaginationSpecification.kt
@@ -23,6 +23,7 @@ sealed interface PostPaginationSpecification {
         val query: String? = null,
         val sortType: SortType = SortType.Active,
         val includeNsfw: Boolean = true,
+        val includeDeleted: Boolean = false,
     ) : PostPaginationSpecification
 
     data class User(
@@ -31,6 +32,7 @@ sealed interface PostPaginationSpecification {
         val otherInstance: String? = null,
         val sortType: SortType = SortType.New,
         val includeNsfw: Boolean = true,
+        val includeDeleted: Boolean = false,
     ) : PostPaginationSpecification
 
     data class Votes(

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommentRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommentRepositoryTest.kt
@@ -407,6 +407,28 @@ class DefaultCommentRepositoryTest {
         }
 
     @Test
+    fun whenRestore_thenInteractionsAreAsExpected() =
+        runTest {
+            val itemId = 1L
+            val token = "fake-token"
+            sut.restore(
+                commentId = itemId,
+                auth = token,
+            )
+
+            coVerify {
+                commentService.delete(
+                    authHeader = token.toAuthHeader(),
+                    form =
+                        withArg { data ->
+                            assertEquals(itemId, data.commentId)
+                            assertFalse(data.deleted)
+                        },
+                )
+            }
+        }
+
+    @Test
     fun whenReport_thenInteractionsAreAsExpected() =
         runTest {
             val itemId = 1L

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultPostRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultPostRepositoryTest.kt
@@ -583,6 +583,35 @@ class DefaultPostRepositoryTest {
                     form =
                         withArg {
                             assertEquals(postId, it.postId)
+                            assertTrue(it.deleted)
+                        },
+                )
+            }
+        }
+
+    @Test
+    fun whenRestore_thenInteractionsAreAsExpected() =
+        runTest {
+            coEvery {
+                postService.delete(
+                    authHeader = any(),
+                    form = any(),
+                )
+            } returns mockk(relaxed = true)
+
+            val postId = 1L
+            sut.restore(
+                id = postId,
+                auth = AUTH_TOKEN,
+            )
+
+            coVerify {
+                postService.delete(
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                    form =
+                        withArg {
+                            assertEquals(postId, it.postId)
+                            assertFalse(it.deleted)
                         },
                 )
             }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommentRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/CommentRepository.kt
@@ -101,7 +101,12 @@ interface CommentRepository {
     suspend fun delete(
         commentId: Long,
         auth: String,
-    )
+    ): CommentModel?
+
+    suspend fun restore(
+        commentId: Long,
+        auth: String,
+    ): CommentModel?
 
     suspend fun report(
         commentId: Long,

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommentRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultCommentRepository.kt
@@ -320,9 +320,24 @@ internal class DefaultCommentRepository(
                     commentId = commentId,
                     deleted = true,
                 )
-            services.comment.delete(authHeader = auth.toAuthHeader(), form = data)
-            Unit
-        }.getOrDefault(Unit)
+            val res = services.comment.delete(authHeader = auth.toAuthHeader(), form = data)
+            res.commentView?.toModel()
+        }.getOrNull()
+    }
+
+    override suspend fun restore(
+        commentId: Long,
+        auth: String,
+    ) = withContext(Dispatchers.IO) {
+        runCatching {
+            val data =
+                DeleteCommentForm(
+                    commentId = commentId,
+                    deleted = false,
+                )
+            val res = services.comment.delete(authHeader = auth.toAuthHeader(), form = data)
+            res.commentView.toModel()
+        }.getOrNull()
     }
 
     override suspend fun report(

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultPostRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/DefaultPostRepository.kt
@@ -301,19 +301,40 @@ internal class DefaultPostRepository(
     override suspend fun delete(
         id: Long,
         auth: String,
-    ): Unit =
+    ) = withContext(Dispatchers.IO) {
+        runCatching {
+            val data =
+                DeletePostForm(
+                    postId = id,
+                    deleted = true,
+                )
+            val res =
+                services.post.delete(
+                    authHeader = auth.toAuthHeader(),
+                    form = data,
+                )
+            res.postView.toModel()
+        }.getOrNull()
+    }
+
+    override suspend fun restore(
+        id: Long,
+        auth: String,
+    ): PostModel? =
         withContext(Dispatchers.IO) {
             runCatching {
                 val data =
                     DeletePostForm(
                         postId = id,
-                        deleted = true,
+                        deleted = false,
                     )
-                services.post.delete(
-                    authHeader = auth.toAuthHeader(),
-                    form = data,
-                )
-            }.getOrDefault(Unit)
+                val res =
+                    services.post.delete(
+                        authHeader = auth.toAuthHeader(),
+                        form = data,
+                    )
+                res.postView.toModel()
+            }.getOrNull()
         }
 
     override suspend fun uploadImage(

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/PostRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/lemmy/repository/PostRepository.kt
@@ -97,7 +97,12 @@ interface PostRepository {
     suspend fun delete(
         id: Long,
         auth: String,
-    )
+    ): PostModel?
+
+    suspend fun restore(
+        id: Long,
+        auth: String,
+    ): PostModel?
 
     suspend fun uploadImage(
         auth: String,

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
@@ -27,11 +27,20 @@ interface CommunityDetailMviModel :
 
         data object LoadNextPage : Intent
 
-        data class UpVotePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class UpVotePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class DownVotePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class DownVotePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class SavePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class SavePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
         data object HapticIndication : Intent
 
@@ -39,11 +48,17 @@ interface CommunityDetailMviModel :
 
         data object Unsubscribe : Intent
 
-        data class DeletePost(val id: Long) : Intent
+        data class DeletePost(
+            val id: Long,
+        ) : Intent
 
-        data class MarkAsRead(val id: Long) : Intent
+        data class MarkAsRead(
+            val id: Long,
+        ) : Intent
 
-        data class Hide(val id: Long) : Intent
+        data class Hide(
+            val id: Long,
+        ) : Intent
 
         data object Block : Intent
 
@@ -51,35 +66,59 @@ interface CommunityDetailMviModel :
 
         data object ClearRead : Intent
 
-        data class StartZombieMode(val index: Int) : Intent
+        data class StartZombieMode(
+            val index: Int,
+        ) : Intent
 
         data object PauseZombieMode : Intent
 
-        data class ModFeaturePost(val id: Long) : Intent
+        data class ModFeaturePost(
+            val id: Long,
+        ) : Intent
 
-        data class AdminFeaturePost(val id: Long) : Intent
+        data class AdminFeaturePost(
+            val id: Long,
+        ) : Intent
 
-        data class ModLockPost(val id: Long) : Intent
+        data class ModLockPost(
+            val id: Long,
+        ) : Intent
 
-        data class ModToggleModUser(val id: Long) : Intent
+        data class ModToggleModUser(
+            val id: Long,
+        ) : Intent
 
         data object ToggleFavorite : Intent
 
-        data class Share(val url: String) : Intent
+        data class Share(
+            val url: String,
+        ) : Intent
 
-        data class SetSearch(val value: String) : Intent
+        data class SetSearch(
+            val value: String,
+        ) : Intent
 
-        data class ChangeSearching(val value: Boolean) : Intent
+        data class ChangeSearching(
+            val value: Boolean,
+        ) : Intent
 
-        data class Copy(val value: String) : Intent
+        data class Copy(
+            val value: String,
+        ) : Intent
 
         data object WillOpenDetail : Intent
 
         data object UnhideCommunity : Intent
 
-        data class SelectPreferredLanguage(val languageId: Long?) : Intent
+        data class SelectPreferredLanguage(
+            val languageId: Long?,
+        ) : Intent
 
         data object DeleteCommunity : Intent
+
+        data class RestorePost(
+            val id: Long,
+        ) : Intent
     }
 
     data class UiState(
@@ -123,15 +162,23 @@ interface CommunityDetailMviModel :
     sealed interface Effect {
         data object Success : Effect
 
-        data class Failure(val message: String?) : Effect
+        data class Failure(
+            val message: String?,
+        ) : Effect
 
-        data class Error(val message: String?) : Effect
+        data class Error(
+            val message: String?,
+        ) : Effect
 
         data object BackToTop : Effect
 
-        data class ZombieModeTick(val index: Int) : Effect
+        data class ZombieModeTick(
+            val index: Int,
+        ) : Effect
 
-        data class TriggerCopy(val text: String) : Effect
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
 
         data object Back : Effect
     }

--- a/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -1205,11 +1205,19 @@ class CommunityDetailScreen(
                                                                 OptionId.Edit,
                                                                 LocalStrings.current.postActionEdit,
                                                             )
-                                                        this +=
-                                                            Option(
-                                                                OptionId.Delete,
-                                                                LocalStrings.current.commentActionDelete,
-                                                            )
+                                                        if (post.deleted) {
+                                                            this +=
+                                                                Option(
+                                                                    OptionId.Restore,
+                                                                    LocalStrings.current.actionRestore,
+                                                                )
+                                                        } else {
+                                                            this +=
+                                                                Option(
+                                                                    OptionId.Delete,
+                                                                    LocalStrings.current.commentActionDelete,
+                                                                )
+                                                        }
                                                     }
                                                     if (uiState.moderators.containsId(uiState.currentUserId)) {
                                                         this +=
@@ -1445,6 +1453,14 @@ class CommunityDetailScreen(
                                                                     )
                                                                 navigationCoordinator.pushScreen(screen)
                                                             }
+                                                        }
+
+                                                        OptionId.Restore -> {
+                                                            model.reduce(
+                                                                CommunityDetailMviModel.Intent.RestorePost(
+                                                                    post.id,
+                                                                ),
+                                                            )
                                                         }
 
                                                         else -> Unit

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
@@ -13,31 +13,65 @@ interface ProfileLoggedMviModel :
     MviModel<ProfileLoggedMviModel.Intent, ProfileLoggedMviModel.UiState, ProfileLoggedMviModel.Effect>,
     ScreenModel {
     sealed interface Intent {
-        data class ChangeSection(val section: ProfileLoggedSection) : Intent
+        data class ChangeSection(
+            val section: ProfileLoggedSection,
+        ) : Intent
 
         data object Refresh : Intent
 
         data object LoadNextPage : Intent
 
-        data class DeletePost(val id: Long) : Intent
+        data class DeletePost(
+            val id: Long,
+        ) : Intent
 
-        data class DeleteComment(val id: Long) : Intent
+        data class DeleteComment(
+            val id: Long,
+        ) : Intent
 
-        data class Share(val url: String) : Intent
+        data class Share(
+            val url: String,
+        ) : Intent
 
-        data class UpVotePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class UpVotePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class DownVotePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class DownVotePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class SavePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class SavePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class UpVoteComment(val id: Long, val feedback: Boolean = false) : Intent
+        data class UpVoteComment(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class DownVoteComment(val id: Long, val feedback: Boolean = false) : Intent
+        data class DownVoteComment(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class SaveComment(val id: Long, val feedback: Boolean = false) : Intent
+        data class SaveComment(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
         data object WillOpenDetail : Intent
+
+        data class RestorePost(
+            val id: Long,
+        ) : Intent
+
+        data class RestoreComment(
+            val id: Long,
+        ) : Intent
     }
 
     data class UiState(

--- a/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -91,22 +91,27 @@ object ProfileLoggedScreen : Tab {
         var commentIdToDelete by remember { mutableStateOf<Long?>(null) }
 
         LaunchedEffect(navigationCoordinator) {
-            navigationCoordinator.onDoubleTabSelection.onEach { section ->
-                runCatching {
-                    if (section == TabNavigationSection.Profile) {
-                        lazyListState.scrollToItem(0)
+            navigationCoordinator.onDoubleTabSelection
+                .onEach { section ->
+                    runCatching {
+                        if (section == TabNavigationSection.Profile) {
+                            lazyListState.scrollToItem(0)
+                        }
                     }
-                }
-            }.launchIn(this)
+                }.launchIn(this)
         }
         LaunchedEffect(notificationCenter) {
-            notificationCenter.subscribe(NotificationCenterEvent.PostCreated::class).onEach {
-                model.reduce(ProfileLoggedMviModel.Intent.Refresh)
-            }.launchIn(this)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.PostCreated::class)
+                .onEach {
+                    model.reduce(ProfileLoggedMviModel.Intent.Refresh)
+                }.launchIn(this)
 
-            notificationCenter.subscribe(NotificationCenterEvent.CommentCreated::class).onEach {
-                model.reduce(ProfileLoggedMviModel.Intent.Refresh)
-            }.launchIn(this)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.CommentCreated::class)
+                .onEach {
+                    model.reduce(ProfileLoggedMviModel.Intent.Refresh)
+                }.launchIn(this)
         }
 
         if (uiState.initial) {
@@ -169,8 +174,7 @@ object ProfileLoggedScreen : Tab {
                                         .padding(
                                             top = Spacing.xs,
                                             bottom = Spacing.s,
-                                        )
-                                        .fillMaxWidth(),
+                                        ).fillMaxWidth(),
                                 isModerator = uiState.user?.moderator == true,
                             )
                             HorizontalDivider()
@@ -296,36 +300,39 @@ object ProfileLoggedScreen : Tab {
                                         },
                                     options =
                                         buildList {
-                                            add(
+                                            this +=
                                                 Option(
                                                     OptionId.Share,
                                                     LocalStrings.current.postActionShare,
-                                                ),
-                                            )
-                                            add(
+                                                )
+                                            this +=
                                                 Option(
                                                     OptionId.CrossPost,
                                                     LocalStrings.current.postActionCrossPost,
-                                                ),
-                                            )
-                                            add(
+                                                )
+                                            this +=
                                                 Option(
                                                     OptionId.SeeRaw,
                                                     LocalStrings.current.postActionSeeRaw,
-                                                ),
-                                            )
-                                            add(
+                                                )
+                                            this +=
                                                 Option(
                                                     OptionId.Edit,
                                                     LocalStrings.current.postActionEdit,
-                                                ),
-                                            )
-                                            add(
-                                                Option(
-                                                    OptionId.Delete,
-                                                    LocalStrings.current.commentActionDelete,
-                                                ),
-                                            )
+                                                )
+                                            if (post.deleted) {
+                                                this +=
+                                                    Option(
+                                                        OptionId.Restore,
+                                                        LocalStrings.current.actionRestore,
+                                                    )
+                                            } else {
+                                                this +=
+                                                    Option(
+                                                        OptionId.Delete,
+                                                        LocalStrings.current.commentActionDelete,
+                                                    )
+                                            }
                                         },
                                     onOptionSelected =
                                         rememberCallbackArgs(model) { optionId ->
@@ -369,6 +376,14 @@ object ProfileLoggedScreen : Tab {
                                                     }
                                                 }
 
+                                                OptionId.Restore -> {
+                                                    model.reduce(
+                                                        ProfileLoggedMviModel.Intent.RestorePost(
+                                                            post.id,
+                                                        ),
+                                                    )
+                                                }
+
                                                 else -> Unit
                                             }
                                         },
@@ -384,7 +399,8 @@ object ProfileLoggedScreen : Tab {
                                 item {
                                     Text(
                                         modifier =
-                                            Modifier.fillMaxWidth()
+                                            Modifier
+                                                .fillMaxWidth()
                                                 .padding(top = Spacing.xs),
                                         textAlign = TextAlign.Center,
                                         text = LocalStrings.current.messageEmptyList,
@@ -490,11 +506,19 @@ object ProfileLoggedScreen : Tab {
                                                     OptionId.Edit,
                                                     LocalStrings.current.postActionEdit,
                                                 )
-                                            this +=
-                                                Option(
-                                                    OptionId.Delete,
-                                                    LocalStrings.current.commentActionDelete,
-                                                )
+                                            if (comment.deleted) {
+                                                this +=
+                                                    Option(
+                                                        OptionId.Restore,
+                                                        LocalStrings.current.actionRestore,
+                                                    )
+                                            } else {
+                                                this +=
+                                                    Option(
+                                                        OptionId.Delete,
+                                                        LocalStrings.current.commentActionDelete,
+                                                    )
+                                            }
                                         },
                                     onOptionSelected =
                                         rememberCallbackArgs(model) { optionId ->
@@ -535,6 +559,14 @@ object ProfileLoggedScreen : Tab {
                                                     }
                                                 }
 
+                                                OptionId.Restore -> {
+                                                    model.reduce(
+                                                        ProfileLoggedMviModel.Intent.RestoreComment(
+                                                            comment.id,
+                                                        ),
+                                                    )
+                                                }
+
                                                 else -> Unit
                                             }
                                         },
@@ -549,7 +581,8 @@ object ProfileLoggedScreen : Tab {
                                 item {
                                     Text(
                                         modifier =
-                                            Modifier.fillMaxWidth()
+                                            Modifier
+                                                .fillMaxWidth()
                                                 .padding(top = Spacing.xs),
                                         textAlign = TextAlign.Center,
                                         text = LocalStrings.current.messageEmptyList,

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailMviModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailMviModel.kt
@@ -22,23 +22,45 @@ interface PostDetailMviModel :
 
         data object LoadNextPage : Intent
 
-        data class FetchMoreComments(val parentId: Long) : Intent
+        data class FetchMoreComments(
+            val parentId: Long,
+        ) : Intent
 
-        data class UpVotePost(val feedback: Boolean = false) : Intent
+        data class UpVotePost(
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class DownVotePost(val feedback: Boolean = false) : Intent
+        data class DownVotePost(
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class SavePost(val post: PostModel, val feedback: Boolean = false) : Intent
+        data class SavePost(
+            val post: PostModel,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class UpVoteComment(val commentId: Long, val feedback: Boolean = false) : Intent
+        data class UpVoteComment(
+            val commentId: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class DownVoteComment(val commentId: Long, val feedback: Boolean = false) : Intent
+        data class DownVoteComment(
+            val commentId: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class SaveComment(val commentId: Long, val feedback: Boolean = false) : Intent
+        data class SaveComment(
+            val commentId: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class ToggleExpandComment(val commentId: Long) : Intent
+        data class ToggleExpandComment(
+            val commentId: Long,
+        ) : Intent
 
-        data class DeleteComment(val commentId: Long) : Intent
+        data class DeleteComment(
+            val commentId: Long,
+        ) : Intent
 
         data object DeletePost : Intent
 
@@ -50,25 +72,47 @@ interface PostDetailMviModel :
 
         data object ModLockPost : Intent
 
-        data class ModDistinguishComment(val commentId: Long) : Intent
+        data class ModDistinguishComment(
+            val commentId: Long,
+        ) : Intent
 
-        data class ModToggleModUser(val id: Long) : Intent
+        data class ModToggleModUser(
+            val id: Long,
+        ) : Intent
 
-        data class Share(val url: String) : Intent
+        data class Share(
+            val url: String,
+        ) : Intent
 
-        data class Copy(val value: String) : Intent
+        data class Copy(
+            val value: String,
+        ) : Intent
 
-        data class SetSearch(val value: String) : Intent
+        data class SetSearch(
+            val value: String,
+        ) : Intent
 
-        data class ChangeSearching(val value: Boolean) : Intent
+        data class ChangeSearching(
+            val value: Boolean,
+        ) : Intent
 
         data object NavigatePrevious : Intent
 
         data object NavigateNext : Intent
 
-        data class NavigatePreviousComment(val currentIndex: Int) : Intent
+        data class NavigatePreviousComment(
+            val currentIndex: Int,
+        ) : Intent
 
-        data class NavigateNextComment(val currentIndex: Int) : Intent
+        data class NavigateNextComment(
+            val currentIndex: Int,
+        ) : Intent
+
+        data object RestorePost : Intent
+
+        data class RestoreComment(
+            val commentId: Long,
+        ) : Intent
     }
 
     data class UiState(
@@ -109,10 +153,14 @@ interface PostDetailMviModel :
     sealed interface Effect {
         data object Close : Effect
 
-        data class ScrollToComment(val index: Int) : Effect
+        data class ScrollToComment(
+            val index: Int,
+        ) : Effect
 
         data object BackToTop : Effect
 
-        data class TriggerCopy(val text: String) : Effect
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -384,11 +384,19 @@ class PostDetailScreen(
                                                 OptionId.Edit,
                                                 LocalStrings.current.postActionEdit,
                                             )
-                                        this +=
-                                            Option(
-                                                OptionId.Delete,
-                                                LocalStrings.current.commentActionDelete,
-                                            )
+                                        if (uiState.post.deleted) {
+                                            this +=
+                                                Option(
+                                                    OptionId.Restore,
+                                                    LocalStrings.current.actionRestore,
+                                                )
+                                        } else {
+                                            this +=
+                                                Option(
+                                                    OptionId.Delete,
+                                                    LocalStrings.current.commentActionDelete,
+                                                )
+                                        }
                                     }
                                     if (uiState.isModerator) {
                                         this +=
@@ -652,6 +660,10 @@ class PostDetailScreen(
                                                             )
                                                         navigationCoordinator.pushScreen(screen)
                                                     }
+                                                }
+
+                                                OptionId.Restore -> {
+                                                    model.reduce(PostDetailMviModel.Intent.RestorePost)
                                                 }
 
                                                 else -> Unit
@@ -1309,11 +1321,19 @@ class PostDetailScreen(
                                                                             OptionId.Edit,
                                                                             LocalStrings.current.postActionEdit,
                                                                         )
-                                                                    this +=
-                                                                        Option(
-                                                                            OptionId.Delete,
-                                                                            LocalStrings.current.commentActionDelete,
-                                                                        )
+                                                                    if (comment.deleted) {
+                                                                        this +=
+                                                                            Option(
+                                                                                OptionId.Restore,
+                                                                                LocalStrings.current.actionRestore,
+                                                                            )
+                                                                    } else {
+                                                                        this +=
+                                                                            Option(
+                                                                                OptionId.Delete,
+                                                                                LocalStrings.current.commentActionDelete,
+                                                                            )
+                                                                    }
                                                                 }
                                                                 if (uiState.isModerator) {
                                                                     this +=
@@ -1508,6 +1528,14 @@ class PostDetailScreen(
                                                                         }
                                                                     }
 
+                                                                    OptionId.Restore -> {
+                                                                        model.reduce(
+                                                                            PostDetailMviModel.Intent.RestoreComment(
+                                                                                comment.id,
+                                                                            ),
+                                                                        )
+                                                                    }
+
                                                                     else -> Unit
                                                                 }
                                                             },
@@ -1603,11 +1631,19 @@ class PostDetailScreen(
                                                                     OptionId.Edit,
                                                                     LocalStrings.current.postActionEdit,
                                                                 )
-                                                            this +=
-                                                                Option(
-                                                                    OptionId.Delete,
-                                                                    LocalStrings.current.commentActionDelete,
-                                                                )
+                                                            if (comment.deleted) {
+                                                                this +=
+                                                                    Option(
+                                                                        OptionId.Restore,
+                                                                        LocalStrings.current.actionRestore,
+                                                                    )
+                                                            } else {
+                                                                this +=
+                                                                    Option(
+                                                                        OptionId.Delete,
+                                                                        LocalStrings.current.commentActionDelete,
+                                                                    )
+                                                            }
                                                         }
                                                         if (uiState.isModerator) {
                                                             this +=
@@ -1723,6 +1759,14 @@ class PostDetailScreen(
                                                                         ),
                                                                     )
                                                                 }
+                                                            }
+
+                                                            OptionId.Restore -> {
+                                                                model.reduce(
+                                                                    PostDetailMviModel.Intent.RestoreComment(
+                                                                        comment.id,
+                                                                    ),
+                                                                )
                                                             }
 
                                                             else -> Unit

--- a/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListMviModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postlist/PostListMviModel.kt
@@ -15,37 +15,60 @@ interface PostListMviModel :
     MviModel<PostListMviModel.Intent, PostListMviModel.UiState, PostListMviModel.Effect>,
     ScreenModel {
     sealed interface Intent {
-        data class Refresh(val hardReset: Boolean = false) : Intent
+        data class Refresh(
+            val hardReset: Boolean = false,
+        ) : Intent
 
         data object LoadNextPage : Intent
 
-        data class ChangeListing(val value: ListingType) : Intent
+        data class ChangeListing(
+            val value: ListingType,
+        ) : Intent
 
-        data class UpVotePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class UpVotePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class DownVotePost(val id: Long, val feedback: Boolean = false) : Intent
+        data class DownVotePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
-        data class SavePost(val id: Long, val feedback: Boolean = false) : Intent
-
-        data class HandlePostUpdate(val post: PostModel) : Intent
+        data class SavePost(
+            val id: Long,
+            val feedback: Boolean = false,
+        ) : Intent
 
         data object HapticIndication : Intent
 
-        data class DeletePost(val id: Long) : Intent
+        data class DeletePost(
+            val id: Long,
+        ) : Intent
 
-        data class Share(val url: String) : Intent
+        data class Share(
+            val url: String,
+        ) : Intent
 
-        data class MarkAsRead(val id: Long) : Intent
+        data class MarkAsRead(
+            val id: Long,
+        ) : Intent
 
-        data class Hide(val id: Long) : Intent
+        data class Hide(
+            val id: Long,
+        ) : Intent
 
         data object ClearRead : Intent
 
-        data class StartZombieMode(val index: Int) : Intent
+        data class StartZombieMode(
+            val index: Int,
+        ) : Intent
 
         data object PauseZombieMode : Intent
 
-        data class Copy(val value: String) : Intent
+        data class Copy(
+            val value: String,
+        ) : Intent
 
         data object WillOpenDetail : Intent
     }
@@ -83,8 +106,12 @@ interface PostListMviModel :
     sealed interface Effect {
         data object BackToTop : Effect
 
-        data class ZombieModeTick(val index: Int) : Effect
+        data class ZombieModeTick(
+            val index: Int,
+        ) : Effect
 
-        data class TriggerCopy(val text: String) : Effect
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }


### PR DESCRIPTION
This PR implements the possibility to undo the deletion of one's own posts and comments. The function is available as a drop-down menu item instead of the "Delete" action where the content is already marked as deleted.