### PR TITLE
feat: use avatar as profile icon in bottom navigation bar

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ArStrings.kt
@@ -421,4 +421,6 @@ internal val ArStrings =
         override val actionRestore = "يعيد"
         override val settingsInboxPreviewMaxLines = "الحد الأقصى لعدد الخطوط في بطاقات البريد الوارد"
         override val settingsDefaultExploreResultType = "وع نتيجة البحث الافتراضي للاستكشاف"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "استخدم الصورة الرمزية كرمز للملف الشخصي في شريط التنقل السفلي"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/BgStrings.kt
@@ -430,4 +430,6 @@ internal val BgStrings =
         override val actionRestore = "Възстанови"
         override val settingsInboxPreviewMaxLines = "Максимален брой редове във входящите карти"
         override val settingsDefaultExploreResultType = "ип резултати от търсенето по подразбиране за Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Използвайте аватара като икона на профил в долната лента за навигация"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/CsStrings.kt
@@ -426,4 +426,6 @@ internal val CsStrings =
         override val actionRestore = "Obnovit"
         override val settingsInboxPreviewMaxLines = "Maximální počet řádků na kartách doručené pošty"
         override val settingsDefaultExploreResultType = "Výchozí typ výsledku vyhledávání pro Prozkoumat"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Použijte avatar jako ikonu profilu v dolní navigační liště"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DaStrings.kt
@@ -426,4 +426,6 @@ internal val DaStrings =
         override val actionRestore = "Gendan"
         override val settingsInboxPreviewMaxLines = "Max antal linjer i indbakkekort"
         override val settingsDefaultExploreResultType = "Standard søgeresultattype for Udforsk"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Brug avatar som profilikon i nederste navigationslinje"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/DeStrings.kt
@@ -430,4 +430,6 @@ internal val DeStrings =
         override val settingsInboxPreviewMaxLines =
             "Maximale Anzahl von Zeilen in Posteingangskarten"
         override val settingsDefaultExploreResultType = "Standard-Suchergebnistyp für Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Verwenden Sie den Avatar als Profilsymbol in der unteren Navigationsleiste"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ElStrings.kt
@@ -433,5 +433,8 @@ internal val ElStrings =
         override val actionRestore = "Αποκαταστήστε το"
         override val settingsInboxPreviewMaxLines =
             "Μέγιστος αριθμός γραμμών σε κάρτες εισερχομένων"
-        override val settingsDefaultExploreResultType = "Προεπιλεγμένος τύπος αποτελεσμάτων αναζήτησης για Εξερεύνηση"
+        override val settingsDefaultExploreResultType =
+            "Προεπιλεγμένος τύπος αποτελεσμάτων αναζήτησης για Εξερεύνηση"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Χρησιμοποιήστε το avatar ως εικονίδιο προφίλ στην κάτω γραμμή πλοήγησης"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EnStrings.kt
@@ -423,4 +423,6 @@ internal val EnStrings =
         override val actionRestore = "Restore"
         override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
         override val settingsDefaultExploreResultType = "Default search result type for explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Use avatar as profile icon in bottom navigation bar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EoStrings.kt
@@ -422,4 +422,6 @@ internal val EoStrings =
         override val actionRestore = "Restaŭri"
         override val settingsInboxPreviewMaxLines = "Maksimuma nombro da linioj en enirkestokartoj"
         override val settingsDefaultExploreResultType = "Defaŭlta serĉrezulto-tipo por esploro"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Uzi avataron kiel profilikonon en la malsupra navigadbreto"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EsStrings.kt
@@ -427,5 +427,8 @@ internal val EsStrings =
         override val actionRestore = "Restaurar"
         override val settingsInboxPreviewMaxLines =
             "Número máximo de líneas en tarjetas de mensajes"
-        override val settingsDefaultExploreResultType = "Tipo de resultado de búsqueda predeterminado para Descubre"
+        override val settingsDefaultExploreResultType =
+            "Tipo de resultado de búsqueda predeterminado para Descubre"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Utilizar avatar como icono de perfil en la barra de navegación inferior"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/EtStrings.kt
@@ -428,4 +428,6 @@ internal val EtStrings =
         override val actionRestore = "Taastama"
         override val settingsInboxPreviewMaxLines = "Maksimaalne ridade arv postkasti kaartidel"
         override val settingsDefaultExploreResultType = "Avastamise vaikeotsingutulemuse tüüp"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Kasutage avatari profiiliikoonina alumisel navigeerimisribal"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FiStrings.kt
