### PR TITLE
feat: configurable preview length in inbox cards

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/InboxCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/lemmyui/InboxCard.kt
@@ -43,6 +43,7 @@ fun InboxCard(
     preferNicknames: Boolean = true,
     showScores: Boolean = true,
     downVoteEnabled: Boolean = true,
+    previewMaxLines: Int? = 1,
     voteFormat: VoteFormat = VoteFormat.Aggregated,
     postLayout: PostLayout = PostLayout.Card,
     options: List<Option> = emptyList(),
@@ -57,27 +58,26 @@ fun InboxCard(
 ) {
     Box(
         modifier =
-            Modifier.then(
-                if (postLayout == PostLayout.Card) {
-                    Modifier
-                        .padding(horizontal = Spacing.xs)
-                        .shadow(
-                            elevation = 5.dp,
-                            shape = RoundedCornerShape(CornerSize.l),
-                        )
-                        .clip(RoundedCornerShape(CornerSize.l))
-                        .background(
-                            color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
-                        )
-                        .padding(vertical = Spacing.s)
-                } else {
-                    Modifier.background(MaterialTheme.colorScheme.background)
-                },
-            ).onClick(
-                onClick = {
-                    onOpenPost(mention.post)
-                },
-            ),
+            Modifier
+                .then(
+                    if (postLayout == PostLayout.Card) {
+                        Modifier
+                            .padding(horizontal = Spacing.xs)
+                            .shadow(
+                                elevation = 5.dp,
+                                shape = RoundedCornerShape(CornerSize.l),
+                            ).clip(RoundedCornerShape(CornerSize.l))
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
+                            ).padding(vertical = Spacing.s)
+                    } else {
+                        Modifier.background(MaterialTheme.colorScheme.background)
+                    },
+                ).onClick(
+                    onClick = {
+                        onOpenPost(mention.post)
+                    },
+                ),
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
@@ -95,14 +95,23 @@ fun InboxCard(
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha),
                 )
             } else {
+                val previewText =
+                    if (previewMaxLines == null || previewMaxLines < 0) {
+                        mention.comment.text.orEmpty()
+                    } else {
+                        mention.comment.text
+                            .orEmpty()
+                            .split("\n")
+                            .take(previewMaxLines)
+                            .joinToString("\n")
+                    }
                 CustomizedContent(ContentFontClass.Body) {
                     PostCardBody(
                         modifier =
                             Modifier.padding(
                                 horizontal = Spacing.s,
                             ),
-                        // takes just the first line
-                        text = mention.comment.text.orEmpty().substringBefore("\n"),
+                        text = previewText,
                         autoLoadImages = autoLoadImages,
                         onOpenImage = onImageClick,
                         onClick = {

--- a/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/NumberPickerDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/commonui/modals/NumberPickerDialog.kt
@@ -32,10 +32,13 @@ import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
 fun NumberPickerDialog(
     title: String = "",
     initialValue: Int = 0,
+    minValue: Int = 0,
+    maxValue: Int = Int.MAX_VALUE,
     onClose: (() -> Unit)? = null,
     onSubmit: ((Int) -> Unit)? = null,
 ) {
     var currentValue by remember { mutableStateOf(initialValue.toString()) }
+    var isOnError by remember { mutableStateOf(false) }
     BasicAlertDialog(
         onDismissRequest = {
             onClose?.invoke()
@@ -63,6 +66,7 @@ fun NumberPickerDialog(
                         unfocusedContainerColor = Color.Transparent,
                         disabledContainerColor = Color.Transparent,
                     ),
+                isError = isOnError,
                 textStyle = MaterialTheme.typography.bodyMedium,
                 value = currentValue,
                 keyboardOptions =
@@ -78,7 +82,13 @@ fun NumberPickerDialog(
             Spacer(modifier = Modifier.height(Spacing.xs))
             Button(
                 onClick = {
-                    onSubmit?.invoke(currentValue.toIntOrNull() ?: 0)
+                    val value = currentValue.toIntOrNull() ?: 0
+                    if (value in minValue until maxValue) {
+                        isOnError = false
+                        onSubmit?.invoke(value)
+                    } else {
+                        isOnError = true
+                    }
                 },
             ) {
                 Text(text = LocalStrings.current.buttonConfirm)

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
@@ -419,4 +419,5 @@ internal val ArStrings =
         override val settingsEnableToggleFavoriteInNavDrawer = "إضافة/إزالة المفضلة في درج التنقل"
         override val messageContentDeleted = "لقد قمت بحذف هذا المحتوى"
         override val actionRestore = "يعيد"
+        override val settingsInboxPreviewMaxLines = "الحد الأقصى لعدد الخطوط في بطاقات البريد الوارد"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
@@ -428,4 +428,5 @@ internal val BgStrings =
             "Добавяне/премахване на любими в чекмеджето за навигация"
         override val messageContentDeleted = "Вие изтрихте това съдържание"
         override val actionRestore = "Възстанови"
+        override val settingsInboxPreviewMaxLines = "Максимален брой редове във входящите карти"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
@@ -424,4 +424,5 @@ internal val CsStrings =
             "Přidat/odebrat oblíbené položky v navigační zásuvce"
         override val messageContentDeleted = "Tento obsah jste smazali"
         override val actionRestore = "Obnovit"
+        override val settingsInboxPreviewMaxLines = "Maximální počet řádků na kartách doručené pošty"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
@@ -424,4 +424,5 @@ internal val DaStrings =
             "Tilføj/fjern favoritter i navigationsskuffen"
         override val messageContentDeleted = "Du har slettet dette indhold"
         override val actionRestore = "Gendan"
+        override val settingsInboxPreviewMaxLines = "Max antal linjer i indbakkekort"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
@@ -427,4 +427,6 @@ internal val DeStrings =
             "Favoriten in der Navigationsleiste hinzufügen/entfernen"
         override val messageContentDeleted = "Sie haben diesen Inhalt gelöscht"
         override val actionRestore = "Wiederherstellen"
+        override val settingsInboxPreviewMaxLines =
+            "Maximale Anzahl von Zeilen in Posteingangskarten"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
@@ -431,4 +431,6 @@ internal val ElStrings =
             "Προσθήκη/αφαίρεση αγαπημένων στο συρτάρι πλοήγησης"
         override val messageContentDeleted = "Έχετε διαγράψει αυτό το περιεχόμενο"
         override val actionRestore = "Αποκαταστήστε το"
+        override val settingsInboxPreviewMaxLines =
+            "Μέγιστος αριθμός γραμμών σε κάρτες εισερχομένων"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
@@ -421,4 +421,5 @@ internal val EnStrings =
             "Add/remove favorites in navigation drawer"
         override val messageContentDeleted = "You have deleted this content"
         override val actionRestore = "Restore"
+        override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
@@ -420,4 +420,5 @@ internal val EoStrings =
             "Aldoni/forigi plej ŝatatajn en navigada tirkesto"
         override val messageContentDeleted = "Vi forigis ĉi tiun enhavon"
         override val actionRestore = "Restaŭri"
+        override val settingsInboxPreviewMaxLines = "Maksimuma nombro da linioj en enirkestokartoj"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
@@ -425,4 +425,6 @@ internal val EsStrings =
             "Agregar/eliminar favoritos en el cajón de navegación"
         override val messageContentDeleted = "Has eliminado este contenido"
         override val actionRestore = "Restaurar"
+        override val settingsInboxPreviewMaxLines =
+            "Número máximo de líneas en tarjetas de mensajes"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
@@ -426,4 +426,5 @@ internal val EtStrings =
             "Lemmikute lisamine/eemaldamine navigeerimissahtlis"
         override val messageContentDeleted = "Olete selle sisu kustutanud"
         override val actionRestore = "Taastama"
+        override val settingsInboxPreviewMaxLines = "Maksimaalne ridade arv postkasti kaartidel"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
@@ -421,4 +421,5 @@ internal val FiStrings =
             "Lisää/poista suosikkeja navigointipaneelissa"
         override val messageContentDeleted = "Olet poistanut tämän sisällön"
         override val actionRestore = "Palauttaa"
+        override val settingsInboxPreviewMaxLines = "Saapuneiden korttien rivien enimmäismäärä"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
@@ -430,4 +430,6 @@ internal val FrStrings =
             "Ajouter/supprimer des favoris dans le tiroir de navigation"
         override val messageContentDeleted = "Vous avez supprimé ce contenu"
         override val actionRestore = "Restaurer"
+        override val settingsInboxPreviewMaxLines =
+            "Nombre maximum de lignes dans les cartes de boîte de réception"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
@@ -425,4 +425,5 @@ internal val GaStrings =
             "Cuir leis/bain na ceanáin sa tarraiceán nascleanúna"
         override val messageContentDeleted = "Tá an t-ábhar seo scriosta agat"
         override val actionRestore = "Athchóirigh"
+        override val settingsInboxPreviewMaxLines = "An líon uasta línte i gcártaí bosca isteach"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
@@ -425,4 +425,5 @@ internal val HrStrings =
             "Dodajte/uklonite favorite u ladici za navigaciju"
         override val messageContentDeleted = "Izbrisali ste ovaj sadržaj"
         override val actionRestore = "Vratiti"
+        override val settingsInboxPreviewMaxLines = "Maksimalan broj redaka u ulaznim karticama"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
@@ -429,4 +429,5 @@ internal val HuStrings =
             "Kedvencek hozzáadása/eltávolítása a navigációs fiókban"
         override val messageContentDeleted = "Ezt a tartalmat törölted"
         override val actionRestore = "visszaállítás"
+        override val settingsInboxPreviewMaxLines = "Maximális sorok száma a postafiók kártyákban"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -426,4 +426,5 @@ internal val ItStrings =
             "Aggiungi/rimuovi preferiti in menu laterale"
         override val messageContentDeleted = "Hai eliminato questo contenuto"
         override val actionRestore = "Ripristina"
+        override val settingsInboxPreviewMaxLines = "Numero massimo righe anteprima in inbox"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
@@ -424,4 +424,5 @@ internal val LtStrings =
             "Pridėti / pašalinti mėgstamiausius naršymo skydelyje"
         override val messageContentDeleted = "Ištrynėte šį turinį"
         override val actionRestore = "Atkurti"
+        override val settingsInboxPreviewMaxLines = "Maksimalus eilučių skaičius gautųjų kortelėse"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
@@ -423,4 +423,5 @@ internal val LvStrings =
             "Pievienojiet/noņemiet izlasi navigācijas atvilktnē"
         override val messageContentDeleted = "Jūs esat izdzēsis šo saturu"
         override val actionRestore = "Atjaunot"
+        override val settingsInboxPreviewMaxLines = "Maksimālais rindu skaits iesūtnes kartītēs"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
@@ -425,4 +425,5 @@ internal val MtStrings =
             "Żid/neħħi l-favoriti fil-kexxun tan-navigazzjoni"
         override val messageContentDeleted = "Ħassejt dan il-kontenut"
         override val actionRestore = "Irrestawra"
+        override val settingsInboxPreviewMaxLines = "Numru massimu ta' linji fil-karti tal-inbox"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
@@ -426,4 +426,5 @@ internal val NlStrings =
             "Favorieten toevoegen/verwijderen in de navigatielade"
         override val messageContentDeleted = "Je hebt deze inhoud verwijderd"
         override val actionRestore = "Herstellen"
+        override val settingsInboxPreviewMaxLines = "Maximaal aantal regels in inboxkaarten"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NoStrings.kt
@@ -423,4 +423,5 @@ internal val NoStrings =
             "Legg til/fjern favoritter i navigasjonsskuffen"
         override val messageContentDeleted = "Du har slettet dette innholdet"
         override val actionRestore = "Restaurere"
+        override val settingsInboxPreviewMaxLines = "Maks antall linjer i innbokskort"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
@@ -425,4 +425,6 @@ internal val PlStrings =
             "Dodaj/usuń ulubione w szufladzie nawigacji"
         override val messageContentDeleted = "Usunąłeś tę treść"
         override val actionRestore = "Przywrócić"
+        override val settingsInboxPreviewMaxLines =
+            "Maksymalna liczba linii w kartach skrzynki odbiorczej"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
@@ -423,4 +423,6 @@ internal val PtBrStrings =
             "Adicionar/remover favoritos na gaveta de navegação"
         override val messageContentDeleted = "Você excluiu este conteúdo"
         override val actionRestore = "Restaura"
+        override val settingsInboxPreviewMaxLines =
+            "Número máximo de linhas nos cartões das mensagens"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
@@ -424,4 +424,6 @@ internal val PtStrings =
             "Adicionar/remover favoritos na gaveta de navegação"
         override val messageContentDeleted = "Você excluiu este conteúdo"
         override val actionRestore = "Restaura"
+        override val settingsInboxPreviewMaxLines =
+            "Número máximo de linhas nos cartões das mensagens"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
@@ -424,4 +424,5 @@ internal val RoStrings =
             "Adăugă/elimină favoritele din sertarul de navigare"
         override val messageContentDeleted = "Ați șters acest conținut"
         override val actionRestore = "Restaurați-l"
+        override val settingsInboxPreviewMaxLines = "Numărul maxim de linii în cardurile de inbox"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
@@ -426,4 +426,6 @@ internal val RuStrings =
             "Добавить/удалить избранное в панели навигации"
         override val messageContentDeleted = "Вы удалили этот контент"
         override val actionRestore = "Восстановить"
+        override val settingsInboxPreviewMaxLines =
+            "Максимальное количество строк во входящих карточках"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SeStrings.kt
@@ -424,4 +424,5 @@ internal val SeStrings =
             "Lägg till/ta bort favoriter i navigeringslådan"
         override val messageContentDeleted = "Du har tagit bort detta innehåll"
         override val actionRestore = "Återställ"
+        override val settingsInboxPreviewMaxLines = "Max antal rader i inkorgskort"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
@@ -426,4 +426,6 @@ internal val SkStrings =
             "Pridať/odstrániť obľúbené položky v navigačnej zásuvke"
         override val messageContentDeleted = "Tento obsah ste odstránili"
         override val actionRestore = "Obnoviť"
+        override val settingsInboxPreviewMaxLines =
+            "Maximálny počet riadkov na kartách doručenej pošty"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
@@ -424,4 +424,6 @@ internal val SlStrings =
             "Dodajte/odstranite priljubljene v predalu za krmarjenje"
         override val messageContentDeleted = "To vsebino ste izbrisali"
         override val actionRestore = "Obnovi"
+        override val settingsInboxPreviewMaxLines =
+            "Največje število vrstic v karticah prejete pošte"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
@@ -426,4 +426,6 @@ internal val SqStrings =
             "Shto/hiq të preferuarat në sirtarin e navigimit"
         override val messageContentDeleted = "Ju e keni fshirë këtë përmbajtje"
         override val actionRestore = "Rivendos"
+        override val settingsInboxPreviewMaxLines =
+            "Numri maksimal i rreshtave në kartat e kutisë hyrëse"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
@@ -426,4 +426,6 @@ internal val SrStrings =
             "Додајте/уклоните фаворите у фиоци за навигацију"
         override val messageContentDeleted = "Избрисали сте овај садржај"
         override val actionRestore = "Ресторе"
+        override val settingsInboxPreviewMaxLines =
+            "Максималан број линија у картицама пријемног сандучет"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -418,6 +418,7 @@ interface Strings {
     val settingsEnableToggleFavoriteInNavDrawer: String
     val messageContentDeleted: String
     val actionRestore: String
+    val settingsInboxPreviewMaxLines: String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
@@ -420,4 +420,5 @@ internal val TokStrings =
             "o sin/o weka e ijo pona lon leko luka"
         override val messageContentDeleted = "tenpo pini la, sina weka e ijo ni"
         override val actionRestore = "o awen e ona"
+        override val settingsInboxPreviewMaxLines = "nanpa linja pi lipu lon toki poki"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
@@ -425,4 +425,6 @@ internal val TrStrings =
             "Gezinme çekmecesinde favorileri ekle/kaldır"
         override val messageContentDeleted = "Bu içeriği sildiniz"
         override val actionRestore = "Eski haline getirmek"
+        override val settingsInboxPreviewMaxLines =
+            "Gelen kutusu kartlarındaki maksimum satır sayısı"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
@@ -426,4 +426,6 @@ internal val UkStrings =
             "Додати/видалити вибране в панелі навігації"
         override val messageContentDeleted = "Ви видалили цей вміст"
         override val actionRestore = "Відновлення"
+        override val settingsInboxPreviewMaxLines =
+            "Максимальна кількість рядків у картках вхідних повідомлень"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhHkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhHkStrings.kt
@@ -414,4 +414,5 @@ internal val ZhHkStrings =
         override val settingsEnableToggleFavoriteInNavDrawer = "加入/攞走導航櫃桶嘅最愛"
         override val messageContentDeleted = "您刪除咗呢個內容"
         override val actionRestore = "恢復"
+        override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
@@ -414,4 +414,5 @@ internal val ZhTwStrings =
         override val settingsEnableToggleFavoriteInNavDrawer = "加入/移除導航抽屜中的收藏"
         override val messageContentDeleted = "您已刪除此內容"
         override val actionRestore = "恢復"
+        override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
     }

--- a/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -153,8 +153,9 @@ sealed interface NotificationCenterEvent {
         val url: String,
     ) : NotificationCenterEvent
 
-    data class ChangePostBodyMaxLines(
+    data class SelectNumberBottomSheetClosed(
         val value: Int?,
+        val type: Int,
     ) : NotificationCenterEvent
 
     data class InstanceSelected(

--- a/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
@@ -157,6 +157,7 @@ class DefaultSettingsRepositoryTest {
                     commentIndentAmount = model.commentIndentAmount.toLong(),
                     enableToggleFavoriteInNavDrawer = if (model.enableToggleFavoriteInNavDrawer) 1 else 0,
                     account_id = 1,
+                    inboxPreviewMaxLines = model.inboxPreviewMaxLines?.toLong(),
                 )
             }
         }
@@ -229,6 +230,7 @@ class DefaultSettingsRepositoryTest {
                     commentIndentAmount = model.commentIndentAmount.toLong(),
                     enableToggleFavoriteInNavDrawer = if (model.enableToggleFavoriteInNavDrawer) 1 else 0,
                     account_id = 1,
+                    inboxPreviewMaxLines = model.inboxPreviewMaxLines?.toLong(),
                 )
             }
         }
@@ -296,6 +298,7 @@ class DefaultSettingsRepositoryTest {
         showUnreadComments: Boolean = true,
         commentIndentAmount: Int = 2,
         enableToggleFavoriteInNavDrawer: Boolean = false,
+        inboxPreviewMaxLines: Int? = null,
     ) = GetBy(
         id = id,
         theme = theme,
@@ -357,5 +360,6 @@ class DefaultSettingsRepositoryTest {
         showUnreadComments = if (showUnreadComments) 1 else 0,
         commentIndentAmount = commentIndentAmount.toLong(),
         enableToggleFavoriteInNavDrawer = if (enableToggleFavoriteInNavDrawer) 1 else 0,
+        inboxPreviewMaxLines = inboxPreviewMaxLines?.toLong(),
     )
 }

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
@@ -63,4 +63,5 @@ data class SettingsModel(
     val enableButtonsToScrollBetweenComments: Boolean = false,
     val commentIndentAmount: Int = 2,
     val enableToggleFavoriteInNavDrawer: Boolean = false,
+    val inboxPreviewMaxLines: Int? = null,
 )

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -157,6 +157,7 @@ internal class DefaultSettingsRepository(
             enableButtonsToScrollBetweenComments = if (settings.enableButtonsToScrollBetweenComments) 1L else 0L,
             fullWidthImages = if (settings.fullWidthImages) 1L else 0L,
             enableToggleFavoriteInNavDrawer = if (settings.enableToggleFavoriteInNavDrawer) 1L else 0L,
+            inboxPreviewMaxLines = settings.inboxPreviewMaxLines?.toLong(),
         )
     }
 
@@ -431,6 +432,7 @@ internal class DefaultSettingsRepository(
                 enableButtonsToScrollBetweenComments = if (settings.enableButtonsToScrollBetweenComments) 1L else 0L,
                 fullWidthImages = if (settings.fullWidthImages) 1L else 0L,
                 enableToggleFavoriteInNavDrawer = if (settings.enableToggleFavoriteInNavDrawer) 1L else 0L,
+                inboxPreviewMaxLines = settings.inboxPreviewMaxLines?.toLong(),
             )
         }
     }
@@ -529,4 +531,5 @@ private fun GetBy.toModel() =
         enableButtonsToScrollBetweenComments = enableButtonsToScrollBetweenComments == 1L,
         fullWidthImages = fullWidthImages == 1L,
         enableToggleFavoriteInNavDrawer = enableToggleFavoriteInNavDrawer == 1L,
+        inboxPreviewMaxLines = inboxPreviewMaxLines?.toInt(),
     )

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/usecase/SerializableSettings.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/usecase/SerializableSettings.kt
@@ -75,6 +75,7 @@ internal data class SerializableSettings(
     val enableButtonsToScrollBetweenComments: Boolean = false,
     val fullWidthImages: Boolean = false,
     val enableToggleFavoriteInNavDrawer: Boolean = false,
+    val inboxPreviewMaxLines: Int? = null,
 )
 
 internal fun SerializableSettings.toModel() =
@@ -141,6 +142,7 @@ internal fun SerializableSettings.toModel() =
         enableButtonsToScrollBetweenComments = enableButtonsToScrollBetweenComments,
         fullWidthImages = fullWidthImages,
         enableToggleFavoriteInNavDrawer = enableToggleFavoriteInNavDrawer,
+        inboxPreviewMaxLines = inboxPreviewMaxLines,
     )
 
 internal fun SettingsModel.toData() =
@@ -148,7 +150,15 @@ internal fun SettingsModel.toData() =
         theme = theme,
         uiFontFamily = uiFontFamily,
         uiFontScale = uiFontScale,
-        contentFontScale = contentFontScale.let { listOf(it.title, it.body, it.comment, it.ancillary) },
+        contentFontScale =
+            contentFontScale.let {
+                listOf(
+                    it.title,
+                    it.body,
+                    it.comment,
+                    it.ancillary,
+                )
+            },
         contentFontFamily = contentFontFamily,
         locale = locale,
         defaultListingType = defaultListingType,
@@ -201,4 +211,5 @@ internal fun SettingsModel.toData() =
         enableButtonsToScrollBetweenComments = enableButtonsToScrollBetweenComments,
         fullWidthImages = fullWidthImages,
         enableToggleFavoriteInNavDrawer = enableToggleFavoriteInNavDrawer,
+        inboxPreviewMaxLines = inboxPreviewMaxLines,
     )

--- a/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
@@ -60,6 +60,7 @@ CREATE TABLE SettingsEntity (
     fullWidthImages INTEGER NOT NULL DEFAULT 0,
     commentIndentAmount INTEGER NOT NULL DEFAULT 2,
     enableToggleFavoriteInNavDrawer INTEGER NOT NULL DEFAULT 0,
+    inboxPreviewMaxLines INTEGER DEFAULT NULL,
     FOREIGN KEY (account_id) REFERENCES AccountEntity(id) ON DELETE CASCADE,
     UNIQUE(account_id)
 );
@@ -125,8 +126,10 @@ INSERT OR IGNORE INTO SettingsEntity (
     fullWidthImages,
     commentIndentAmount,
     enableToggleFavoriteInNavDrawer,
+    inboxPreviewMaxLines,
     account_id
 ) VALUES (
+    ?,
     ?,
     ?,
     ?,
@@ -249,7 +252,8 @@ SET theme = ?,
     enableButtonsToScrollBetweenComments = ?,
     fullWidthImages = ?,
     commentIndentAmount = ?,
-    enableToggleFavoriteInNavDrawer = ?
+    enableToggleFavoriteInNavDrawer = ?,
+    inboxPreviewMaxLines = ?
 WHERE account_id = ?;
 
 getBy:
@@ -313,6 +317,7 @@ SELECT
     enableButtonsToScrollBetweenComments,
     fullWidthImages,
     commentIndentAmount,
-    enableToggleFavoriteInNavDrawer
+    enableToggleFavoriteInNavDrawer,
+    inboxPreviewMaxLines
 FROM SettingsEntity
 WHERE account_id = ?;

--- a/core/persistence/src/commonMain/sqldelight/migrations/35.sqm
+++ b/core/persistence/src/commonMain/sqldelight/migrations/35.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE SettingsEntity
+ADD COLUMN inboxPreviewMaxLines INTEGER DEFAULT NULL;

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -106,6 +106,7 @@ interface AdvancedSettingsMviModel :
         val loading: Boolean = false,
         val enableButtonsToScrollBetweenComments: Boolean = false,
         val enableToggleFavoriteInNavDrawer: Boolean = false,
+        val inboxPreviewMaxLines: Int? = null,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -56,6 +56,8 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.DurationBot
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.InboxTypeSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.ListingTypeBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectLanguageDialog
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SliderBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -283,6 +285,34 @@ class AdvancedSettingsScreen : Screen {
                                     navigationCoordinator.showBottomSheet(sheet)
                                 },
                         )
+
+                        // inbox preview max lines
+                        SettingsRow(
+                            title = LocalStrings.current.settingsInboxPreviewMaxLines,
+                            value =
+                                if (uiState.inboxPreviewMaxLines == null) {
+                                    LocalStrings.current.settingsPostBodyMaxLinesUnlimited
+                                } else {
+                                    uiState.inboxPreviewMaxLines.toString()
+                                },
+                            onTap =
+                                rememberCallback {
+                                    val screen =
+                                        SelectNumberBottomSheet(
+                                            values =
+                                                listOf(
+                                                    1,
+                                                    10,
+                                                    50,
+                                                    -1, // custom number
+                                                    null, // unlimited
+                                                ),
+                                            type = SelectNumberBottomSheetType.InboxPreviewMaxLines,
+                                            initialValue = uiState.inboxPreviewMaxLines,
+                                        )
+                                    navigationCoordinator.showBottomSheet(screen)
+                                },
+                        )
                     }
 
                     // default language
