### PR TITLE
Sets the comment expand state to the current toggle, if loading more …

### DIFF
--- a/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
@@ -479,7 +479,9 @@ class PostDetailViewModel(
                 .populateLoadMoreComments()
                 .map {
                     it.copy(
-                        expanded = autoExpandComments,
+                        // retain comment expand state if refreshing or loading more
+                        expanded = currentState.comments.firstOrNull() { comment -> comment.id == it.id }?.expanded
+                            ?: autoExpandComments,
                         // only first level are visible and can be expanded
                         visible = autoExpandComments || it.depth == 0,
                     )


### PR DESCRIPTION
Comment expanded state will reset to the settings default when loading more or refreshing. 

This PR will check each loaded comment against the current list when loading new comments or refreshing, and will toggle the expanded state to match what the user manually changed. 

I just stumbled on this one and kept working at it until it was more kotlin-friendly, so please let me know if you have feedback to improve the solution! 