@@ -423,4 +423,6 @@ internal val FiStrings =
         override val actionRestore = "Palauttaa"
         override val settingsInboxPreviewMaxLines = "Saapuneiden korttien rivien enimmäismäärä"
         override val settingsDefaultExploreResultType = "Tutkimuksen oletushakutulostyyppi"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Käytä avataria profiilikuvakkeena navigointipalkin alaosassa"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/FrStrings.kt
@@ -432,5 +432,8 @@ internal val FrStrings =
         override val actionRestore = "Restaurer"
         override val settingsInboxPreviewMaxLines =
             "Nombre maximum de lignes dans les cartes de boîte de réception"
-        override val settingsDefaultExploreResultType = "Type de résultat de recherche par défaut pour Explorer"
+        override val settingsDefaultExploreResultType =
+            "Type de résultat de recherche par défaut pour Explorer"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Utiliser l\'avatar comme icône de profil dans la barre de navigation inférieure"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/GaStrings.kt
@@ -426,5 +426,8 @@ internal val GaStrings =
         override val messageContentDeleted = "Tá an t-ábhar seo scriosta agat"
         override val actionRestore = "Athchóirigh"
         override val settingsInboxPreviewMaxLines = "An líon uasta línte i gcártaí bosca isteach"
-        override val settingsDefaultExploreResultType = "Cineál toradh cuardaigh réamhshocraithe le haghaidh Explore"
+        override val settingsDefaultExploreResultType =
+            "Cineál toradh cuardaigh réamhshocraithe le haghaidh Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Úsáid avatar mar dheilbhín próifíle sa bharra nascleanúna ag bun"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HrStrings.kt
@@ -426,5 +426,8 @@ internal val HrStrings =
         override val messageContentDeleted = "Izbrisali ste ovaj sadržaj"
         override val actionRestore = "Vratiti"
         override val settingsInboxPreviewMaxLines = "Maksimalan broj redaka u ulaznim karticama"
-        override val settingsDefaultExploreResultType = "Zadana vrsta rezultata pretraživanja za Istraživanje"
+        override val settingsDefaultExploreResultType =
+            "Zadana vrsta rezultata pretraživanja za Istraživanje"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Koristite avatar kao ikonu profila na donjoj navigacijskoj traci"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/HuStrings.kt
@@ -430,5 +430,8 @@ internal val HuStrings =
         override val messageContentDeleted = "Ezt a tartalmat törölted"
         override val actionRestore = "visszaállítás"
         override val settingsInboxPreviewMaxLines = "Maximális sorok száma a postafiók kártyákban"
-        override val settingsDefaultExploreResultType = "A Felfedezés alapértelmezett keresési eredménytípusa"
+        override val settingsDefaultExploreResultType =
+            "A Felfedezés alapértelmezett keresési eredménytípusa"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Használja az avatart profilikonként az alsó navigációs sávban"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -428,4 +428,6 @@ internal val ItStrings =
         override val actionRestore = "Ripristina"
         override val settingsInboxPreviewMaxLines = "Numero massimo righe anteprima in inbox"
         override val settingsDefaultExploreResultType = "Tipo di risultato di ricerca predefinito per Esplora"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Usa avatar come icona profilo nella barra di navigazione inferiore"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LtStrings.kt
@@ -427,4 +427,6 @@ internal val LtStrings =
         override val settingsInboxPreviewMaxLines = "Maksimalus eilučių skaičius gautųjų kortelėse"
         override val settingsDefaultExploreResultType =
             "Numatytasis Naršymo paieškos rezultatų tipas"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Naudokite avatarą kaip profilio piktogramą apatinėje naršymo juostoje"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/LvStrings.kt
@@ -424,5 +424,8 @@ internal val LvStrings =
         override val messageContentDeleted = "Jūs esat izdzēsis šo saturu"
         override val actionRestore = "Atjaunot"
         override val settingsInboxPreviewMaxLines = "Maksimālais rindu skaits iesūtnes kartītēs"