@@ -393,7 +423,9 @@ class AdvancedSettingsScreen : Screen {
                         onValueChanged =
                             rememberCallbackArgs(model) { value ->
                                 model.reduce(
-                                    AdvancedSettingsMviModel.Intent.ChangeEnableButtonsToScrollBetweenComments(value),
+                                    AdvancedSettingsMviModel.Intent.ChangeEnableButtonsToScrollBetweenComments(
+                                        value,
+                                    ),
                                 )
                             },
                     )

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -4,6 +4,8 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.UiBarTheme
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.DefaultMviModel
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.toSelectNumberBottomSheetType
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenter
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.SettingsModel
@@ -93,6 +95,13 @@ class AdvancedSettingsViewModel(
                 .onEach { evt ->
                     changeAppIconVariant(evt.value.toAppIconVariant())
                 }.launchIn(this)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.SelectNumberBottomSheetClosed::class)
+                .onEach { evt ->
+                    if (evt.type.toSelectNumberBottomSheetType() == SelectNumberBottomSheetType.InboxPreviewMaxLines) {
+                        changeInboxPreviewMaxLines(evt.value)
+                    }
+                }.launchIn(this)
 
             updateAvailableLanguages()
 
@@ -122,6 +131,7 @@ class AdvancedSettingsViewModel(
                     supportSettingsImportExport = fileSystemManager.isSupported,
                     enableButtonsToScrollBetweenComments = settings.enableButtonsToScrollBetweenComments,
                     enableToggleFavoriteInNavDrawer = settings.enableToggleFavoriteInNavDrawer,
+                    inboxPreviewMaxLines = settings.inboxPreviewMaxLines,
                 )
             }
         }
