### PR TITLE
Process error messages from instances.

### DIFF
--- a/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/LoginResponse.kt
+++ b/core/api/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/api/dto/LoginResponse.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LoginResponse(
     @SerialName("jwt") val token: String? = null,
-    @SerialName("registration_created") val registrationCreated: Boolean,
-    @SerialName("verify_email_sent") val verifyEmailSent: Boolean,
+    @SerialName("registration_created") val registrationCreated: Boolean? = null,
+    @SerialName("verify_email_sent") val verifyEmailSent: Boolean? = null,
+    @SerialName("error") var error: String? = null,
 )

--- a/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLoginUseCase.kt
+++ b/domain/identity/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/domain/identity/usecase/DefaultLoginUseCase.kt
@@ -40,6 +40,10 @@ internal class DefaultLoginUseCase(
         return response.onFailure {
             logDebug("Login failure: ${it.message}")
         }.mapCatching {
+            if (it.error != null) {
+                throw Exception("${instance} says: ${it.error}")
+            }
+
             val auth = it.token
             if (auth == null) {
                 apiConfigurationRepository.changeInstance(oldInstance)


### PR DESCRIPTION
The PR allows `LoginResponse` properties to be null and adds the `error` property to receive error messages from the API. 

Adds a check to see if `error` is not null and throws an exception with a user friendly message.

Addresses #1005 