-        override val settingsDefaultExploreResultType = "Noklusējuma meklēšanas rezultāta veids funkcijai Izpētīt"
+        override val settingsDefaultExploreResultType =
+            "Noklusējuma meklēšanas rezultāta veids funkcijai Izpētīt"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Izmantojiet iemiesojumu kā profila ikonu apakšējā navigācijas joslā"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/MtStrings.kt
@@ -426,5 +426,8 @@ internal val MtStrings =
         override val messageContentDeleted = "Ħassejt dan il-kontenut"
         override val actionRestore = "Irrestawra"
         override val settingsInboxPreviewMaxLines = "Numru massimu ta' linji fil-karti tal-inbox"
-        override val settingsDefaultExploreResultType = "Tip ta' riżultat tat-tfittxija default għal Esplora"
+        override val settingsDefaultExploreResultType =
+            "Tip ta' riżultat tat-tfittxija default għal Esplora"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Uża l-avatar bħala ikona tal-profil fil-bar tan-navigazzjoni t\'isfel"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NbStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NbStrings.kt
@@ -423,4 +423,6 @@ internal val NbStrings =
         override val actionRestore = "Restore"
         override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
         override val settingsDefaultExploreResultType = "Default search result type for Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Use avatar as profile icon in bottom navigation bar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NlStrings.kt
@@ -428,4 +428,6 @@ internal val NlStrings =
         override val actionRestore = "Herstellen"
         override val settingsInboxPreviewMaxLines = "Maximaal aantal regels in inboxkaarten"
         override val settingsDefaultExploreResultType = "Standaard zoekresultaattype voor Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Gebruik avatar als profielpictogram in de onderste navigatiebalk"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/NnStrings.kt
@@ -425,4 +425,6 @@ internal val NnStrings =
         override val actionRestore = "Restaurere"
         override val settingsInboxPreviewMaxLines = "Maks antall linjer i innbokskort"
         override val settingsDefaultExploreResultType = "Standard søkeresultattype for Utforsk"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Bruk avatar som profilikon i navigasjonslinjen nederst"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PlStrings.kt
@@ -427,5 +427,8 @@ internal val PlStrings =
         override val actionRestore = "Przywrócić"
         override val settingsInboxPreviewMaxLines =
             "Maksymalna liczba linii w kartach skrzynki odbiorczej"
-        override val settingsDefaultExploreResultType = "Domyślny typ wyniku wyszukiwania dla Eksploruj"
+        override val settingsDefaultExploreResultType =
+            "Domyślny typ wyniku wyszukiwania dla Eksploruj"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Użyj awatara jako ikony profilu na dolnym pasku nawigacyjnym"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
@@ -425,5 +425,8 @@ internal val PtBrStrings =
         override val actionRestore = "Restaura"
         override val settingsInboxPreviewMaxLines =
             "Número máximo de linhas nos cartões das mensagens"
-        override val settingsDefaultExploreResultType = "Tipo de resultado de pesquisa padrão para Explorar"
+        override val settingsDefaultExploreResultType =
+            "Tipo de resultado de pesquisa padrão para Explorar"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Use o avatar como ícone do perfil na barra de navegação inferiorr"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/PtStrings.kt
@@ -426,5 +426,8 @@ internal val PtStrings =
         override val actionRestore = "Restaura"
         override val settingsInboxPreviewMaxLines =
             "Número máximo de linhas nos cartões das mensagens"
-        override val settingsDefaultExploreResultType = "Tipo de resultado de pesquisa padrão para Explorar"
+        override val settingsDefaultExploreResultType =
+            "Tipo de resultado de pesquisa padrão para Explorar"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Use o avatar como ícone do perfil na barra de navegação inferior"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RoStrings.kt
@@ -425,5 +425,8 @@ internal val RoStrings =
         override val messageContentDeleted = "Ați șters acest conținut"
         override val actionRestore = "Restaurați-l"
         override val settingsInboxPreviewMaxLines = "Numărul maxim de linii în cardurile de inbox"
-        override val settingsDefaultExploreResultType = "Tip de rezultat de căutare prestabilit pentru Explorarea"
+        override val settingsDefaultExploreResultType =
+            "Tip de rezultat de căutare prestabilit pentru Explorarea"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Utilizează avatarul ca pictogramă de profil în bara de navigare de jos"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/RuStrings.kt
@@ -430,4 +430,6 @@ internal val RuStrings =
             "Максимальное количество строк во входящих карточках"
         override val settingsDefaultExploreResultType =
             "Тип результатов поиска по умолчанию для Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Использовать аватар в качестве значка профиля в нижней панели навигации"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SkStrings.kt
