### PR TITLE
fix: case sensitive account lookup

### DIFF
--- a/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultAccountRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultAccountRepositoryTest.kt
@@ -27,7 +27,7 @@ class DefaultAccountRepositoryTest {
         mockk<AccountsQueries>(relaxUnitFun = true) {
             every { getAll() } returns query
             every { getActive() } returns query
-            every { getBy(username = any(), instance = any()) } returns query
+            every { getBy(any(), any()) } returns query
             every { getActive() } returns query
         }
     private val provider =

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultAccountRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultAccountRepository.kt
@@ -14,14 +14,20 @@ internal class DefaultAccountRepository(
 
     override suspend fun getAll(): List<AccountModel> =
         withContext(Dispatchers.IO) {
-            db.accountsQueries.getAll().executeAsList().map { it.toModel() }
+            db.accountsQueries
+                .getAll()
+                .executeAsList()
+                .map { it.toModel() }
         }
 
     override suspend fun getBy(
         username: String,
         instance: String,
     ) = withContext(Dispatchers.IO) {
-        db.accountsQueries.getBy(username, instance).executeAsOneOrNull()?.toModel()
+        db.accountsQueries
+            .getBy(username.lowercase(), instance.lowercase())
+            .executeAsOneOrNull()
+            ?.toModel()
     }
 
     override suspend fun createAccount(account: AccountModel) =
@@ -33,7 +39,10 @@ internal class DefaultAccountRepository(
                 avatar = account.avatar,
             )
             val entity =
-                db.accountsQueries.getAll().executeAsList().firstOrNull { it.jwt == account.jwt }
+                db.accountsQueries
+                    .getAll()
+                    .executeAsList()
+                    .firstOrNull { it.jwt == account.jwt }
             entity?.id ?: 0
         }
 

--- a/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/accounts.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/accounts.sq
@@ -37,7 +37,7 @@ FROM AccountEntity;
 getBy:
 SELECT *
 FROM AccountEntity
-WHERE username = ? AND instance = ?;
+WHERE username = LOWER(?) AND instance = LOWER(?);
 
 update:
 UPDATE AccountEntity


### PR DESCRIPTION
This PR fixes a bug which led to account duplication if, while switching account and selecting "Add new account" you entered the same credentials but with a different capitalization on the username/instance fields.