@@ -368,6 +378,15 @@ class AdvancedSettingsViewModel(
             updateState { it.copy(enableToggleFavoriteInNavDrawer = value) }
             val settings =
                 settingsRepository.currentSettings.value.copy(enableToggleFavoriteInNavDrawer = value)
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeInboxPreviewMaxLines(value: Int?) {
+        screenModelScope.launch {
+            updateState { it.copy(inboxPreviewMaxLines = value) }
+            val settings =
+                settingsRepository.currentSettings.value.copy(inboxPreviewMaxLines = value)
             saveSettings(settings)
         }
     }

--- a/unit/configurecontentview/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -42,8 +42,9 @@ import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsHe
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsIntValueRow
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
-import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.PostBodyMaxLinesBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.PostLayoutBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheet
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
 import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.VoteFormatBottomSheet
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -102,8 +103,7 @@ class ConfigureContentViewScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        )
-                        .nestedScroll(scrollBehavior.nestedScrollConnection),
+                        ).nestedScroll(scrollBehavior.nestedScrollConnection),
             ) {
                 Column(
                     modifier = Modifier.fillMaxSize().verticalScroll(scrollState),
@@ -128,7 +128,10 @@ class ConfigureContentViewScreen : Screen {
                     // content font scale
                     SettingsRow(
                         title = LocalStrings.current.settingsTitleFontScale,
-                        value = uiState.contentFontScale.title.toFontScale().toReadableName(),
+                        value =
+                            uiState.contentFontScale.title
+                                .toFontScale()
+                                .toReadableName(),
                         onTap =
                             rememberCallback {
                                 val sheet = FontScaleBottomSheet(contentClass = ContentFontClass.Title)
@@ -137,7 +140,10 @@ class ConfigureContentViewScreen : Screen {
                     )
                     SettingsRow(
                         title = LocalStrings.current.settingsContentFontScale,
-                        value = uiState.contentFontScale.body.toFontScale().toReadableName(),
+                        value =
+                            uiState.contentFontScale.body
+                                .toFontScale()
+                                .toReadableName(),
                         onTap =
                             rememberCallback {
                                 val sheet = FontScaleBottomSheet(contentClass = ContentFontClass.Body)
@@ -146,7 +152,10 @@ class ConfigureContentViewScreen : Screen {
                     )
                     SettingsRow(
                         title = LocalStrings.current.settingsCommentFontScale,
-                        value = uiState.contentFontScale.comment.toFontScale().toReadableName(),
+                        value =
+                            uiState.contentFontScale.comment
+                                .toFontScale()
+                                .toReadableName(),
                         onTap =
                             rememberCallback {
                                 val sheet =
@@ -156,7 +165,10 @@ class ConfigureContentViewScreen : Screen {
                     )
                     SettingsRow(
                         title = LocalStrings.current.settingsAncillaryFontScale,
-                        value = uiState.contentFontScale.ancillary.toFontScale().toReadableName(),
+                        value =
+                            uiState.contentFontScale.ancillary
+                                .toFontScale()
+                                .toReadableName(),
                         onTap =
                             rememberCallback {
                                 val sheet =
@@ -193,7 +205,11 @@ class ConfigureContentViewScreen : Screen {
                                 },
                             onTap =
                                 rememberCallback {
-                                    val screen = PostBodyMaxLinesBottomSheet()
+                                    val screen =
+                                        SelectNumberBottomSheet(
+                                            type = SelectNumberBottomSheetType.PostBodyMaxLines,
+                                            initialValue = uiState.postBodyMaxLines,
+                                        )
                                     navigationCoordinator.showBottomSheet(screen)
                                 },
                         )

--- a/unit/configurecontentview/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewViewModel.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewViewModel.kt
@@ -8,6 +8,8 @@ import com.github.diegoberaldin.raccoonforlemmy.core.appearance.data.toInt
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ContentFontClass
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.repository.ThemeRepository
 import com.github.diegoberaldin.raccoonforlemmy.core.architecture.DefaultMviModel
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.modals.toSelectNumberBottomSheetType
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenter
 import com.github.diegoberaldin.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.github.diegoberaldin.raccoonforlemmy.core.persistence.data.SettingsModel
@@ -29,39 +31,49 @@ class ConfigureContentViewViewModel(
     private val identityRepository: IdentityRepository,
     private val siteRepository: SiteRepository,
     private val notificationCenter: NotificationCenter,
-) : ConfigureContentViewMviModel,
-    DefaultMviModel<ConfigureContentViewMviModel.Intent, ConfigureContentViewMviModel.State, ConfigureContentViewMviModel.Effect>(
+) : DefaultMviModel<ConfigureContentViewMviModel.Intent, ConfigureContentViewMviModel.State, ConfigureContentViewMviModel.Effect>(
         initialState = ConfigureContentViewMviModel.State(),
-    ) {
+    ),
+    ConfigureContentViewMviModel {
     init {
         screenModelScope.launch {
-            themeRepository.postLayout.onEach { value ->
-                updateState { it.copy(postLayout = value) }
-            }.launchIn(this)
-            themeRepository.contentFontScale.onEach { value ->
-                updateState { it.copy(contentFontScale = value) }
-            }.launchIn(this)
-            themeRepository.contentFontFamily.onEach { value ->
-                updateState { it.copy(contentFontFamily = value) }
-            }.launchIn(this)
+            themeRepository.postLayout
+                .onEach { value ->
+                    updateState { it.copy(postLayout = value) }
+                }.launchIn(this)
+            themeRepository.contentFontScale
+                .onEach { value ->
+                    updateState { it.copy(contentFontScale = value) }
+                }.launchIn(this)
+            themeRepository.contentFontFamily
+                .onEach { value ->
+                    updateState { it.copy(contentFontFamily = value) }
+                }.launchIn(this)
 
-            notificationCenter.subscribe(NotificationCenterEvent.ChangePostLayout::class)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.ChangePostLayout::class)
                 .onEach { evt ->
                     changePostLayout(evt.value)
                 }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.ChangeVoteFormat::class)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.ChangeVoteFormat::class)
                 .onEach { evt ->
                     changeVoteFormat(evt.value)
                 }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.ChangePostBodyMaxLines::class)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.SelectNumberBottomSheetClosed::class)
                 .onEach { evt ->
-                    changePostBodyMaxLines(evt.value)
+                    if (evt.type.toSelectNumberBottomSheetType() == SelectNumberBottomSheetType.PostBodyMaxLines) {
+                        changePostBodyMaxLines(evt.value)
+                    }
                 }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.ChangeContentFontSize::class)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.ChangeContentFontSize::class)
                 .onEach { evt ->
                     changeContentFontScale(evt.value, evt.contentClass)
                 }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.ChangeContentFontFamily::class)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.ChangeContentFontFamily::class)
                 .onEach { evt ->
                     changeContentFontFamily(evt.value)
                 }.launchIn(this)

--- a/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsMviModel.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsMviModel.kt
@@ -17,13 +17,20 @@ interface InboxMentionsMviModel :
 
         data object LoadNextPage : Intent
 
-        data class MarkAsRead(val read: Boolean, val id: Long) : Intent
+        data class MarkAsRead(
+            val read: Boolean,
+            val id: Long,
+        ) : Intent
 
         data object HapticIndication : Intent
 
-        data class UpVoteComment(val id: Long) : Intent
+        data class UpVoteComment(
+            val id: Long,
+        ) : Intent
 
-        data class DownVoteComment(val id: Long) : Intent
+        data class DownVoteComment(
+            val id: Long,
+        ) : Intent
     }
 
     data class UiState(
@@ -33,6 +40,7 @@ interface InboxMentionsMviModel :
         val canFetchMore: Boolean = true,
         val unreadOnly: Boolean = true,
         val mentions: List<PersonMentionModel> = emptyList(),
+        val previewMaxLines: Int? = null,
         val swipeActionsEnabled: Boolean = true,
         val postLayout: PostLayout = PostLayout.Card,
         val autoLoadImages: Boolean = true,
@@ -45,7 +53,9 @@ interface InboxMentionsMviModel :
     )
 
     sealed interface Effect {
-        data class UpdateUnreadItems(val value: Int) : Effect
+        data class UpdateUnreadItems(
+            val value: Int,
+        ) : Effect
 
         data object BackToTop : Effect
     }

--- a/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsScreen.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/mentions/InboxMentionsScreen.kt
@@ -80,28 +80,30 @@ class InboxMentionsScreen : Tab {
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
 
         LaunchedEffect(navigationCoordinator) {
-            navigationCoordinator.onDoubleTabSelection.onEach { section ->
-                runCatching {
-                    if (section == TabNavigationSection.Inbox) {
-                        lazyListState.scrollToItem(0)
-                    }
-                }
-            }.launchIn(this)
-        }
-        LaunchedEffect(model) {
-            model.effects.onEach { effect ->
-                when (effect) {
-                    is InboxMentionsMviModel.Effect.UpdateUnreadItems -> {
-                        navigationCoordinator.setInboxUnread(effect.value)
-                    }
-
-                    InboxMentionsMviModel.Effect.BackToTop -> {
-                        runCatching {
+            navigationCoordinator.onDoubleTabSelection
+                .onEach { section ->
+                    runCatching {
+                        if (section == TabNavigationSection.Inbox) {
                             lazyListState.scrollToItem(0)
                         }
                     }
-                }
-            }.launchIn(this)
+                }.launchIn(this)
+        }
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { effect ->
+                    when (effect) {
+                        is InboxMentionsMviModel.Effect.UpdateUnreadItems -> {
+                            navigationCoordinator.setInboxUnread(effect.value)
+                        }
+
+                        InboxMentionsMviModel.Effect.BackToTop -> {
+                            runCatching {
+                                lazyListState.scrollToItem(0)
+                            }
+                        }
+                    }
+                }.launchIn(this)
         }
 
         val pullRefreshState =
@@ -241,6 +243,7 @@ class InboxMentionsScreen : Tab {
                                 showScores = uiState.showScores,
                                 voteFormat = uiState.voteFormat,
                                 downVoteEnabled = uiState.downVoteEnabled,
+                                previewMaxLines = uiState.previewMaxLines,
                                 onOpenPost =
                                     rememberCallbackArgs { post ->
                                         if (!mention.read) {
@@ -270,7 +273,10 @@ class InboxMentionsScreen : Tab {
                                         navigationCoordinator.pushScreen(
                                             ZoomableImageScreen(
                                                 url = url,
-                                                source = mention.post.community?.readableHandle.orEmpty(),
+                                                source =
+                                                    mention.post.community
+                                                        ?.readableHandle
+                                                        .orEmpty(),
                                             ),
                                         )
                                     },

--- a/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesMviModel.kt
+++ b/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesMviModel.kt
@@ -17,13 +17,20 @@ interface InboxRepliesMviModel :
 
         data object LoadNextPage : Intent
 
-        data class MarkAsRead(val read: Boolean, val id: Long) : Intent
+        data class MarkAsRead(
+            val read: Boolean,
+            val id: Long,
+        ) : Intent
 
         data object HapticIndication : Intent
 
-        data class UpVoteComment(val id: Long) : Intent
+        data class UpVoteComment(
+            val id: Long,
+        ) : Intent
 
-        data class DownVoteComment(val id: Long) : Intent
+        data class DownVoteComment(
+            val id: Long,
+        ) : Intent
     }
 
     data class UiState(
@@ -33,6 +40,7 @@ interface InboxRepliesMviModel :
         val canFetchMore: Boolean = true,
         val unreadOnly: Boolean = true,
         val replies: List<PersonMentionModel> = emptyList(),
+        val previewMaxLines: Int? = null,
         val postLayout: PostLayout = PostLayout.Card,
         val swipeActionsEnabled: Boolean = true,
         val autoLoadImages: Boolean = true,
@@ -45,7 +53,9 @@ interface InboxRepliesMviModel :
     )
 
     sealed interface Effect {
-        data class UpdateUnreadItems(val value: Int) : Effect
+        data class UpdateUnreadItems(
+            val value: Int,
+        ) : Effect
 
         data object BackToTop : Effect
     }

--- a/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesScreen.kt
+++ b/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesScreen.kt
@@ -81,28 +81,30 @@ class InboxRepliesScreen : Tab {
         val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
 
         LaunchedEffect(navigationCoordinator) {
-            navigationCoordinator.onDoubleTabSelection.onEach { section ->
-                runCatching {
-                    if (section == TabNavigationSection.Inbox) {
-                        lazyListState.scrollToItem(0)
-                    }
-                }
-            }.launchIn(this)
-        }
-        LaunchedEffect(model) {
-            model.effects.onEach { effect ->
-                when (effect) {
-                    is InboxRepliesMviModel.Effect.UpdateUnreadItems -> {
-                        navigationCoordinator.setInboxUnread(effect.value)
-                    }
-
-                    InboxRepliesMviModel.Effect.BackToTop -> {
-                        runCatching {
+            navigationCoordinator.onDoubleTabSelection
+                .onEach { section ->
+                    runCatching {
+                        if (section == TabNavigationSection.Inbox) {
                             lazyListState.scrollToItem(0)
                         }
                     }
-                }
-            }.launchIn(this)
+                }.launchIn(this)
+        }
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { effect ->
+                    when (effect) {
+                        is InboxRepliesMviModel.Effect.UpdateUnreadItems -> {
+                            navigationCoordinator.setInboxUnread(effect.value)
+                        }
+
+                        InboxRepliesMviModel.Effect.BackToTop -> {
+                            runCatching {
+                                lazyListState.scrollToItem(0)
+                            }
+                        }
+                    }
+                }.launchIn(this)
         }
 
         val pullRefreshState =
@@ -164,7 +166,11 @@ class InboxRepliesScreen : Tab {
                                         backgroundColor = upVoteColor ?: defaultUpvoteColor,
                                         onTriggered =
                                             rememberCallback {
-                                                model.reduce(InboxRepliesMviModel.Intent.UpVoteComment(reply.id))
+                                                model.reduce(
+                                                    InboxRepliesMviModel.Intent.UpVoteComment(
+                                                        reply.id,
+                                                    ),
+                                                )
                                             },
                                     )
 
@@ -183,7 +189,11 @@ class InboxRepliesScreen : Tab {
                                             backgroundColor = downVoteColor ?: defaultDownVoteColor,
                                             onTriggered =
                                                 rememberCallback {
-                                                    model.reduce(InboxRepliesMviModel.Intent.DownVoteComment(reply.id))
+                                                    model.reduce(
+                                                        InboxRepliesMviModel.Intent.DownVoteComment(
+                                                            reply.id,
+                                                        ),
+                                                    )
                                                 },
                                         )
                                     }
@@ -237,6 +247,7 @@ class InboxRepliesScreen : Tab {
                                 showScores = uiState.showScores,
                                 voteFormat = uiState.voteFormat,
                                 downVoteEnabled = uiState.downVoteEnabled,
+                                previewMaxLines = uiState.previewMaxLines,
                                 onOpenPost =
                                     rememberCallbackArgs { post ->
                                         if (!reply.read) {
@@ -265,7 +276,10 @@ class InboxRepliesScreen : Tab {
                                         navigationCoordinator.pushScreen(
                                             ZoomableImageScreen(
                                                 url = url,
-                                                source = reply.post.community?.readableHandle.orEmpty(),
+                                                source =
+                                                    reply.post.community
+                                                        ?.readableHandle
+                                                        .orEmpty(),
                                             ),
                                         )
                                     },

--- a/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
+++ b/unit/replies/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
@@ -28,49 +28,57 @@ class InboxRepliesViewModel(
     private val coordinator: InboxCoordinator,
     private val notificationCenter: NotificationCenter,
     private val settingsRepository: SettingsRepository,
-) : InboxRepliesMviModel,
-    DefaultMviModel<InboxRepliesMviModel.Intent, InboxRepliesMviModel.UiState, InboxRepliesMviModel.Effect>(
+) : DefaultMviModel<InboxRepliesMviModel.Intent, InboxRepliesMviModel.UiState, InboxRepliesMviModel.Effect>(
         initialState = InboxRepliesMviModel.UiState(),
-    ) {
+    ),
+    InboxRepliesMviModel {
     private var currentPage: Int = 1
 
     init {
         screenModelScope.launch {
-            coordinator.events.onEach {
-                when (it) {
-                    InboxCoordinator.Event.Refresh -> {
-                        refresh()
-                        emitEffect(InboxRepliesMviModel.Effect.BackToTop)
+            coordinator.events
+                .onEach {
+                    when (it) {
+                        InboxCoordinator.Event.Refresh -> {
+                            refresh()
+                            emitEffect(InboxRepliesMviModel.Effect.BackToTop)
+                        }
                     }
-                }
-            }.launchIn(this)
-            coordinator.unreadOnly.onEach {
-                if (it != uiState.value.unreadOnly) {
-                    changeUnreadOnly(it)
-                }
-            }.launchIn(this)
-            themeRepository.postLayout.onEach { layout ->
-                updateState { it.copy(postLayout = layout) }
-            }.launchIn(this)
-            settingsRepository.currentSettings.onEach { settings ->
-                updateState {
-                    it.copy(
-                        swipeActionsEnabled = settings.enableSwipeActions,
-                        autoLoadImages = settings.autoLoadImages,
-                        preferNicknames = settings.preferUserNicknames,
-                        voteFormat = settings.voteFormat,
-                        actionsOnSwipeToStartInbox = settings.actionsOnSwipeToStartInbox,
-                        actionsOnSwipeToEndInbox = settings.actionsOnSwipeToEndInbox,
-                        showScores = settings.showScores,
-                    )
-                }
-            }.launchIn(this)
-            notificationCenter.subscribe(NotificationCenterEvent.Logout::class).onEach {
-                handleLogout()
-            }.launchIn(this)
+                }.launchIn(this)
+            coordinator.unreadOnly
+                .onEach {
+                    if (it != uiState.value.unreadOnly) {
+                        changeUnreadOnly(it)
+                    }
+                }.launchIn(this)
+            themeRepository.postLayout
+                .onEach { layout ->
+                    updateState { it.copy(postLayout = layout) }
+                }.launchIn(this)
+            settingsRepository.currentSettings
+                .onEach { settings ->
+                    updateState {
+                        it.copy(
+                            swipeActionsEnabled = settings.enableSwipeActions,
+                            autoLoadImages = settings.autoLoadImages,
+                            preferNicknames = settings.preferUserNicknames,
+                            voteFormat = settings.voteFormat,
+                            actionsOnSwipeToStartInbox = settings.actionsOnSwipeToStartInbox,
+                            actionsOnSwipeToEndInbox = settings.actionsOnSwipeToEndInbox,
+                            showScores = settings.showScores,
+                            previewMaxLines = settings.inboxPreviewMaxLines,
+                        )
+                    }
+                }.launchIn(this)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.Logout::class)
+                .onEach {
+                    handleLogout()
+                }.launchIn(this)
 
             if (uiState.value.initial) {
-                val downVoteEnabled = siteRepository.isDownVoteEnabled(identityRepository.authToken.value)
+                val downVoteEnabled =
+                    siteRepository.isDownVoteEnabled(identityRepository.authToken.value)
                 updateState { it.copy(downVoteEnabled = downVoteEnabled) }
                 refresh(initial = true)
             }
@@ -142,14 +150,15 @@ class InboxRepliesViewModel(
         val refreshing = currentState.refreshing
         val unreadOnly = currentState.unreadOnly
         val itemList =
-            userRepository.getReplies(
-                auth = auth,
-                page = currentPage,
-                unreadOnly = unreadOnly,
-                sort = SortType.New,
-            )?.map {
-                it.copy(isCommentReply = it.comment.depth > 0)
-            }
+            userRepository
+                .getReplies(
+                    auth = auth,
+                    page = currentPage,
+                    unreadOnly = unreadOnly,
+                    sort = SortType.New,
+                )?.map {
+                    it.copy(isCommentReply = it.comment.depth > 0)
+                }
         if (!itemList.isNullOrEmpty()) {
             currentPage++
         }


### PR DESCRIPTION
Until now, it was only possible to see the first lines in mentions and replies cards (previews) in the inbox screen. This is fine for most cases, but it's better if users can configure this parameter in the advanced settings.

Incidentally, this is the same bottom sheet that was previously used for post body max lines, which is now made generic and reusable.

This allows to solve issues like the one reported [here](https://feddit.it/post/8731626).