@@ -428,5 +428,8 @@ internal val SkStrings =
         override val actionRestore = "Obnoviť"
         override val settingsInboxPreviewMaxLines =
             "Maximálny počet riadkov na kartách doručenej pošty"
-        override val settingsDefaultExploreResultType = "Predvolený typ výsledku vyhľadávania pre Preskúmať"
+        override val settingsDefaultExploreResultType =
+            "Predvolený typ výsledku vyhľadávania pre Preskúmať"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Použite avatar ako ikonu profilu v dolnom navigačnom paneli"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SlStrings.kt
@@ -426,5 +426,8 @@ internal val SlStrings =
         override val actionRestore = "Obnovi"
         override val settingsInboxPreviewMaxLines =
             "Največje število vrstic v karticah prejete pošte"
-        override val settingsDefaultExploreResultType = "Privzeta vrsta rezultatov iskanja za Raziskovanje"
+        override val settingsDefaultExploreResultType =
+            "Privzeta vrsta rezultatov iskanja za Raziskovanje"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Uporabite avatar kot ikono profila v spodnji vrstici za krmarjenje"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SqStrings.kt
@@ -428,5 +428,8 @@ internal val SqStrings =
         override val actionRestore = "Rivendos"
         override val settingsInboxPreviewMaxLines =
             "Numri maksimal i rreshtave në kartat e kutisë hyrëse"
-        override val settingsDefaultExploreResultType = "Lloji i parazgjedhur i rezultatit të kërkimit për Eksploro"
+        override val settingsDefaultExploreResultType =
+            "Lloji i parazgjedhur i rezultatit të kërkimit për Eksploro"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Përdorni avatarin si ikonë të profilit në shiritin e poshtëm të navigimit"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SrStrings.kt
@@ -428,5 +428,8 @@ internal val SrStrings =
         override val actionRestore = "Ресторе"
         override val settingsInboxPreviewMaxLines =
             "Максималан број линија у картицама пријемног сандучет"
-        override val settingsDefaultExploreResultType = "Подразумевани тип резултата претраге за Истраживање"
+        override val settingsDefaultExploreResultType =
+            "Подразумевани тип резултата претраге за Истраживање"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Користите аватар као икону профила на доњој траци за навигацију"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -420,6 +420,7 @@ interface Strings {
     val actionRestore: String
     val settingsInboxPreviewMaxLines: String
     val settingsDefaultExploreResultType: String
+    val settingsUseAvatarAsProfileNavigationIcon: String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/SvStrings.kt
@@ -426,4 +426,6 @@ internal val SvStrings =
         override val actionRestore = "Återställ"
         override val settingsInboxPreviewMaxLines = "Max antal rader i inkorgskort"
         override val settingsDefaultExploreResultType = "Standard sökresultattyp för Utforska"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Använd avatar som profilikon i det nedre navigeringsfältet"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TokStrings.kt
@@ -422,4 +422,6 @@ internal val TokStrings =
         override val actionRestore = "o awen e ona"
         override val settingsInboxPreviewMaxLines = "nanpa linja pi lipu lon toki poki"
         override val settingsDefaultExploreResultType = "nasin ijo pi lipu lukin"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "o kepeken e sitelen jan tawa sitelen lili pi linja anpa"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/TrStrings.kt
@@ -428,4 +428,6 @@ internal val TrStrings =
         override val settingsInboxPreviewMaxLines =
             "Gelen kutusu kartlarındaki maksimum satır sayısı"
         override val settingsDefaultExploreResultType = "Keşfet için varsayılan arama sonucu türü"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Alt gezinme çubuğunda avatarı profil simgesi olarak kullan"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/UkStrings.kt
@@ -428,5 +428,8 @@ internal val UkStrings =
         override val actionRestore = "Відновлення"
         override val settingsInboxPreviewMaxLines =
             "Максимальна кількість рядків у картках вхідних повідомлень"
-        override val settingsDefaultExploreResultType = "Тип результатів пошуку за умовчанням для Explore"
+        override val settingsDefaultExploreResultType =
+            "Тип результатів пошуку за умовчанням для Explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Використовуйте аватар як значок профілю на нижній панелі навігації"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhHkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhHkStrings.kt
@@ -416,4 +416,6 @@ internal val ZhHkStrings =
         override val actionRestore = "恢復"
         override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
         override val settingsDefaultExploreResultType = "Default search result type for explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Use avatar as profile icon in bottom navigation bar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
