### PR TITLE
fix: shortcut selection for feeds from navigation drawer

### DIFF
--- a/core/navigation/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/androidUnitTest/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -34,9 +34,10 @@ class DefaultNavigationCoordinatorTest {
     @get:Rule
     val dispatcherRule = DispatcherTestRule()
 
-    private val sut = DefaultNavigationCoordinator(
-        dispatcher = dispatcherRule.dispatcher,
-    )
+    private val sut =
+        DefaultNavigationCoordinator(
+            dispatcher = dispatcherRule.dispatcher,
+        )
 
     @Test
     fun whenSetCurrentSection_thenValueIsUpdated() =
@@ -319,6 +320,22 @@ class DefaultNavigationCoordinatorTest {
             sut.globalMessage.test {
                 val item = awaitItem()
                 assertEquals(message, item)
+            }
+        }
+
+    @Test
+    fun whenPopUntilRoot_thenInteractionsAreAsExpected() =
+        runTest {
+            val navigator =
+                mockk<Navigator>(relaxUnitFun = true) {
+                    every { canPop } returns false
+                }
+            sut.setRootNavigator(navigator)
+
+            sut.popUntilRoot()
+
+            verify {
+                navigator.popUntilRoot()
             }
         }
 

--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration
 
 private sealed interface NavigationEvent {
-    data class Show(val screen: Screen) : NavigationEvent
+    data class Show(
+        val screen: Screen,
+    ) : NavigationEvent
 }
 
 internal class DefaultNavigationCoordinator(
@@ -55,24 +57,28 @@ internal class DefaultNavigationCoordinator(
 
     init {
         scope.launch {
-            bottomSheetChannel.receiveAsFlow().onEach { evt ->
-                when (evt) {
-                    is NavigationEvent.Show -> {
-                        bottomNavigator?.show(evt.screen)
-                    }
-                }
-            }.launchIn(this)
-            screenChannel.receiveAsFlow().onEach { evt ->
-                when (evt) {
-                    is NavigationEvent.Show -> {
-                        // make sure the new screen has a different key than the top of the stack
-                        if (evt.screen.key != navigator?.lastItem?.key) {
-                            navigator?.push(evt.screen)
-                            canPop.value = navigator?.canPop == true
+            bottomSheetChannel
+                .receiveAsFlow()
+                .onEach { evt ->
+                    when (evt) {
+                        is NavigationEvent.Show -> {
+                            bottomNavigator?.show(evt.screen)
                         }
                     }
-                }
-            }.launchIn(this)
+                }.launchIn(this)
+            screenChannel
+                .receiveAsFlow()
+                .onEach { evt ->
+                    when (evt) {
+                        is NavigationEvent.Show -> {
+                            // make sure the new screen has a different key than the top of the stack
+                            if (evt.screen.key != navigator?.lastItem?.key) {
+                                navigator?.push(evt.screen)
+                                canPop.value = navigator?.canPop == true
+                            }
+                        }
+                    }
+                }.launchIn(this)
         }
     }
 
@@ -187,5 +193,9 @@ internal class DefaultNavigationCoordinator(
             delay(delay)
             globalMessage.emit(message)
         }
+    }
+
+    override fun popUntilRoot() {
+        navigator?.popUntilRoot()
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/NavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/core/navigation/NavigationCoordinator.kt
@@ -24,13 +24,19 @@ sealed interface TabNavigationSection {
 }
 
 sealed interface ComposeEvent {
-    data class WithUrl(val url: String) : ComposeEvent
+    data class WithUrl(
+        val url: String,
+    ) : ComposeEvent
 
-    data class WithText(val text: String) : ComposeEvent
+    data class WithText(
+        val text: String,
+    ) : ComposeEvent
 }
 
 sealed interface SideMenuEvents {
-    data class Open(val screen: Screen) : SideMenuEvents
+    data class Open(
+        val screen: Screen,
+    ) : SideMenuEvents
 
     data object Close : SideMenuEvents
 }
@@ -90,4 +96,6 @@ interface NavigationCoordinator {
         message: String,
         delay: Duration = Duration.ZERO,
     )
+
+    fun popUntilRoot()
 }

--- a/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
+++ b/unit/drawer/src/commonMain/kotlin/com/github/diegoberaldin/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
@@ -192,7 +192,9 @@ object ModalDrawerContent : Tab {
                                             rememberCallback(coordinator) {
                                                 scope.launch {
                                                     focusManager.clearFocus()
+                                                    navigationCoordinator.popUntilRoot()
                                                     coordinator.toggleDrawer()
+                                                    delay(50)
                                                     coordinator.sendEvent(
                                                         DrawerEvent.ChangeListingType(listingType),
                                                     )
@@ -214,10 +216,10 @@ object ModalDrawerContent : Tab {
                                 onSelected = {
                                     focusManager.clearFocus()
                                     scope.launch {
-                                        coordinator.toggleDrawer()
                                         coordinator.sendEvent(
                                             DrawerEvent.OpenMultiCommunity(community),
                                         )
+                                        coordinator.toggleDrawer()
                                     }
                                 },
                             )


### PR DESCRIPTION
This PR fixes a bug due to which selecting All/Subscribed/Local from the navigation drawer when in a subsection (e.g. community detail or user detail) did not do anything.