### PR TITLE
Simplify network availability checks

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/network/DefaultNetworkManager.kt
+++ b/core/utils/src/androidMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/utils/network/DefaultNetworkManager.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.os.Build
 
 class DefaultNetworkManager(
     private val context: Context,
@@ -12,18 +11,8 @@ class DefaultNetworkManager(
     @SuppressLint("MissingPermission")
     override suspend fun isNetworkAvailable(): Boolean =
         with(context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val capabilities = getNetworkCapabilities(activeNetwork) ?: return@with false
-                when {
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> true
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> true
-                    capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> true
-                    else -> false
-                }
-            } else if (activeNetworkInfo != null && activeNetworkInfo?.isConnectedOrConnecting == true) {
-                true
-            } else {
-                false
-            }
+            // min SDK for project is 26 and methods used are 23+
+            val netCapabilities = getNetworkCapabilities(activeNetwork)
+            return netCapabilities != null && netCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) && netCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
         }
 }


### PR DESCRIPTION
Not 100% sure about this one - would definitely appreciate feedback! 

This PR removes deprecated methods and simplifies the existing, as the methods used are available SDK version 23, and the minimum for the project is 26. 

`isNetworkAvailable` should return `true` if a connection is active and has internet access, otherwise returns `false`. 