@@ -416,4 +416,6 @@ internal val ZhTwStrings =
         override val actionRestore = "恢復"
         override val settingsInboxPreviewMaxLines = "Inbox card preview max lines"
         override val settingsDefaultExploreResultType = "Default search result type for explore"
+        override val settingsUseAvatarAsProfileNavigationIcon =
+            "Use avatar as profile icon in bottom navigation bar"
     }

--- a/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
@@ -159,6 +159,7 @@ class DefaultSettingsRepositoryTest {
                     account_id = 1,
                     inboxPreviewMaxLines = model.inboxPreviewMaxLines?.toLong(),
                     defaultExploreResultType = model.defaultExploreResultType.toLong(),
+                    useAvatarAsProfileNavigationIcon = if (model.useAvatarAsProfileNavigationIcon) 1 else 0,
                 )
             }
         }
@@ -233,6 +234,7 @@ class DefaultSettingsRepositoryTest {
                     account_id = 1,
                     inboxPreviewMaxLines = model.inboxPreviewMaxLines?.toLong(),
                     defaultExploreResultType = model.defaultExploreResultType.toLong(),
+                    useAvatarAsProfileNavigationIcon = if (model.useAvatarAsProfileNavigationIcon) 1 else 0,
                 )
             }
         }
@@ -302,6 +304,7 @@ class DefaultSettingsRepositoryTest {
         enableToggleFavoriteInNavDrawer: Boolean = false,
         inboxPreviewMaxLines: Int? = null,
         defaultExploreResultType: Int = 2,
+        useAvatarAsProfileNavigationIcon: Boolean = false,
     ) = GetBy(
         id = id,
         theme = theme,
@@ -365,5 +368,6 @@ class DefaultSettingsRepositoryTest {
         enableToggleFavoriteInNavDrawer = if (enableToggleFavoriteInNavDrawer) 1 else 0,
         inboxPreviewMaxLines = inboxPreviewMaxLines?.toLong(),
         defaultExploreResultType = defaultExploreResultType.toLong(),
+        useAvatarAsProfileNavigationIcon = if (useAvatarAsProfileNavigationIcon) 1 else 0,
     )
 }

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/data/SettingsModel.kt
@@ -65,4 +65,5 @@ data class SettingsModel(
     val enableToggleFavoriteInNavDrawer: Boolean = false,
     val inboxPreviewMaxLines: Int? = null,
     val defaultExploreResultType: Int = 2,
+    val useAvatarAsProfileNavigationIcon: Boolean = false,
 )

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -160,6 +160,7 @@ internal class DefaultSettingsRepository(
             enableToggleFavoriteInNavDrawer = if (settings.enableToggleFavoriteInNavDrawer) 1L else 0L,
             inboxPreviewMaxLines = settings.inboxPreviewMaxLines?.toLong(),
             defaultExploreResultType = settings.defaultExploreResultType.toLong(),
+            useAvatarAsProfileNavigationIcon = if (settings.useAvatarAsProfileNavigationIcon) 1L else 0L,
         )
     }
 
@@ -441,6 +442,7 @@ internal class DefaultSettingsRepository(
                 enableToggleFavoriteInNavDrawer = if (settings.enableToggleFavoriteInNavDrawer) 1L else 0L,
                 inboxPreviewMaxLines = settings.inboxPreviewMaxLines?.toLong(),
                 defaultExploreResultType = settings.defaultExploreResultType.toLong(),
+                useAvatarAsProfileNavigationIcon = if (settings.useAvatarAsProfileNavigationIcon) 1L else 0L,
             )
         }
     }
@@ -541,4 +543,5 @@ private fun GetBy.toModel() =
         enableToggleFavoriteInNavDrawer = enableToggleFavoriteInNavDrawer == 1L,
         inboxPreviewMaxLines = inboxPreviewMaxLines?.toInt(),
         defaultExploreResultType = defaultExploreResultType.toInt(),
+        useAvatarAsProfileNavigationIcon = useAvatarAsProfileNavigationIcon == 1L,
     )

