### PR TITLE
fix: workaround for markdown escapes

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/markdown/Utils.kt
@@ -19,16 +19,16 @@ internal fun ASTNode.findChildOfTypeRecursive(type: IElementType): ASTNode? {
 
 internal fun String.sanitize(): String =
     this
-        .removeEntities()
+        .removeHtmlEntities()
         .spoilerFixUp()
         .quoteFixUp()
         .expandLemmyHandles()
-        .cleanupEscapes()
         .dollarSignFixUp()
+        .unescapeMarkdown()
         .emptyLinkFixup()
         .imageBeforeFixup()
 
-private fun String.removeEntities(): String =
+private fun String.removeHtmlEntities(): String =
     replace("&amp;", "&")
         .replace("&nbsp;", " ")
         .replace("&hellip;", "…")
@@ -85,8 +85,6 @@ private fun String.quoteFixUp(): String =
 
 private fun String.expandLemmyHandles(): String = LemmyLinkRegex.lemmyHandle.replace(this, "[$1@$2](!$1@$2)")
 
-private fun String.cleanupEscapes(): String = replace("\\#", "#")
-
 private fun String.dollarSignFixUp(): String =
     // due to a bug in how the renderer builds annotated strings, replace with full width dollar sign
     replace("$", "\uff04")
@@ -94,6 +92,14 @@ private fun String.dollarSignFixUp(): String =
 private fun String.emptyLinkFixup(): String = replace("[]()", "")
 
 private fun String.imageBeforeFixup(): String =
-    // due to a bug in the renderer, images after a new line must be on a paragraph on their own,
+// due to a bug in the renderer, images after a new line must be on a paragraph on their own,
     // so an additional newline must be inserted (they are nor inline nor a block otherwise)
     ImageRegex.imageNotAfter2Newlines.replace(this, "$1\n\n$2")
+
+private fun String.unescapeMarkdown(): String =
+    // due to a bug in the library, markdown escapes are NOT recognized, quick workaround to replace them with similar characters
+    replace("\\*", "\u2217")
+        .replace("\\_", "\uff3f")
+        .replace("\\~", "\u2035")
+        .replace("\\#", "\u266f")
+        .replace("\\>", "\u232a")


### PR DESCRIPTION
This PR replaces some common elements of Markdown syntax which are escaped in the source text with equivalent characters to avoid rendering the backslash (which is not recognized as an escape character by the library) and messing up the subsequent syntax.