--- a/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/usecase/SerializableSettings.kt
+++ b/core/persistence/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/persistence/usecase/SerializableSettings.kt
@@ -77,6 +77,7 @@ internal data class SerializableSettings(
     val enableToggleFavoriteInNavDrawer: Boolean = false,
     val inboxPreviewMaxLines: Int? = null,
     val defaultExploreResultType: Int = 2,
+    val useAvatarAsProfileNavigationIcon: Boolean = false,
 )
 
 internal fun SerializableSettings.toModel() =
@@ -144,6 +145,7 @@ internal fun SerializableSettings.toModel() =
         fullWidthImages = fullWidthImages,
         enableToggleFavoriteInNavDrawer = enableToggleFavoriteInNavDrawer,
         inboxPreviewMaxLines = inboxPreviewMaxLines,
+        useAvatarAsProfileNavigationIcon = useAvatarAsProfileNavigationIcon,
     )
 
 internal fun SettingsModel.toData() =
@@ -213,4 +215,5 @@ internal fun SettingsModel.toData() =
         fullWidthImages = fullWidthImages,
         enableToggleFavoriteInNavDrawer = enableToggleFavoriteInNavDrawer,
         inboxPreviewMaxLines = inboxPreviewMaxLines,
+        useAvatarAsProfileNavigationIcon = useAvatarAsProfileNavigationIcon,
     )

--- a/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/github/diegoberaldin/raccoonforlemmy/core/persistence/settings.sq
@@ -62,6 +62,7 @@ CREATE TABLE SettingsEntity (
     enableToggleFavoriteInNavDrawer INTEGER NOT NULL DEFAULT 0,
     inboxPreviewMaxLines INTEGER DEFAULT NULL,
     defaultExploreResultType INTEGER NOT NULL DEFAULT 2,
+    useAvatarAsProfileNavigationIcon INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (account_id) REFERENCES AccountEntity(id) ON DELETE CASCADE,
     UNIQUE(account_id)
 );
@@ -129,8 +130,10 @@ INSERT OR IGNORE INTO SettingsEntity (
     enableToggleFavoriteInNavDrawer,
     inboxPreviewMaxLines,
     defaultExploreResultType,
+    useAvatarAsProfileNavigationIcon,
     account_id
 ) VALUES (
+    ?,
     ?,
     ?,
     ?,
@@ -257,7 +260,8 @@ SET theme = ?,
     commentIndentAmount = ?,
     enableToggleFavoriteInNavDrawer = ?,
     inboxPreviewMaxLines = ?,
-    defaultExploreResultType = ?
+    defaultExploreResultType = ?,
+    useAvatarAsProfileNavigationIcon = ?
 WHERE account_id = ?;
 
 getBy:
@@ -323,6 +327,7 @@ SELECT
     commentIndentAmount,
     enableToggleFavoriteInNavDrawer,
     inboxPreviewMaxLines,
-    defaultExploreResultType
+    defaultExploreResultType,
+    useAvatarAsProfileNavigationIcon
 FROM SettingsEntity
 WHERE account_id = ?;

--- a/core/persistence/src/commonMain/sqldelight/migrations/36.sqm
+++ b/core/persistence/src/commonMain/sqldelight/migrations/36.sqm
@@ -1,2 +1,5 @@
 ALTER TABLE SettingsEntity
 ADD COLUMN defaultExploreResultType INTEGER NOT NULL DEFAULT 2;
+
+ALTER TABLE SettingsEntity
+ADD COLUMN useAvatarAsProfileNavigationIcon INTEGER NOT NULL DEFAULT 0;

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -77,6 +77,10 @@ interface AdvancedSettingsMviModel :
         data class ChangeEnableToggleFavoriteInNavDrawer(
             val value: Boolean,
         ) : Intent
+
+        data class ChangeUseAvatarAsProfileNavigationIcon(
+            val value: Boolean,
+        ) : Intent
     }
 
     data class UiState(
@@ -109,6 +113,7 @@ interface AdvancedSettingsMviModel :
         val enableToggleFavoriteInNavDrawer: Boolean = false,
         val inboxPreviewMaxLines: Int? = null,
         val defaultExploreResultType: SearchResultType = SearchResultType.Communities,
+        val useAvatarAsProfileNavigationIcon: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -588,6 +588,22 @@ class AdvancedSettingsScreen : Screen {
                         )
                     }
 
+                    if (uiState.isLogged) {
+                        // use avatar as profile navigation icon
+                        SettingsSwitchRow(
+                            title = LocalStrings.current.settingsUseAvatarAsProfileNavigationIcon,
+                            value = uiState.useAvatarAsProfileNavigationIcon,
+                            onValueChanged =
+                                rememberCallbackArgs(model) { value ->
+                                    model.reduce(
+                                        AdvancedSettingsMviModel.Intent.ChangeUseAvatarAsProfileNavigationIcon(
+                                            value,
+                                        ),
+                                    )
+                                },
+                        )
+                    }
+
                     Spacer(modifier = Modifier.height(Spacing.xxxl))
                 }
             }

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -142,6 +142,7 @@ class AdvancedSettingsViewModel(
                     enableToggleFavoriteInNavDrawer = settings.enableToggleFavoriteInNavDrawer,
                     inboxPreviewMaxLines = settings.inboxPreviewMaxLines,
                     defaultExploreResultType = settings.defaultExploreResultType.toSearchResultType(),
+                    useAvatarAsProfileNavigationIcon = settings.useAvatarAsProfileNavigationIcon,
                 )
             }
         }
@@ -193,6 +194,11 @@ class AdvancedSettingsViewModel(
 
             is AdvancedSettingsMviModel.Intent.ChangeEnableToggleFavoriteInNavDrawer ->
                 changeEnableToggleFavoriteInNavDrawer(
+                    intent.value,
+                )
+
+            is AdvancedSettingsMviModel.Intent.ChangeUseAvatarAsProfileNavigationIcon ->
+                changeUseAvatarAsProfileNavigationIcon(
                     intent.value,
                 )
         }
@@ -408,6 +414,15 @@ class AdvancedSettingsViewModel(
             updateState { it.copy(inboxPreviewMaxLines = value) }
             val settings =
                 settingsRepository.currentSettings.value.copy(inboxPreviewMaxLines = value)
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeUseAvatarAsProfileNavigationIcon(value: Boolean) {
+        screenModelScope.launch {
+            updateState { it.copy(useAvatarAsProfileNavigationIcon = value) }
+            val settings =
+                settingsRepository.currentSettings.value.copy(useAvatarAsProfileNavigationIcon = value)
             saveSettings(settings)
         }
     }

--- a/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -100,20 +100,23 @@ class SettingsScreen : Screen {
         val customTabsHelper = remember { getCustomTabsHelper() }
 
         LaunchedEffect(Unit) {
-            navigationCoordinator.onDoubleTabSelection.onEach { section ->
-                runCatching {
-                    if (section == TabNavigationSection.Settings) {
-                        scrollState.scrollTo(0)
-                        topAppBarState.heightOffset = 0f
-                        topAppBarState.contentOffset = 0f
+            navigationCoordinator.onDoubleTabSelection
+                .onEach { section ->
+                    runCatching {
+                        if (section == TabNavigationSection.Settings) {
+                            scrollState.scrollTo(0)
+                            topAppBarState.heightOffset = 0f
+                            topAppBarState.contentOffset = 0f
+                        }
                     }
-                }
-            }.launchIn(this)
+                }.launchIn(this)
         }
         LaunchedEffect(notificationCenter) {
-            notificationCenter.subscribe(NotificationCenterEvent.CloseDialog::class).onEach {
-                infoDialogOpened = false
-            }.launchIn(this)
+            notificationCenter
+                .subscribe(NotificationCenterEvent.CloseDialog::class)
+                .onEach {
+                    infoDialogOpened = false
+                }.launchIn(this)
         }
 
         Scaffold(
@@ -151,8 +154,8 @@ class SettingsScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        )
-                        .nestedScroll(scrollBehavior.nestedScrollConnection),
+                            bottom = padding.calculateBottomPadding(),
+                        ).nestedScroll(scrollBehavior.nestedScrollConnection),
             ) {
                 Column(
                     modifier = Modifier.fillMaxSize().verticalScroll(scrollState),

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreen.kt
@@ -208,8 +208,8 @@ internal object MainScreen : Screen {
                                 .onEach {
                                     uiFontSizeWorkaround = false
                                     delay(50)
-                                uiFontSizeWorkaround = true
-                            }.launchIn(this)
+                                    uiFontSizeWorkaround = true
+                                }.launchIn(this)
                         }
                         if (uiFontSizeWorkaround) {
                             NavigationBar(
@@ -234,11 +234,27 @@ internal object MainScreen : Screen {
                                     ),
                                 tonalElevation = 0.dp,
                             ) {
-                                TabNavigationItem(HomeTab, withText = titleVisible)
-                                TabNavigationItem(ExploreTab, withText = titleVisible)
-                                TabNavigationItem(ProfileTab, withText = titleVisible)
-                                TabNavigationItem(InboxTab, withText = titleVisible)
-                                TabNavigationItem(SettingsTab, withText = titleVisible)
+                                TabNavigationItem(
+                                    tab = HomeTab,
+                                    withText = titleVisible,
+                                )
+                                TabNavigationItem(
+                                    tab = ExploreTab,
+                                    withText = titleVisible,
+                                )
+                                TabNavigationItem(
+                                    tab = ProfileTab,
+                                    withText = titleVisible,
+                                    customIconUrl = uiState.customProfileUrl,
+                                )
+                                TabNavigationItem(
+                                    tab = InboxTab,
+                                    withText = titleVisible,
+                                )
+                                TabNavigationItem(
+                                    tab = SettingsTab,
+                                    withText = titleVisible,
+                                )
                             }
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreenMviModel.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/MainScreenMviModel.kt
@@ -7,14 +7,19 @@ interface MainScreenMviModel :
     MviModel<MainScreenMviModel.Intent, MainScreenMviModel.UiState, MainScreenMviModel.Effect>,
     ScreenModel {
     sealed interface Intent {
-        data class SetBottomBarOffsetHeightPx(val value: Float) : Intent
+        data class SetBottomBarOffsetHeightPx(
+            val value: Float,
+        ) : Intent
     }
 
     data class UiState(
         val bottomBarOffsetHeightPx: Float = 0f,
+        val customProfileUrl: String? = null,
     )
 
     sealed interface Effect {
-        data class UnreadItemsDetected(val value: Int) : Effect
+        data class UnreadItemsDetected(
+            val value: Int,
+        ) : Effect
     }
 }

--- a/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/ui/navigation/TabNavigationItem.kt
+++ b/shared/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/ui/navigation/TabNavigationItem.kt
@@ -2,6 +2,8 @@ package com.github.diegoberaldin.raccoonforlemmy.ui.navigation
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.BadgedBox
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -15,11 +17,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.style.TextOverflow
 import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.Tab
+import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.IconSize
 import com.github.diegoberaldin.raccoonforlemmy.core.appearance.theme.Spacing
+import com.github.diegoberaldin.raccoonforlemmy.core.commonui.components.CustomImage
 import com.github.diegoberaldin.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.TabNavigationSection
 import com.github.diegoberaldin.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -32,6 +37,7 @@ import com.github.diegoberaldin.raccoonforlemmy.feature.settings.ui.SettingsTab
 internal fun RowScope.TabNavigationItem(
     tab: Tab,
     withText: Boolean = true,
+    customIconUrl: String? = null,
 ) {
     val tabNavigator = LocalTabNavigator.current
     val navigationCoordinator = remember { getNavigationCoordinator() }
@@ -59,11 +65,22 @@ internal fun RowScope.TabNavigationItem(
         selected = tabNavigator.current == tab,
         icon = {
             val content = @Composable {
-                Icon(
-                    painter = tab.options.icon ?: rememberVectorPainter(Icons.Default.Home),
-                    contentDescription = null,
-                    tint = color,
-                )
+                if (customIconUrl != null) {
+                    val iconSize = IconSize.m
+                    CustomImage(
+                        url = customIconUrl,
+                        modifier =
+                            Modifier
+                                .size(iconSize)
+                                .clip(RoundedCornerShape(iconSize / 2)),
+                    )
+                } else {
+                    Icon(
+                        painter = tab.options.icon ?: rememberVectorPainter(Icons.Default.Home),
+                        contentDescription = null,
+                        tint = color,
+                    )
+                }
             }
             val inboxTitle = LocalStrings.current.navigationInbox
             if (tab.options.title == inboxTitle && unread > 0) {


### PR DESCRIPTION
This PR adds an option in the Advanced settings screen for logged users to use the current user's avatar as an icon in the bottom bar for the Profile section.

This is particularly useful for multi-account configurations, in order to better distinguish what is the current account when browsing.